### PR TITLE
#116 HardDeleteAsync 다중 저장을 트랜잭션으로 원자화

### DIFF
--- a/Vanadium.Note.REST.Tests/HardDeleteTransactionTests.cs
+++ b/Vanadium.Note.REST.Tests/HardDeleteTransactionTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore;
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression tests for issue #116: <c>HardDeleteAsync</c>'s multi-save sequence
+/// (parent page-link strip + mention stripping over the whole subtree + the note
+/// removal) is wrapped in a single execution-strategy transaction, so it commits
+/// atomically. These tests exercise the wrapped happy path across a descendant
+/// subtree, guarding that the transaction wrapping did not regress the outcome.
+/// (True rollback-on-failure is not asserted here — the current in-memory SQLite
+/// harness offers no clean seam to inject a mid-sequence DB failure.)
+/// </summary>
+public class HardDeleteTransactionTests
+{
+    /// <summary>Inserts a soft-deleted note with exact content, bypassing the
+    /// service's sanitizer so the reference markup under test is preserved.</summary>
+    private static async Task<NoteItem> AddSoftDeletedNoteAsync(TestHost h, string content)
+    {
+        var note = new NoteItem
+        {
+            Title = "Referencing (recycle bin)",
+            Content = content,
+            ContentText = content,
+            DeletedAt = DateTime.UtcNow,
+            IsDeletionRoot = true,
+        };
+        h.Db.Notes.Add(note);
+        await h.Db.SaveChangesAsync();
+        return note;
+    }
+
+    [Fact]
+    public async Task PermanentDelete_WithSubtree_AtomicallyRemovesNotesAndStripsMentions()
+    {
+        using var h = new TestHost();
+
+        // Parent with a child — the child is a descendant swept into the subtree.
+        var parent = await h.CreateNoteAsync("Parent");
+        var child = await h.CreateNoteAsync("Child", parentId: parent.Id);
+
+        // A recycle-bin note mentions the child — stripping it happens inside the
+        // subtree loop, i.e. within the transaction.
+        var mention =
+            $"<p><a data-type=\"noteMention\" data-note-id=\"{child.Id}\" " +
+            $"data-title=\"Child\">@Child</a></p>";
+        var referencing = await AddSoftDeletedNoteAsync(h, mention);
+
+        // Soft-delete the parent (cascades the child into the bin), then purge it.
+        Assert.True(await h.Notes.Delete(parent.Id));
+        var (found, wasInBin) = await h.Notes.DeletePermanent(parent.Id);
+        Assert.True(found);
+        Assert.True(wasInBin);
+
+        // Both parent and child are gone — the whole subtree committed.
+        Assert.Null(await h.FindAsync(parent.Id));
+        Assert.Null(await h.FindAsync(child.Id));
+
+        // The recycle-bin note's dead mention to the child was stripped.
+        var reloaded = await h.FindAsync(referencing.Id);
+        Assert.NotNull(reloaded);
+        Assert.DoesNotContain($"data-note-id=\"{child.Id}\"", reloaded!.Content);
+        Assert.Contains("@Child", reloaded.Content);
+    }
+}

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -759,32 +759,51 @@ public class NoteService(
     {
         var subtree = await CollectDescendantsUnfilteredAsync(note.Id);
 
-        // Remove any page-link blocks referencing this note from the parent's content
-        if (note.ParentNoteId.HasValue)
-        {
-            var parent = await db.Notes.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(n => n.Id == note.ParentNoteId.Value);
-            if (parent is not null)
-            {
-                var cleaned = RemovePageLinkFromContent(parent.Content, note.Id);
-                if (cleaned != parent.Content)
-                {
-                    parent.Content = cleaned;
-                    parent.ContentText = StripHtml(cleaned);
-                }
-            }
-        }
-
-        // Strip mention links referencing any note in the subtree from active notes
-        await StripMentionReferencesAsync(note.Id);
-        foreach (var descendant in subtree)
-            await StripMentionReferencesAsync(descendant.Id);
-
         var combinedContent = string.Join(' ',
             subtree.Select(n => n.Content).Prepend(note.Content));
 
-        db.Notes.Remove(note);
-        await db.SaveChangesAsync();
+        // Wrap the multi-save sequence (parent page-link strip, mention stripping,
+        // and the note removal) in a single transaction so a mid-sequence failure
+        // rolls the whole unit back instead of leaving a partial commit. The DB is
+        // configured with a retrying execution strategy (EnableRetryOnFailure),
+        // which forbids user-initiated transactions unless the whole unit runs
+        // through the strategy so it can be retried atomically — mirrors
+        // AccountService.PurgeAllDataAsync.
+        var strategy = db.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var tx = await db.Database.BeginTransactionAsync();
+
+            // Remove any page-link blocks referencing this note from the parent's content
+            if (note.ParentNoteId.HasValue)
+            {
+                var parent = await db.Notes.IgnoreQueryFilters()
+                    .FirstOrDefaultAsync(n => n.Id == note.ParentNoteId.Value);
+                if (parent is not null)
+                {
+                    var cleaned = RemovePageLinkFromContent(parent.Content, note.Id);
+                    if (cleaned != parent.Content)
+                    {
+                        parent.Content = cleaned;
+                        parent.ContentText = StripHtml(cleaned);
+                    }
+                }
+            }
+
+            // Strip mention links referencing any note in the subtree from active notes
+            await StripMentionReferencesAsync(note.Id);
+            foreach (var descendant in subtree)
+                await StripMentionReferencesAsync(descendant.Id);
+
+            db.Notes.Remove(note);
+            await db.SaveChangesAsync();
+
+            await tx.CommitAsync();
+        });
+
+        // File cleanup runs AFTER the transaction commits: deleting files is an
+        // irreversible filesystem side effect and must not sit inside the DB
+        // transaction (a rollback cannot un-delete files).
         await fileCleanup.DeleteOrphanedFromContentAsync(combinedContent);
         logger.LogInformation(
             "Note {NoteId} permanently deleted with {DescendantCount} descendant(s).",


### PR DESCRIPTION
Closes #116

## 문제
`HardDeleteAsync`가 멘션 스트리핑 저장들(노트 + 각 자손)과 노트 `Remove` 저장을 트랜잭션 없이 순차 실행하여, 중간에 실패하면 일부 참조만 정리되고 노트는 남는(또는 그 반대의) 부분 완료(partial commit) 상태가 될 수 있었다.

## 변경
- `HardDeleteAsync`의 다중 저장 시퀀스(부모 page-link 스트리핑 · 서브트리 멘션 스트리핑 · 노트 `Remove`)를 단일 트랜잭션으로 감쌌다.
- `AccountService.PurgeAllDataAsync`와 동일하게 `db.Database.CreateExecutionStrategy()` + `BeginTransactionAsync`로 감싸, `EnableRetryOnFailure` 재시도 실행 전략과 호환되게 처리했다.
- 파일 정리(`DeleteOrphanedFromContentAsync`)는 되돌릴 수 없는 파일시스템 부작용이므로 트랜잭션 커밋 **이후**에 수행하도록 유지했다(트랜잭션 범위에 파일 I/O 미포함).

## 완료 조건 검증
- [x] **다중 저장이 execution strategy + 트랜잭션으로 원자적 커밋/롤백** — `HardDeleteAsync`를 `strategy.ExecuteAsync` + `BeginTransactionAsync`/`CommitAsync`로 래핑.
- [x] **실패 시 부분 완료 상태가 남지 않음** — 트랜잭션 원자성으로 보장. 커밋 전 예외 시 전체 롤백.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 통과(기존 NU1903 경고 외 신규 경고 없음).
- 회귀 테스트: `HardDeleteTransactionTests` 추가(부모+자식 서브트리 영구 삭제 시 노트 전체 제거 + 자식 멘션 스트리핑이 원자적으로 완료됨을 검증). `dotnet test Vanadium.slnx` → 55 통과 / 3 스킵(PostgreSQL 전용) / 0 실패.

## 참고
- 트랜잭션 롤백-on-failure의 직접 단위 테스트는 현재 in-memory SQLite 하네스에 중간 실패를 주입할 깨끗한 seam이 없어 추가하지 않았다(테스트 파일 주석에 명시). 기존/신규 테스트가 래핑된 happy path를 커버한다.
- soft delete 등 다른 삭제 경로는 변경하지 않았다.