### PR TITLE
#107 오펀 파일 정리에 업로드 유예 창 추가

### DIFF
--- a/Vanadium.Note.REST.Tests/ArchiveServiceTests.cs
+++ b/Vanadium.Note.REST.Tests/ArchiveServiceTests.cs
@@ -296,7 +296,13 @@ public class ArchiveServiceTests
     {
         using var h = new TestHost();
 
-        var attachment = new FileAttachment { OriginalName = "spec.pdf", ContentType = "application/pdf" };
+        // Uploaded well before the grace window so grace never shields it.
+        var attachment = new FileAttachment
+        {
+            OriginalName = "spec.pdf",
+            ContentType = "application/pdf",
+            UploadedAt = DateTime.UtcNow.AddHours(-2),
+        };
         h.Db.FileAttachments.Add(attachment);
         await h.Db.SaveChangesAsync();
         var physicalPath = Path.Combine(h.ContentRoot, "uploads", $"file_{attachment.Id}");

--- a/Vanadium.Note.REST.Tests/FileCleanupGraceTests.cs
+++ b/Vanadium.Note.REST.Tests/FileCleanupGraceTests.cs
@@ -1,0 +1,55 @@
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Tests for the upload grace window in <c>FileCleanupService.DeleteAllOrphansAsync</c>
+/// (issue #107): a freshly uploaded file may not yet be referenced by any note
+/// because the editor auto-save is debounced, so the periodic scan must skip
+/// files within the grace window (default 60 min) instead of collecting them.
+/// </summary>
+public class FileCleanupGraceTests
+{
+    [Fact]
+    public async Task OrphanScan_RecentlyUploadedAttachment_IsSkipped()
+    {
+        using var h = new TestHost();
+
+        // Uploaded just now, not yet referenced by any note (still within grace).
+        var attachment = new FileAttachment
+        {
+            OriginalName = "in-progress.txt",
+            ContentType = "text/plain",
+            UploadedAt = DateTime.UtcNow,
+        };
+        h.Db.FileAttachments.Add(attachment);
+        await h.Db.SaveChangesAsync();
+        var physicalPath = Path.Combine(h.ContentRoot, "uploads", $"file_{attachment.Id}");
+        await File.WriteAllTextAsync(physicalPath, "draft body");
+
+        await h.CreateNoteAsync("Unrelated", content: "<p>no references yet</p>");
+
+        await h.FileCleanup.DeleteAllOrphansAsync();
+
+        Assert.NotNull(await h.Db.FileAttachments.FindAsync(attachment.Id));
+        Assert.True(File.Exists(physicalPath));
+    }
+
+    [Fact]
+    public async Task OrphanScan_RecentlyCreatedImage_IsSkipped()
+    {
+        using var h = new TestHost();
+
+        // Disk-only image (no DB record); a fresh file's creation time is within grace.
+        var imageId = Guid.NewGuid();
+        var imagePath = Path.Combine(h.ContentRoot, "uploads", $"{imageId}.png");
+        await File.WriteAllTextAsync(imagePath, "png bytes");
+
+        await h.CreateNoteAsync("Unrelated", content: "<p>no references yet</p>");
+
+        await h.FileCleanup.DeleteAllOrphansAsync();
+
+        Assert.True(File.Exists(imagePath));
+    }
+}

--- a/Vanadium.Note.REST.Tests/TestHost.cs
+++ b/Vanadium.Note.REST.Tests/TestHost.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging.Abstractions;
 using Vanadium.Note.REST.Data;
@@ -43,8 +44,9 @@ public sealed class TestHost : IDisposable
         ContentRoot = Path.Combine(Path.GetTempPath(), $"vanadium-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(Path.Combine(ContentRoot, "uploads"));
 
+        var configuration = new ConfigurationBuilder().Build();
         FileCleanup = new FileCleanupService(
-            Db, new TestWebHostEnvironment(ContentRoot), NullLogger<FileCleanupService>.Instance);
+            Db, new TestWebHostEnvironment(ContentRoot), configuration, NullLogger<FileCleanupService>.Instance);
         Notes = new NoteService(Db, FileCleanup, NullLogger<NoteService>.Instance);
         Labels = new LabelService(Db, NullLogger<LabelService>.Instance);
         Account = new AccountService(Db, NullLogger<AccountService>.Instance);

--- a/Vanadium.Note.REST.Tests/ToggleContentTests.cs
+++ b/Vanadium.Note.REST.Tests/ToggleContentTests.cs
@@ -164,7 +164,13 @@ public class ToggleContentTests
     {
         using var h = new TestHost();
 
-        var orphan = new FileAttachment { OriginalName = "orphan.txt", ContentType = "text/plain" };
+        // Uploaded well before the grace window so it counts as a real orphan.
+        var orphan = new FileAttachment
+        {
+            OriginalName = "orphan.txt",
+            ContentType = "text/plain",
+            UploadedAt = DateTime.UtcNow.AddHours(-2),
+        };
         h.Db.FileAttachments.Add(orphan);
         await h.Db.SaveChangesAsync();
         var orphanPath = Path.Combine(h.ContentRoot, "uploads", $"file_{orphan.Id}");

--- a/Vanadium.Note.REST/Services/FileCleanupService.cs
+++ b/Vanadium.Note.REST/Services/FileCleanupService.cs
@@ -9,8 +9,14 @@ namespace Vanadium.Note.REST.Services;
 /// referenced by any note. Used both at note-deletion time and by the
 /// periodic background GC job.
 /// </summary>
-public class FileCleanupService(NoteDbContext db, IWebHostEnvironment env, ILogger<FileCleanupService> logger)
+public class FileCleanupService(
+    NoteDbContext db,
+    IWebHostEnvironment env,
+    IConfiguration config,
+    ILogger<FileCleanupService> logger)
 {
+    private const int DefaultGraceMinutes = 60;
+
     private string UploadsPath => Path.Combine(env.ContentRootPath, "uploads");
 
     // Matches /api/files/{guid} — file attachments stored in DB
@@ -65,6 +71,12 @@ public class FileCleanupService(NoteDbContext db, IWebHostEnvironment env, ILogg
     /// </summary>
     public async Task DeleteAllOrphansAsync(CancellationToken ct = default)
     {
+        // Files uploaded within the grace window are skipped: a freshly uploaded
+        // file may not yet be referenced in any note's HTML because the editor
+        // auto-save is debounced (~1500ms) and the note may still be in progress.
+        var graceMinutes = config.GetValue("FileCleanup:GraceMinutes", DefaultGraceMinutes);
+        var graceCutoff = DateTime.UtcNow.AddMinutes(-graceMinutes);
+
         // IgnoreQueryFilters: content of soft-deleted notes still counts as a live
         // file reference until the recycle bin purge actually deletes the note.
         var allContent = string.Join(' ',
@@ -73,7 +85,9 @@ public class FileCleanupService(NoteDbContext db, IWebHostEnvironment env, ILogg
         // --- File attachments (have DB records) ---
         var attachments = await db.FileAttachments.ToListAsync(ct);
 
-        logger.LogDebug("Periodic orphan scan: checking {AttachmentCount} file attachment record(s).", attachments.Count);
+        logger.LogDebug(
+            "Periodic orphan scan: checking {AttachmentCount} file attachment record(s) (grace: {GraceMinutes}m).",
+            attachments.Count, graceMinutes);
 
         int filesRemoved = 0;
 
@@ -81,6 +95,15 @@ public class FileCleanupService(NoteDbContext db, IWebHostEnvironment env, ILogg
         {
             if (allContent.Contains(attachment.Id.ToString(), StringComparison.OrdinalIgnoreCase))
                 continue;
+
+            // Skip recently uploaded attachments still within the grace window.
+            if (attachment.UploadedAt > graceCutoff)
+            {
+                logger.LogDebug(
+                    "Periodic scan: skipping recently uploaded attachment {FileId} (within grace window).",
+                    attachment.Id);
+                continue;
+            }
 
             db.FileAttachments.Remove(attachment);
             DeletePhysicalFile(Path.Combine(UploadsPath, $"file_{attachment.Id}"));
@@ -114,6 +137,16 @@ public class FileCleanupService(NoteDbContext db, IWebHostEnvironment env, ILogg
 
             if (allContent.Contains(guidStr, StringComparison.OrdinalIgnoreCase))
                 continue;
+
+            // Disk-only images have no DB record, so fall back to the file's
+            // creation time to honor the same grace window.
+            if (file.CreationTimeUtc > graceCutoff)
+            {
+                logger.LogDebug(
+                    "Periodic scan: skipping recently created image {ImageFile} (within grace window).",
+                    file.Name);
+                continue;
+            }
 
             DeletePhysicalFile(file.FullName);
             logger.LogDebug("Periodic scan: removed orphaned image {ImageFile}.", file.Name);

--- a/Vanadium.Note.REST/appsettings.json
+++ b/Vanadium.Note.REST/appsettings.json
@@ -15,6 +15,9 @@
   "RecycleBin": {
     "RetentionDays": 30
   },
+  "FileCleanup": {
+    "GraceMinutes": 60
+  },
   "Seq": {
     "ServerUrl": "",
     "ApiKey": ""


### PR DESCRIPTION
## 배경
`FileCleanupService.DeleteAllOrphansAsync`(24시간 주기 스캔)가 유예 없이 미참조 파일을 즉시 오펀으로 처리했다. 에디터 자동 저장은 1500ms debounce라, 파일 업로드 직후 노트 HTML에 참조가 아직 커밋되지 않은 상태에서 스캔이 돌면 작성 중인 파일이 삭제될 수 있었다.

## 변경 내용
- `DeleteAllOrphansAsync`에 업로드 유예 창을 추가. 유예 창 내 파일은 미참조여도 스캔에서 스킵한다.
  - **첨부 파일**(DB 레코드 있음): `FileAttachment.UploadedAt` 기준 (기존 미활용 필드 활용)
  - **디스크 전용 이미지**(DB 레코드 없음): 파일 `CreationTimeUtc` 기준
- 유예 시간은 `FileCleanup:GraceMinutes`로 설정 가능(기본 60분). `appsettings.json`에 기본값 추가.
- `DeleteOrphanedFromContentAsync`(노트 삭제 시 즉시 정리)와 24시간 스캔 주기는 변경하지 않음(범위 밖).

## 테스트
- `FileCleanupGraceTests` 추가: 유예 창 내 첨부/이미지가 스킵되는지 검증.
- 기존 오펀 삭제 테스트는 `UploadedAt`을 유예 창 밖으로 백데이트해 의도 유지.
- `dotnet build Vanadium.slnx` 클린, `dotnet test` 전체 통과(41 통과 / 3 스킵).

Closes #107