### PR TITLE
#114 인증 이미지 엔드포인트 Cache-Control을 private로 변경

### DIFF
--- a/Vanadium.Note.REST.Tests/ImagesControllerCacheTests.cs
+++ b/Vanadium.Note.REST.Tests/ImagesControllerCacheTests.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Vanadium.Note.REST.Controllers;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Guards the caching policy on the authenticated image download endpoint
+/// (<see cref="ImagesController.Get"/>). Because the endpoint requires
+/// authentication, its response must be marked <c>Cache-Control: private</c>
+/// so that shared (intermediary) proxies never cache a private image, while
+/// long-lived client-side caching is preserved. The <c>[ResponseCache]</c>
+/// attribute is framework metadata applied by the MVC pipeline, so it is
+/// asserted here via reflection (a full HTTP integration host is out of scope
+/// for this project).
+/// </summary>
+public class ImagesControllerCacheTests
+{
+    private static ResponseCacheAttribute GetAttribute()
+    {
+        var method = typeof(ImagesController).GetMethod(nameof(ImagesController.Get))!;
+        return method.GetCustomAttribute<ResponseCacheAttribute>()!;
+    }
+
+    [Fact]
+    public void Get_UsesClientLocation_SoResponseIsPrivate()
+    {
+        var attribute = GetAttribute();
+
+        Assert.NotNull(attribute);
+        Assert.Equal(ResponseCacheLocation.Client, attribute.Location);
+    }
+
+    [Fact]
+    public void Get_RetainsLongLivedClientCaching()
+    {
+        var attribute = GetAttribute();
+
+        Assert.Equal(31536000, attribute.Duration);
+    }
+}

--- a/Vanadium.Note.REST/Controllers/ImagesController.cs
+++ b/Vanadium.Note.REST/Controllers/ImagesController.cs
@@ -50,7 +50,7 @@ public class ImagesController(IWebHostEnvironment env, ILogger<ImagesController>
 
     [Authorize]
     [HttpGet("{id:guid}")]
-    [ResponseCache(Duration = 31536000, Location = ResponseCacheLocation.Any)]
+    [ResponseCache(Duration = 31536000, Location = ResponseCacheLocation.Client)]
     public IActionResult Get(Guid id)
     {
         logger.LogDebug("Image requested: {ImageId}", id);


### PR DESCRIPTION
## 개요
Closes #114

인증이 필요한 이미지 다운로드 엔드포인트 `GET /api/images/{id}`(`[Authorize]`)에 `ResponseCacheLocation.Any`가 적용되어 `Cache-Control: public` 응답이 나갔다. 이로 인해 공유(중간) 프록시가 비공개 이미지를 캐시할 수 있는 문제가 있었다.

## 변경 내용
- `ImagesController.Get`의 `ResponseCache` 속성을 `Location = ResponseCacheLocation.Any` → `Location = ResponseCacheLocation.Client`로 변경. 이제 `Cache-Control: private`이 나가며, 장기 클라이언트 캐싱(`Duration = 31536000`)은 그대로 유지된다.
- 속성 값을 검증하는 회귀 테스트 추가(`ImagesControllerCacheTests`). `[ResponseCache]`는 MVC 파이프라인이 적용하는 프레임워크 메타데이터라 HTTP 통합 호스트 없이 리플렉션으로 검증(이 프로젝트는 통합 테스트 호스트가 없음).

## 완료 조건 검증
- [x] `Get` 액션의 `ResponseCacheLocation`이 `Client`로 변경되어 응답이 `Cache-Control: private`이 된다 — 코드 변경 + `Get_UsesClientLocation_SoResponseIsPrivate` 테스트로 검증.
- [x] 브라우저 클라이언트 캐싱(장기 `Duration`)은 유지된다 — `Duration`은 `31536000` 유지, `Get_RetainsLongLivedClientCaching` 테스트로 검증.
- [x] 빌드 클린 — 컴파일 성공, 전체 테스트 52 통과 / 3 건너뜀(PostgreSQL 전용) / 0 실패.

## 범위
`ImagesController.Get`의 캐시 속성만 변경했으며 업로드/포맷 검증 등 다른 동작은 건드리지 않았다.