### PR TITLE
#137 FilesController.Upload의 도달 불가 content-type 폴백 제거

### DIFF
--- a/Vanadium.Note.REST/Controllers/FilesController.cs
+++ b/Vanadium.Note.REST/Controllers/FilesController.cs
@@ -71,9 +71,7 @@ public class FilesController(IWebHostEnvironment env, NoteDbContext db, ILogger<
         {
             Id = id,
             OriginalName = originalName,
-            ContentType = string.IsNullOrWhiteSpace(request.File.ContentType)
-                ? "application/octet-stream"
-                : request.File.ContentType,
+            ContentType = request.File.ContentType,
         };
         db.FileAttachments.Add(attachment);
         await db.SaveChangesAsync();


### PR DESCRIPTION
## 개요

`FilesController.Upload`에서 `FileAttachment.ContentType`을 설정할 때 사용하던 도달 불가 폴백 코드를 제거합니다.

## 변경 내용

```csharp
// Before
ContentType = string.IsNullOrWhiteSpace(request.File.ContentType)
    ? "application/octet-stream"
    : request.File.ContentType,

// After
ContentType = request.File.ContentType,
```

## 이유

업로드 핸들러는 앞부분에서 `AllowedContentTypes.Contains(request.File.ContentType)`를 검사해, 허용 목록에 없는 content-type은 이미 400으로 거부합니다. 허용 목록에는 null/빈 문자열/공백 항목이 없으므로, 폴백 코드에 도달하는 시점에는 `ContentType`이 항상 유효한 값입니다. 따라서 `string.IsNullOrWhiteSpace(...)` 분기와 `"application/octet-stream"` 폴백은 실행될 수 없는 데드 코드입니다.

## 검증

- `dotnet build Vanadium.slnx` 클린 빌드 (신규 경고 없음)

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)