### PR TITLE
#106 Ctrl+K 이중 바인딩 수정 — 링크 팝오버와 퀵내브 동시 발동 차단

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/tiptap-editor.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap-editor.js
@@ -1793,6 +1793,10 @@ window.tiptapInterop = {
         editor.view.dom.addEventListener('keydown', (e) => {
             if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
                 e.preventDefault();
+                // Stop propagation so the event does not bubble to the global
+                // ctrl+k handler (Quick Navigation); otherwise both the link
+                // popover and the Quick Nav dialog would open at once.
+                e.stopPropagation();
                 showLinkPopover(elementId);
             }
         });


### PR DESCRIPTION
## 요약

편집기 본문에 포커스를 둔 상태에서 Ctrl/Cmd+K를 누르면 링크 팝오버와 퀵내브(Quick Navigation) 다이얼로그가 동시에 뜨던 문제를 수정한다.

## 원인

`tiptap-editor.js`의 편집기 keydown 리스너가 Ctrl/Cmd+K 처리 시 `e.preventDefault()`만 호출하고 `e.stopPropagation()`을 호출하지 않았다. 그 결과 이벤트가 `document`에 등록된 전역 `ctrl+k` 핸들러(`keyboard-shortcuts.js` → `KeyboardShortcutService` → 퀵내브)까지 버블링되어 링크 팝오버 위로 퀵내브가 함께 열렸다.

## 변경 내용

- 편집기 keydown 리스너의 Ctrl/Cmd+K 분기에 `e.stopPropagation()` 추가. 편집기의 리스너는 `editor.view.dom`(document의 하위 요소)에 붙어 버블 단계에서 전역 핸들러보다 먼저 실행되므로, 전파를 막으면 퀵내브가 발동하지 않는다.

## 완료 조건 확인

- [x] 편집기 리스너에서 Ctrl/Cmd+K 처리 시 `e.stopPropagation()` 호출
- [x] 편집기에서 Ctrl+K 시 퀵내브가 함께 뜨지 않음 (전파 차단으로 전역 핸들러 미도달)
- [x] 편집기 밖에서의 Ctrl+K 퀵내브는 정상 동작 (편집기 리스너 미실행 → 기존 전역 경로 유지)
- [x] 빌드 클린 (`dotnet build Vanadium.slnx`, 신규 경고 없음)

## 범위 밖

- `KeyboardShortcutService` 전역 단축키 등록 로직은 변경하지 않음
- 링크 단축키를 Ctrl+Shift+K로 옮기는 건 선택적 후속 항목으로 이번 범위에서 제외

Closes #106