### PR TITLE
#109 탭 닫기/새로고침 시 미저장 변경 보호

### DIFF
--- a/Vanadium.Note.REST.Tests/TestHost.cs
+++ b/Vanadium.Note.REST.Tests/TestHost.cs
@@ -47,7 +47,7 @@ public sealed class TestHost : IDisposable
         var configuration = new ConfigurationBuilder().Build();
         FileCleanup = new FileCleanupService(
             Db, new TestWebHostEnvironment(ContentRoot), configuration, NullLogger<FileCleanupService>.Instance);
-        Notes = new NoteService(Db, FileCleanup, NullLogger<NoteService>.Instance);
+        Notes = new NoteService(Db, FileCleanup, new HtmlSanitizerService(), NullLogger<NoteService>.Instance);
         Labels = new LabelService(Db, NullLogger<LabelService>.Instance);
         Account = new AccountService(Db, NullLogger<AccountService>.Instance);
     }

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -258,6 +258,35 @@
     private DotNetObjectReference<NoteEditor>? _objRef;
     private CancellationTokenSource? _debounceCts;
     private bool _hasPendingChanges = false;
+
+    /// <summary>
+    /// Whether the editor holds edits not yet persisted to the server. Setting
+    /// it also arms/disarms a browser <c>beforeunload</c> guard so that closing
+    /// or reloading the tab during the auto-save debounce window warns the user
+    /// instead of silently dropping the change (issue #109).
+    /// </summary>
+    private bool HasPendingChanges
+    {
+        get => _hasPendingChanges;
+        set
+        {
+            if (_hasPendingChanges == value) return;
+            _hasPendingChanges = value;
+            _ = SyncUnsavedChangesGuardAsync(value);
+        }
+    }
+
+    private async Task SyncUnsavedChangesGuardAsync(bool armed)
+    {
+        try
+        {
+            await JS.InvokeVoidAsync(
+                armed ? "unsavedChangesInterop.enable" : "unsavedChangesInterop.disable");
+        }
+        catch (JSException) { }
+        catch (InvalidOperationException) { }
+    }
+
     private bool _isSaving = false;
     private bool _isDisposing = false;
     private bool _hasConflict = false;
@@ -407,7 +436,7 @@
     private void ScheduleAutoSave()
     {
         if (_hasConflict || IsArchived) return;
-        _hasPendingChanges = true;
+        HasPendingChanges = true;
         SetStatus("Writing...", "status-pending");
         _debounceCts?.Cancel();
         _debounceCts?.Dispose();
@@ -453,7 +482,7 @@
             return null;
         }
         _serverUpdatedAt = result.Value!.UpdatedAt;
-        _hasPendingChanges = false;
+        HasPendingChanges = false;
         return result.Value;
     }
 
@@ -500,7 +529,7 @@
         }
 
         // Save any changes that arrived while this save was in flight
-        if (_hasPendingChanges && !_hasConflict && !_isDisposing)
+        if (HasPendingChanges && !_hasConflict && !_isDisposing)
             ScheduleAutoSave();
     }
 
@@ -537,7 +566,7 @@
     {
         _serverUpdatedAt = default;
         _hasConflict = false;
-        _hasPendingChanges = true;
+        HasPendingChanges = true;
         await DoAutoSave();
     }
 
@@ -551,7 +580,7 @@
         noteLabels = result.Value!.Labels ?? [];
         _serverUpdatedAt = result.Value!.UpdatedAt;
         _hasConflict = false;
-        _hasPendingChanges = false;
+        HasPendingChanges = false;
         SetStatus(string.Empty, string.Empty);
         await JS.InvokeVoidAsync("tiptapInterop.setContent", _editorId, content);
         StateHasChanged();
@@ -601,7 +630,7 @@
     {
         if (IsArchived) return;
         archivedAt = DateTime.UtcNow; // marker only; the server holds the real value
-        _hasPendingChanges = false;
+        HasPendingChanges = false;
         _debounceCts?.Cancel();
         Snackbar.Add("This note has been archived and is now read-only.", Severity.Warning);
         if (_editorMounted)
@@ -619,7 +648,7 @@
 
         // Flush any pending edits before the note becomes read-only.
         _debounceCts?.Cancel();
-        if (_hasPendingChanges)
+        if (HasPendingChanges)
             await SaveCoreAsync();
 
         var noteId = Id.Value;
@@ -630,7 +659,7 @@
             return;
         }
 
