### PR TITLE
#105 SubNoteDialog 닫을 때 마지막 편집분 flush

### DIFF
--- a/Vanadium.Note.Web/Pages/SubNoteDialog.razor
+++ b/Vanadium.Note.Web/Pages/SubNoteDialog.razor
@@ -1,4 +1,4 @@
-@implements IDisposable
+@implements IAsyncDisposable
 @using System.Text.Json.Serialization
 @inject NoteService NoteService
 @inject LabelService LabelService
@@ -116,6 +116,7 @@
     private readonly string _editorId = "tiptap-" + Guid.NewGuid().ToString("N")[..8];
     private DotNetObjectReference<SubNoteDialog>? _objRef;
     private CancellationTokenSource? _debounceCts;
+    private bool _hasPendingChanges = false;
     private bool _editorMounted = false;
     private bool _contentJustLoaded = false;
 
@@ -219,6 +220,7 @@
     private void ScheduleAutoSave()
     {
         if (_isArchived) return; // archived notes are read-only
+        _hasPendingChanges = true;
         _debounceCts?.Cancel();
         _debounceCts = new CancellationTokenSource();
         var token = _debounceCts.Token;
@@ -233,14 +235,10 @@
         }, TaskScheduler.Default);
     }
 
-    private async Task DoAutoSave()
+    // UI-free save used by both the debounced path and the close/dispose flush. It never touches
+    // StateHasChanged so it is safe to await while the component is being torn down (Esc/backdrop).
+    private async Task<ServiceResult<NoteItem>> SaveCoreAsync()
     {
-        if (_isArchived) return;
-
-        saveStatusText = "Saving…";
-        saveStatusCss = "status-saving";
-        StateHasChanged();
-
         // Send the tracked server timestamp so optimistic concurrency passes; without it the
         // Web NoteItem's UpdatedAt default (DateTime.UtcNow) never matches and every save 409s.
         var result = await NoteService.SaveAsync(new NoteItem
@@ -255,6 +253,23 @@
         if (result.IsSuccess)
         {
             _serverUpdatedAt = result.Value!.UpdatedAt;
+            _hasPendingChanges = false;
+        }
+        return result;
+    }
+
+    private async Task DoAutoSave()
+    {
+        if (_isArchived) return;
+
+        saveStatusText = "Saving…";
+        saveStatusCss = "status-saving";
+        StateHasChanged();
+
+        var result = await SaveCoreAsync();
+
+        if (result.IsSuccess)
+        {
             saveStatusText = "Saved";
             saveStatusCss = "status-saved";
         }
@@ -287,9 +302,13 @@
         Nav.NavigateTo($"/editor/{NoteId}");
     }
 
-    private void Close()
+    private async Task Close()
     {
+        // Cancel the pending debounce, then flush any unsaved edit before the dialog goes away so
+        // the last <1.5s of typing is not silently discarded.
         _debounceCts?.Cancel();
+        if (_hasPendingChanges && !_isArchived)
+            await DoAutoSave();
         MudDialog.Close(DialogResult.Ok(title));
     }
 
@@ -337,11 +356,17 @@
         noteLabels.RemoveAll(l => l.Id == labelId);
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
+        // Esc/backdrop closes bypass Close() and only reach here, so flush pending edits on this
+        // path too. Use SaveCoreAsync (no StateHasChanged) since the component is being disposed.
         _debounceCts?.Cancel();
+        if (_hasPendingChanges && !_isArchived)
+            await SaveCoreAsync();
+
         _objRef?.Dispose();
-        _ = JS.InvokeVoidAsync("tiptapInterop.destroy", _editorId);
+        if (_editorMounted)
+            await JS.InvokeVoidAsync("tiptapInterop.destroy", _editorId);
     }
 
     public record JsMentionItem(


### PR DESCRIPTION
Closes #105

## 문제

`SubNoteDialog.razor`의 `Close()`와 `Dispose()`가 debounce용 `_debounceCts`를 flush 없이 취소한다. 자동 저장은 마지막 편집 1500ms 후에 발생하므로, 그 전에 Close 버튼/Esc/백드롭으로 다이얼로그를 닫으면 대기 중이던 편집 내용이 저장되지 않고 유실되었다. Esc/백드롭 닫기는 `Close()`를 거치지 않고 `Dispose()`만 실행되며, `Dispose()`는 동기 메서드라 flush를 await할 수 없었다.

## 변경 내용

- **`_hasPendingChanges` 플래그** 추가 — `ScheduleAutoSave`에서 true, 저장 성공 시 false. 저장 대기 여부를 정확히 판단한다.
- **`SaveCoreAsync()` 추출** — `StateHasChanged`를 호출하지 않는 순수 저장 로직. 컴포넌트 소멸 중에도 안전하게 await할 수 있다. `DoAutoSave`는 이 코어를 감싸 상태 표시만 담당한다.
- **`Close()` → async** — 닫기 전 대기 편집이 있으면 `DoAutoSave()`로 flush한 뒤 닫는다.
- **`Dispose()` → `DisposeAsync()` (`IAsyncDisposable`)** — Esc/백드롭 경로도 `SaveCoreAsync()`로 flush. `NoteEditor.DisposeAsync`와 동일한 패턴.

`_isArchived` 가드는 모든 경로에서 유지되어 아카이브(읽기 전용) 노트는 저장을 시도하지 않는다.

## 완료 조건 확인

- [x] 편집 후 1.5초 이내에 Close/Esc/백드롭으로 닫아도 마지막 편집분이 저장된다.
- [x] flush는 `_hasPendingChanges`가 해제된 뒤(저장 완료 후)에만 대기 상태가 풀린다 — "Unsaved changes"로 오인되지 않는다.
- [x] 아카이브 노트에서는 저장을 시도하지 않는다(`_isArchived` 가드 유지).
- [x] 빌드 클린 (`dotnet build Vanadium.slnx`, 오류 0 / 신규 경고 없음).

## 범위 밖

자동 저장 debounce 간격(1500ms) 및 낙관적 동시성(`_serverUpdatedAt`) 처리 로직은 변경하지 않았다.