### PR TITLE
#103 노트 저장 시 서버 사이드 HTML 새니타이징 추가

### DIFF
--- a/Vanadium.Note.REST.Tests/HtmlSanitizerServiceTests.cs
+++ b/Vanadium.Note.REST.Tests/HtmlSanitizerServiceTests.cs
@@ -1,0 +1,133 @@
+using Vanadium.Note.REST.Services;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Pins the server-side HTML sanitizing that guards Create/Update (issue #103):
+/// active content is stripped while the Tiptap editor's markup — every custom
+/// node and its data-* attributes — survives round-tripping.
+/// </summary>
+public class HtmlSanitizerServiceTests
+{
+    private readonly HtmlSanitizerService _sanitizer = new();
+
+    [Fact]
+    public void Sanitize_RemovesScriptTag()
+    {
+        var result = _sanitizer.Sanitize("<p>hi</p><script>steal(localStorage.jwt)</script>");
+
+        Assert.DoesNotContain("<script", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("steal", result);
+        Assert.Contains("hi", result);
+    }
+
+    [Fact]
+    public void Sanitize_RemovesEventHandlerAttributes()
+    {
+        var result = _sanitizer.Sanitize("<img src=\"/api/files/x\" onerror=\"steal()\">");
+
+        Assert.DoesNotContain("onerror", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("steal", result);
+    }
+
+    [Fact]
+    public void Sanitize_RemovesJavascriptScheme()
+    {
+        var result = _sanitizer.Sanitize("<a href=\"javascript:steal()\">x</a>");
+
+        Assert.DoesNotContain("javascript:", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sanitize_PreservesDataAttributesOnCustomNodes()
+    {
+        const string html =
+            "<div data-type=\"page-link\" data-note-id=\"abc\" data-title=\"Spec\" class=\"page-link-block\">" +
+            "<span class=\"page-link-icon\">📄</span><span class=\"page-link-title\">Spec</span></div>";
+
+        var result = _sanitizer.Sanitize(html);
+
+        Assert.Contains("data-type=\"page-link\"", result);
+        Assert.Contains("data-note-id=\"abc\"", result);
+        Assert.Contains("data-title=\"Spec\"", result);
+    }
+
+    [Fact]
+    public void Sanitize_PreservesToggleAndCollapsibleHeadingMarkup()
+    {
+        const string html =
+            "<h2 data-collapsible=\"true\" data-open=\"false\">Section</h2>" +
+            "<div data-type=\"toggle\" data-open=\"false\" class=\"toggle-block\">" +
+            "<div data-type=\"toggle-summary\" class=\"toggle-summary\">Summary</div>" +
+            "<div data-type=\"toggle-content\" class=\"toggle-content\"><p>body</p></div></div>";
+
+        var result = _sanitizer.Sanitize(html);
+
+        Assert.Contains("data-collapsible=\"true\"", result);
+        Assert.Contains("data-type=\"toggle\"", result);
+        Assert.Contains("data-type=\"toggle-summary\"", result);
+        Assert.Contains("data-type=\"toggle-content\"", result);
+        Assert.Contains("body", result);
+    }
+
+    [Fact]
+    public void Sanitize_PreservesFileAttachmentDownloadAnchor()
+    {
+        const string html =
+            "<a class=\"file-attachment\" data-filename=\"log.txt\" download=\"log.txt\" " +
+            "href=\"/api/files/abc\">📎 log.txt</a>";
+
+        var result = _sanitizer.Sanitize(html);
+
+        Assert.Contains("download=\"log.txt\"", result);
+        Assert.Contains("data-filename=\"log.txt\"", result);
+        Assert.Contains("/api/files/abc", result);
+    }
+
+    [Fact]
+    public void Sanitize_KeepsRelativeImageSource()
+    {
+        var result = _sanitizer.Sanitize("<img src=\"/api/files/abc\" alt=\"pic\">");
+
+        Assert.Contains("/api/files/abc", result);
+    }
+
+    [Fact]
+    public async Task Create_StripsScriptButKeepsCustomNode()
+    {
+        using var h = new TestHost();
+
+        const string html =
+            "<div data-type=\"callout\" data-emoji=\"💡\" class=\"callout-block\">" +
+            "<div class=\"callout-content\"><p>note</p></div></div>" +
+            "<script>steal(localStorage.jwt)</script>";
+
+        var note = await h.CreateNoteAsync("Note", content: html);
+        var saved = await h.FindAsync(note.Id);
+
+        Assert.DoesNotContain("<script", saved!.Content, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("steal", saved.Content);
+        Assert.Contains("data-type=\"callout\"", saved.Content);
+        Assert.Contains("data-emoji", saved.Content);
+    }
+
+    [Fact]
+    public async Task Update_StripsScriptOnStore()
+    {
+        using var h = new TestHost();
+        var note = await h.CreateNoteAsync("Note", content: "<p>clean</p>");
+
+        note.Content = "<p>edited</p><img src=\"x\" onerror=\"steal()\">";
+        var (updated, conflict, archived) = await h.Notes.Update(note.Id, note);
+
+        Assert.NotNull(updated);
+        Assert.False(conflict);
+        Assert.False(archived);
+
+        var saved = await h.FindAsync(note.Id);
+        Assert.DoesNotContain("onerror", saved!.Content, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("steal", saved.Content);
+        Assert.Contains("edited", saved.Content);
+    }
+}

--- a/Vanadium.Note.REST.Tests/TestHost.cs
+++ b/Vanadium.Note.REST.Tests/TestHost.cs
@@ -45,7 +45,8 @@ public sealed class TestHost : IDisposable
 
         FileCleanup = new FileCleanupService(
             Db, new TestWebHostEnvironment(ContentRoot), NullLogger<FileCleanupService>.Instance);
-        Notes = new NoteService(Db, FileCleanup, NullLogger<NoteService>.Instance);
+        Notes = new NoteService(
+            Db, FileCleanup, new HtmlSanitizerService(), NullLogger<NoteService>.Instance);
         Labels = new LabelService(Db, NullLogger<LabelService>.Instance);
         Account = new AccountService(Db, NullLogger<AccountService>.Instance);
     }

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -109,6 +109,7 @@ builder.Services.AddRateLimiter(options =>
 });
 
 builder.Services.AddControllers();
+builder.Services.AddSingleton<IHtmlSanitizerService, HtmlSanitizerService>();
 builder.Services.AddScoped<NoteService>();
 builder.Services.AddScoped<LabelService>();
 builder.Services.AddScoped<SettingsService>();

--- a/Vanadium.Note.REST/Services/HtmlSanitizerService.cs
+++ b/Vanadium.Note.REST/Services/HtmlSanitizerService.cs
@@ -1,0 +1,50 @@
+using Ganss.Xss;
+
+namespace Vanadium.Note.REST.Services;
+
+/// <summary>
+/// <see cref="IHtmlSanitizerService"/> backed by Ganss.Xss (HtmlSanitizer).
+///
+/// The default HtmlSanitizer allowlist already covers the standard formatting
+/// tags Tiptap emits (headings, lists, tables, code, blockquote, img, a, div,
+/// span, ...) and removes <c>&lt;script&gt;</c>, inline event handlers
+/// (<c>onerror</c>, <c>onclick</c>, ...) and unsafe URI schemes
+/// (<c>javascript:</c>). Two Tiptap-specific allowances are added on top:
+///
+/// <list type="bullet">
+///   <item>Every <c>data-*</c> attribute is preserved — custom nodes serialize
+///   as <c>div/span/a/pre</c> carrying <c>data-type</c> plus node attributes
+///   (<c>data-note-id</c>, <c>data-emoji</c>, <c>data-open</c>, ...), and the
+///   collapsible-heading feature relies on <c>data-collapsible</c>/<c>data-open</c>.
+///   Dropping them would break round-tripping and search derivation.</item>
+///   <item>The <c>download</c> attribute is allowed for file-attachment anchors
+///   (<c>&lt;a class="file-attachment" download="..."&gt;</c>).</item>
+/// </list>
+///
+/// A single HtmlSanitizer instance is reused; it is stateless per call and safe
+/// to share, so this service is registered as a singleton.
+/// </summary>
+public sealed class HtmlSanitizerService : IHtmlSanitizerService
+{
+    private readonly HtmlSanitizer _sanitizer;
+
+    public HtmlSanitizerService()
+    {
+        _sanitizer = new HtmlSanitizer();
+
+        // Keep all data-* attributes: they carry custom-node identity/state and
+        // must survive sanitizing. Event handlers (on*) are still stripped
+        // because this only cancels removal for the data- prefix.
+        _sanitizer.RemovingAttribute += (_, e) =>
+        {
+            if (e.Attribute.Name.StartsWith("data-", StringComparison.OrdinalIgnoreCase))
+                e.Cancel = true;
+        };
+
+        // File-attachment anchors render as <a download="filename">.
+        _sanitizer.AllowedAttributes.Add("download");
+    }
+
+    public string Sanitize(string html) =>
+        string.IsNullOrEmpty(html) ? html : _sanitizer.Sanitize(html);
+}

--- a/Vanadium.Note.REST/Services/IHtmlSanitizerService.cs
+++ b/Vanadium.Note.REST/Services/IHtmlSanitizerService.cs
@@ -1,0 +1,16 @@
+namespace Vanadium.Note.REST.Services;
+
+/// <summary>
+/// Sanitizes note HTML before it is persisted, stripping active content
+/// (scripts, event handlers, dangerous URI schemes) while preserving the
+/// Tiptap editor's markup — including every <c>data-type</c>/<c>data-*</c>
+/// attribute that custom nodes and ContentText derivation depend on.
+/// </summary>
+public interface IHtmlSanitizerService
+{
+    /// <summary>
+    /// Returns a sanitized copy of <paramref name="html"/>. Null/empty input
+    /// is returned unchanged.
+    /// </summary>
+    string Sanitize(string html);
+}

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -6,7 +6,11 @@ using Vanadium.Note.REST.Models;
 
 namespace Vanadium.Note.REST.Services;
 
-public class NoteService(NoteDbContext db, FileCleanupService fileCleanup, ILogger<NoteService> logger)
+public class NoteService(
+    NoteDbContext db,
+    FileCleanupService fileCleanup,
+    IHtmlSanitizerService htmlSanitizer,
+    ILogger<NoteService> logger)
 {
     public async Task<PagedResult<NoteSummary>> GetPaged(
         int page,
@@ -204,6 +208,10 @@ public class NoteService(NoteDbContext db, FileCleanupService fileCleanup, ILogg
     {
         note.Id = Guid.NewGuid();
         note.UpdatedAt = UtcNowMicroseconds();
+        // Sanitize before persisting so stored HTML can never carry active
+        // content (script/event handlers), then derive the search text from the
+        // sanitized markup.
+        note.Content = htmlSanitizer.Sanitize(note.Content);
         note.ContentText = StripHtml(note.Content);
         // Server-owned lifecycle fields: force to the active state so a client
         // cannot over-post DeletedAt/ArchivedAt and create a note that is hidden
@@ -243,6 +251,9 @@ public class NoteService(NoteDbContext db, FileCleanupService fileCleanup, ILogg
         var titleChanged = existing.Title != note.Title;
 
         existing.Title = note.Title;
+        // Sanitize on the update path too — a leaked PAT could otherwise store a
+        // payload via PUT just as easily as via POST.
+        note.Content = htmlSanitizer.Sanitize(note.Content);
         existing.Content = note.Content;
         existing.ContentText = StripHtml(note.Content);
         existing.ParentNoteId = note.ParentNoteId;

--- a/Vanadium.Note.REST/Vanadium.Note.REST.csproj
+++ b/Vanadium.Note.REST/Vanadium.Note.REST.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## 배경

노트 HTML이 서버에서 새니타이징 없이 그대로 저장되고 있었다(`NoteService.Create`/`Update`가 `note.Content`를 검증 없이 저장, `ContentText`만 `StripHtml`로 파생). 유출된 API 토큰(PAT)이 `<script>`/이벤트 핸들러를 심으면 소유자가 노트를 열 때 브라우저에서 실행 → localStorage의 JWT 탈취 → `DELETE /api/settings/all-data` 등 소유자 권한 엔드포인트에 도달할 수 있었다.

## 변경

- **`HtmlSanitizer`(Ganss.Xss) 의존성 추가** — 이슈에서 지정한 새니타이저.
- **`IHtmlSanitizerService` / `HtmlSanitizerService` 신설** (중앙 캡슐화):
  - `<script>`, 인라인 이벤트 핸들러(`onerror`/`onclick` 등), `javascript:` 스킴 제거.
  - 모든 `data-*` 속성 보존 (`RemovingAttribute` 이벤트로 `data-` 접두사만 취소) → Tiptap 커스텀 노드(`data-type`/`data-note-id`/`data-emoji`/`data-open`/`data-collapsible` 등) 및 `ContentText` 파생이 깨지지 않음.
  - file-attachment 앵커의 `download` 속성 허용.
  - 상태 없음 · 인스턴스 재사용 가능 → 싱글턴 등록.
- **`NoteService.Create`/`Update`**: `Content` 저장 직전에 새니타이즈하고, 그 결과로 `ContentText`를 파생.
- **테스트 추가** (`HtmlSanitizerServiceTests`): 위험 요소 제거 및 커스텀 노드/`data-*`/상대경로 URL 보존을 검증. 전체 48개 통과.

## 완료 조건

- [x] Create/Update 경로에서 노트 HTML이 새니타이즈된 후 저장된다.
- [x] `<script>`/이벤트 핸들러(`onerror` 등) 등 위험 요소가 저장 시점에 제거된다.
- [x] Tiptap 커스텀 노드(`data-type`/`data-*` 포함)가 새니타이징 후에도 보존된다.
- [x] 빌드 클린 (dotnet build Vanadium.slnx)

## 범위 밖 (미변경)

- `ContentText` 파생 로직(`StripHtml`) 및 트라이그램 검색 인덱스 — 변경하지 않음.
- 클라이언트 측 렌더링/`innerHTML` 싱크 방어 — 별도 이슈(#104).

Closes #103