-        _hasPendingChanges = false;
+        HasPendingChanges = false;
         Snackbar.Add("Note archived.", Severity.Normal, config =>
         {
             config.Action = "Undo";
@@ -883,8 +912,12 @@
         _debounceCts?.Cancel();
         _debounceCts?.Dispose();
 
-        if (_hasPendingChanges && !_hasConflict && !IsArchived)
+        if (HasPendingChanges && !_hasConflict && !IsArchived)
             await SaveCoreAsync();
+
+        // Tear down the beforeunload guard so it can never outlive this editor
+        // instance (e.g. when an unresolved conflict left changes unsaved above).
+        await SyncUnsavedChangesGuardAsync(false);
 
         _objRef?.Dispose();
         await ShortcutService.UnregisterAsync("ctrl+s");

--- a/Vanadium.Note.Web/wwwroot/index.html
+++ b/Vanadium.Note.Web/wwwroot/index.html
@@ -33,6 +33,7 @@
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script src="js/keyboard-shortcuts.js"></script>
     <script src="js/quick-nav.js"></script>
+    <script src="js/unsaved-changes.js"></script>
     <script type="module" src="js/tiptap-editor.js"></script>
     <script src="js/board-drag-drop.js"></script>
     <script>

--- a/Vanadium.Note.Web/wwwroot/js/unsaved-changes.js
+++ b/Vanadium.Note.Web/wwwroot/js/unsaved-changes.js
@@ -1,0 +1,30 @@
+(function () {
+    'use strict';
+
+    // Guards against silently losing unsaved edits when the browser tab is
+    // closed or reloaded during the auto-save debounce window. NoteEditor arms
+    // this whenever it holds pending (not-yet-persisted) changes and disarms it
+    // once those changes are saved (issue #109).
+    function _handler(e) {
+        // preventDefault + a returnValue value are what trigger the browser's
+        // native "Leave site? Changes you made may not be saved." dialog.
+        e.preventDefault();
+        e.returnValue = '';
+        return '';
+    }
+
+    let _armed = false;
+
+    window.unsavedChangesInterop = {
+        enable() {
+            if (_armed) return;
+            _armed = true;
+            window.addEventListener('beforeunload', _handler);
+        },
+        disable() {
+            if (!_armed) return;
+            _armed = false;
+            window.removeEventListener('beforeunload', _handler);
+        }
+    };
+})();


### PR DESCRIPTION
Closes #109

## 문제
자동 저장 debounce(1500ms) 창이 열려 있는 동안 브라우저 탭을 닫거나 새로고침하면, `NoteEditor.DisposeAsync`의 앱 내부 저장 경로가 실행되지 않아 마지막 편집이 유실되었다. 앱 JS에 `beforeunload` 핸들러가 없었다.

## 변경 내용
- `wwwroot/js/unsaved-changes.js` 추가: `window.unsavedChangesInterop.enable()/disable()`로 `beforeunload` 리스너를 등록/해제한다. 핸들러는 `preventDefault()` + `returnValue`로 브라우저 네이티브 이탈 경고를 띄운다.
- `index.html`에 스크립트 등록.
- `NoteEditor.razor`: `_hasPendingChanges` 필드를 `HasPendingChanges` 프로퍼티로 감싸, 값이 전이될 때마다 가드를 arm/disarm 한다. `DisposeAsync`에서도 가드를 확실히 해제해 리스너가 에디터 인스턴스보다 오래 남지 않도록 한다.

## 부수 수정 (범위 밖이지만 빌드 클린을 위해 불가피)
- `Vanadium.Note.REST.Tests/TestHost.cs`: #103에서 `NoteService` 생성자에 `IHtmlSanitizerService`가 추가되었으나 테스트 호스트가 갱신되지 않아 솔루션 빌드가 깨져 있었다. 누락된 인수를 보정해 빌드/테스트 스위트를 복구했다. (별도 커밋)

## 완료 조건 검증
- ✅ `HasPendingChanges`가 true인 동안 `beforeunload` 핸들러 등록, false가 되면 해제 — 프로퍼티 setter의 전이 감지로 `unsavedChangesInterop.enable/disable` 호출.
- ✅ debounce 창 중 탭 닫기/새로고침 시 이탈 경고 표시 — 핸들러의 `preventDefault()` + `returnValue`.
- ✅ 빌드 클린 — `dotnet build Vanadium.slnx` 오류 0개 (기존 NU1903 경고 외 신규 경고 없음), `dotnet test` 50 통과.

## 참고
- `beforeunload` 동작은 브라우저 상호작용이라 Web 프로젝트(테스트 없음)에서 자동 회귀 테스트를 추가하지 못했다. 수동 확인이 필요하다.
- debounce 시간(1500ms)과 아카이브 읽기 전용 모드 동작은 변경하지 않았다.