### PR TITLE
#102 노트 생성 시 오버포스팅으로 보이지 않는 purge 대상 노트 생성 수정

### DIFF
--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -205,6 +205,13 @@ public class NoteService(NoteDbContext db, FileCleanupService fileCleanup, ILogg
         note.Id = Guid.NewGuid();
         note.UpdatedAt = UtcNowMicroseconds();
         note.ContentText = StripHtml(note.Content);
+        // Server-owned lifecycle fields: force to the active state so a client
+        // cannot over-post DeletedAt/ArchivedAt and create a note that is hidden
+        // by the soft-delete filter (and silently purged) or born archived.
+        note.DeletedAt = null;
+        note.IsDeletionRoot = false;
+        note.ArchivedAt = null;
+        note.IsArchiveRoot = false;
         db.Notes.Add(note);
         await db.SaveChangesAsync();
         return note;


### PR DESCRIPTION
## 배경

`NotesController.Create`가 요청 body를 `NoteItem`에 직접 바인딩하는데, `DeletedAt`/`ArchivedAt`은 `[JsonIgnore]`가 아니라 그대로 클라이언트 입력에서 바인딩된다. `NoteService.Create`는 이 상태 필드들을 초기화하지 않아, 오버포스팅으로 `deletedAt`(+ `isDeletionRoot=false`)이 채워진 노트가 생성될 수 있었다. 이 경우:

- soft-delete 전역 쿼리 필터(`DeletedAt == null`)에 걸려 Home/목록에서 보이지 않음
- `IsDeletionRoot=false`라 휴지통 목록에도 안 나타나 복원 불가
- `RecycleBinPurgeJob`이 보존 기간 경과 시 조용히 영구 삭제

## 변경

`NoteService.Create`에서 서버 소유 수명주기 필드를 항상 active 기본값으로 강제 초기화:

- `DeletedAt = null`, `IsDeletionRoot = false`
- `ArchivedAt = null`, `IsArchiveRoot = false`

## 완료 조건

- [x] `NoteService.Create`가 상태 필드를 항상 active 기본값으로 강제 초기화
- [x] body에 `deletedAt`/`archivedAt`를 넣어 생성해도 노트가 정상적으로 보임 (soft-delete/아카이브 상태로 저장되지 않음)
- [x] 빌드 클린 (dotnet build Vanadium.slnx)

## 범위 밖

- 전역 쿼리 필터 / `RecycleBinPurgeJob` 로직 미변경 (생성 경로만 수정)
- `Update` 경로 미변경

Closes #102