### PR TITLE
#104 tiptap-editor.js의 innerHTML XSS 싱크 제거

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/tiptap-editor.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap-editor.js
@@ -477,7 +477,15 @@ function createMentionExtension(dotnetRef) {
                             currentItems.forEach((item, i) => {
                                 const row = document.createElement('div');
                                 row.className = 'mention-menu-item' + (i === selectedIndex ? ' mention-menu-item-active' : '');
-                                row.innerHTML = `<span class="mention-menu-icon">📄</span><span class="mention-menu-title">${item.title || '(Untitled)'}</span>`;
+                                // Build via textContent so a note title like
+                                // `<img src=x onerror=...>` is rendered as text, not HTML.
+                                const icon = document.createElement('span');
+                                icon.className = 'mention-menu-icon';
+                                icon.textContent = '📄';
+                                const title = document.createElement('span');
+                                title.className = 'mention-menu-title';
+                                title.textContent = item.title || '(Untitled)';
+                                row.append(icon, title);
                                 row.addEventListener('mousedown', e => {
                                     e.preventDefault();
                                     currentCommand?.(item);
@@ -697,7 +705,11 @@ const MermaidNode = Node.create({
                 try {
                     preview.innerHTML = await renderMermaidSvg(code);
                 } catch (err) {
-                    preview.innerHTML = `<div class="mermaid-error">⚠ ${err.message || 'Syntax error'}</div>`;
+                    // Mermaid error messages can echo user input; insert as text.
+                    const errDiv = document.createElement('div');
+                    errDiv.className = 'mermaid-error';
+                    errDiv.textContent = `⚠ ${err.message || 'Syntax error'}`;
+                    preview.replaceChildren(errDiv);
                 }
             }
 
@@ -1450,11 +1462,24 @@ function uploadWithProgress(url, formData, headers, onProgress) {
 function createProgressToast(filename) {
     const toast = document.createElement('div');
     toast.className = 'upload-toast';
-    toast.innerHTML = `
-        <span class="upload-toast-name">${filename}</span>
-        <div class="upload-toast-bar-wrap"><div class="upload-toast-bar"></div></div>
-        <span class="upload-toast-pct">0%</span>
-    `;
+
+    // Only the filename is user-derived; insert it via textContent so it is
+    // never interpreted as HTML. The rest is fixed structure.
+    const nameEl = document.createElement('span');
+    nameEl.className = 'upload-toast-name';
+    nameEl.textContent = filename;
+
+    const barWrap = document.createElement('div');
+    barWrap.className = 'upload-toast-bar-wrap';
+    const bar = document.createElement('div');
+    bar.className = 'upload-toast-bar';
+    barWrap.appendChild(bar);
+
+    const pct = document.createElement('span');
+    pct.className = 'upload-toast-pct';
+    pct.textContent = '0%';
+
+    toast.append(nameEl, barWrap, pct);
     document.body.appendChild(toast);
 
     return {


### PR DESCRIPTION
## 배경

`wwwroot/js/tiptap-editor.js`가 사용자 유래 문자열을 `innerHTML`로 직접 보간하는 3개의 싱크가 있었다. 노트 제목이 `<img src=x onerror=...>` 같은 값이면 렌더 시점에 스크립트가 실행되는 DOM XSS다.

## 변경

세 곳 모두 `innerHTML` 보간 대신 `createElement` + `textContent` 경로로 교체 (DOM 구조·클래스명은 동일하게 유지):

- **멘션 메뉴 행** (`renderItems`): 노트 제목을 `span.textContent`로 삽입.
- **Mermaid 에러** (`renderPreview` catch): `err.message`를 `div.textContent`로 만든 뒤 `preview.replaceChildren(...)`.
- **업로드 토스트** (`createProgressToast`): 파일명을 `span.textContent`로 삽입. 진행바/퍼센트 요소는 그대로라 `update`/`done`/`error`의 `querySelector` 동작 불변.

## 완료 조건

- [x] 멘션 메뉴/업로드 토스트/Mermaid 에러의 사용자 유래 문자열이 `textContent`/`createElement`로 삽입된다.
- [x] `<img src=x onerror=...>` 제목이 멘션 메뉴에서 실행되지 않는다 (HTML이 아닌 텍스트로 렌더).
- [x] 편집기 UI가 기존과 동일하게 표시된다 (동일 태그/클래스 구조 유지).
- [x] 빌드 클린 — C# 컴파일 오류 0 (JS `node --check` 통과). 참고: 로컬에서 실행 중인 Web 인스턴스가 `Web.dll`을 잠가 copy-to-bin 단계만 실패하며, 이는 정적 JS 변경과 무관한 환경 이슈다.

## 범위 밖 (미변경)

- 서버 사이드 HTML 새니타이징 — 별도 이슈(#103).
- 고정 문자열/렌더링된 SVG를 다루는 나머지 `innerHTML` 사용처(line 469/693/696/698 등).

Closes #104