### PR TITLE
#115 멘션 스트리핑/page-link 갱신이 휴지통 노트를 포함하도록 수정

### DIFF
--- a/Vanadium.Note.REST.Tests/ReferenceCleanupRecycleBinTests.cs
+++ b/Vanadium.Note.REST.Tests/ReferenceCleanupRecycleBinTests.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore;
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression tests for issue #115: mention stripping and page-link title
+/// propagation must reach recycle-bin (soft-deleted) referencing notes, so a
+/// restored note never carries a dead mention or a stale page-link title.
+/// </summary>
+public class ReferenceCleanupRecycleBinTests
+{
+    /// <summary>Inserts a soft-deleted note with exact content, bypassing the
+    /// service's sanitizer so the reference markup under test is preserved.</summary>
+    private static async Task<NoteItem> AddSoftDeletedNoteAsync(TestHost h, string content)
+    {
+        var note = new NoteItem
+        {
+            Title = "Referencing (recycle bin)",
+            Content = content,
+            ContentText = content,
+            DeletedAt = DateTime.UtcNow,
+            IsDeletionRoot = true,
+        };
+        h.Db.Notes.Add(note);
+        await h.Db.SaveChangesAsync();
+        return note;
+    }
+
+    // ── Mention stripping reaches soft-deleted referencing notes ──────────────
+
+    [Fact]
+    public async Task PermanentDelete_StripsMentions_FromRecycleBinNote()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Target");
+
+        var mention =
+            $"<p><a data-type=\"noteMention\" data-note-id=\"{target.Id}\" " +
+            $"data-title=\"Target\">@Target</a></p>";
+        var referencing = await AddSoftDeletedNoteAsync(h, mention);
+
+        // Soft-delete then permanently delete the target — this triggers mention stripping.
+        Assert.True(await h.Notes.Delete(target.Id));
+        var (found, wasInBin) = await h.Notes.DeletePermanent(target.Id);
+        Assert.True(found);
+        Assert.True(wasInBin);
+
+        // The recycle-bin note no longer holds a dead mention link to the target.
+        var reloaded = await h.FindAsync(referencing.Id);
+        Assert.NotNull(reloaded);
+        Assert.DoesNotContain($"data-note-id=\"{target.Id}\"", reloaded!.Content);
+        // The plain "@Target" text remains (the link wrapper is stripped, not the text).
+        Assert.Contains("@Target", reloaded.Content);
+    }
+
+    // ── Page-link title propagation reaches soft-deleted referencing notes ─────
+
+    [Fact]
+    public async Task TitleChange_UpdatesPageLink_InRecycleBinNote()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Old Title");
+
+        var pageLink =
+            $"<div data-type=\"pageLink\" data-note-id=\"{target.Id}\" " +
+            $"data-title=\"Old Title\">\U0001F4C4 Old Title</div>";
+        var referencing = await AddSoftDeletedNoteAsync(h, pageLink);
+
+        // Rename the target (UpdatedAt=default → force-save, bypasses concurrency check).
+        var (updated, conflict, archived) = await h.Notes.Update(
+            target.Id,
+            new NoteItem { Title = "New Title", Content = target.Content, UpdatedAt = default });
+        Assert.NotNull(updated);
+        Assert.False(conflict);
+        Assert.False(archived);
+
+        // The recycle-bin note's page-link now reflects the new title.
+        var reloaded = await h.FindAsync(referencing.Id);
+        Assert.NotNull(reloaded);
+        Assert.Contains("New Title", reloaded!.Content);
+        Assert.DoesNotContain("Old Title", reloaded.Content);
+    }
+}

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -269,7 +269,10 @@ public class NoteService(
     private async Task UpdatePageLinkReferences(Guid noteId, string newTitle)
     {
         var idStr = noteId.ToString();
-        var referencingNotes = await db.Notes
+        // IgnoreQueryFilters so recycle-bin (soft-deleted) notes referencing this
+        // note also get their page-link title refreshed — otherwise a restored note
+        // keeps a stale title.
+        var referencingNotes = await db.Notes.IgnoreQueryFilters()
             .Where(n => n.Content.Contains($"data-note-id=\"{idStr}\""))
             .ToListAsync();
 
@@ -829,7 +832,10 @@ public class NoteService(
     private async Task StripMentionReferencesAsync(Guid noteId)
     {
         var idStr = noteId.ToString();
-        var referencingNotes = await db.Notes
+        // IgnoreQueryFilters so recycle-bin (soft-deleted) notes referencing this
+        // note also get their dead mention links stripped — otherwise a restored
+        // note keeps a dead mention pointing at a permanently-deleted note.
+        var referencingNotes = await db.Notes.IgnoreQueryFilters()
             .Where(n => n.Content.Contains($"data-note-id=\"{idStr}\""))
             .ToListAsync();
 


### PR DESCRIPTION
## 요약
`StripMentionReferencesAsync`와 `UpdatePageLinkReferences`가 기본 전역 쿼리 필터(`DeletedAt == null`)가 적용된 `db.Notes`로 참조 노트를 조회해, 휴지통(soft-deleted) 노트가 정리 대상에서 누락되던 버그를 수정합니다. 두 조회에 `IgnoreQueryFilters()`를 추가해 휴지통 노트도 포함시킵니다.

- 아카이브 노트는 전역 필터가 없어 이미 조회에 포함되므로 `IgnoreQueryFilters()` 추가로 아카이브 가시성 규칙은 변하지 않습니다(범위 밖 준수).

## 완료 조건 검증
- [x] **두 조회에 `IgnoreQueryFilters()` 추가** — `NoteService.cs`의 `UpdatePageLinkReferences`(page-link 제목 갱신)와 `StripMentionReferencesAsync`(멘션 스트리핑) 조회에 각각 추가.
- [x] **복원 시 죽은 멘션/오래된 page-link 제목이 남지 않음** — 회귀 테스트 2건으로 검증:
  - `PermanentDelete_StripsMentions_FromRecycleBinNote`: 휴지통 노트가 참조하는 대상 노트를 영구 삭제하면 휴지통 노트의 멘션 링크가 제거됨.
  - `TitleChange_UpdatesPageLink_InRecycleBinNote`: 대상 노트 제목 변경 시 휴지통 노트의 page-link 제목이 갱신됨.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 오류 0개(기존 NU1903 경고 외 신규 경고 없음).
- [x] `dotnet test Vanadium.slnx` — 54건 통과, 3건 건너뜀, 실패 0.

Closes #115
