### PR TITLE
#117 세션 중 401로 인한 작업/컨텍스트 유실 방지

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -14,6 +14,7 @@
 @inject IDialogService DialogService
 @inject KeyboardShortcutService ShortcutService
 @inject QuickNavService QuickNav
+@inject DraftStore DraftStore
 @implements IAsyncDisposable
 
 <PageTitle>@(isNew ? "New Note" : "Edit Note")</PageTitle>
@@ -366,6 +367,22 @@
                 parentTitle = parentResult.Value!.Title;
         }
 
+        // Restore any unsaved draft stashed when a save failed mid-session (e.g. an
+        // auth-expiry 401 that redirected to login). The draft is keyed by note id, so
+        // this only fires for the note the user was actually editing (issue #117).
+        // Skip archived notes — they are read-only and cannot hold pending edits.
+        if (!IsArchived)
+        {
+            var draft = await DraftStore.GetAsync(Id);
+            if (draft is not null)
+            {
+                title = draft.Title;
+                content = draft.Content;
+                HasPendingChanges = true;
+                Snackbar.Add("Restored your unsaved changes.", Severity.Info);
+            }
+        }
+
         // Mark content ready ONLY after it is loaded. Setting this before the awaited GET
         // let the render that fires while awaiting push the reset-to-empty content into the
         // editor and consume the flag, leaving the editor blank on component reuse
@@ -479,10 +496,14 @@
         if (!result.IsSuccess)
         {
             Logger.LogError("Save failed for note {NoteId}.", note.Id);
+            // The session may have expired (401 → redirect to login). Stash the draft
+            // so the in-progress edit survives re-login and is restored on return (#117).
+            await DraftStore.SaveAsync(Id, title, content);
             return null;
         }
         _serverUpdatedAt = result.Value!.UpdatedAt;
         HasPendingChanges = false;
+        await DraftStore.ClearAsync();
         return result.Value;
     }
 

--- a/Vanadium.Note.Web/Program.cs
+++ b/Vanadium.Note.Web/Program.cs
@@ -45,6 +45,7 @@ namespace Vanadium.Note.Web
             builder.Services.AddScoped<ThemeService>();
             builder.Services.AddScoped<KeyboardShortcutService>();
             builder.Services.AddScoped<QuickNavService>();
+            builder.Services.AddScoped<DraftStore>();
             builder.Services.AddMudServices();
 
             await builder.Build().RunAsync();

--- a/Vanadium.Note.Web/Services/AuthTokenHandler.cs
+++ b/Vanadium.Note.Web/Services/AuthTokenHandler.cs
@@ -23,9 +23,23 @@ public class AuthTokenHandler(
         {
             await tokenStore.ClearAsync();
             authProvider.NotifyAuthStateChanged();
-            navigation.NavigateTo("/login");
+            navigation.NavigateTo(BuildLoginUrl());
         }
 
         return response;
+    }
+
+    /// <summary>
+    /// Builds the login redirect target, carrying the current location as a
+    /// <c>returnUrl</c> so re-login returns the user to where the session
+    /// expired (issue #117). Avoids a redirect loop when already on /login.
+    /// </summary>
+    private string BuildLoginUrl()
+    {
+        var relative = navigation.ToBaseRelativePath(navigation.Uri);
+        var path = relative.Split('?', '#')[0];
+        if (string.IsNullOrEmpty(path) || path.Equals("login", StringComparison.OrdinalIgnoreCase))
+            return "login";
+        return $"login?returnUrl={Uri.EscapeDataString("/" + relative)}";
     }
 }

--- a/Vanadium.Note.Web/Services/DraftStore.cs
+++ b/Vanadium.Note.Web/Services/DraftStore.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using Microsoft.JSInterop;
+
+namespace Vanadium.Note.Web.Services;
+
+/// <summary>
+/// Persists the in-progress editor draft to the browser's <c>sessionStorage</c>
+/// so that a mid-session auth expiry (401 → redirect to login) does not discard
+/// unsaved work. Only a single draft slot is kept; it is keyed by note id so a
+/// stashed draft is restored only when the same note is reopened after re-login
+/// (issue #117). Mirrors <see cref="Vanadium.Note.Web.Auth.TokenStore"/>.
+/// </summary>
+public class DraftStore(IJSRuntime js, ILogger<DraftStore> logger)
+{
+    private const string StorageKey = "vanadium.editor-draft.v1";
+
+    public async Task SaveAsync(Guid? noteId, string title, string content)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(new EditorDraft(noteId, title, content));
+            await js.InvokeVoidAsync("sessionStorage.setItem", StorageKey, json);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to persist editor draft to sessionStorage.");
+        }
+    }
+
+    /// <summary>
+    /// Returns the stashed draft only when it belongs to <paramref name="noteId"/>
+    /// (both <c>null</c> matches a new-note draft); otherwise <c>null</c>.
+    /// </summary>
+    public async Task<EditorDraft?> GetAsync(Guid? noteId)
+    {
+        try
+        {
+            var json = await js.InvokeAsync<string?>("sessionStorage.getItem", StorageKey);
+            if (string.IsNullOrEmpty(json))
+                return null;
+            var draft = JsonSerializer.Deserialize<EditorDraft>(json);
+            return draft is not null && draft.NoteId == noteId ? draft : null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to read editor draft from sessionStorage.");
+            return null;
+        }
+    }
+
+    public async Task ClearAsync()
+    {
+        try
+        {
+            await js.InvokeVoidAsync("sessionStorage.removeItem", StorageKey);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to clear editor draft from sessionStorage.");
+        }
+    }
+}

--- a/Vanadium.Note.Web/Services/EditorDraft.cs
+++ b/Vanadium.Note.Web/Services/EditorDraft.cs
@@ -1,0 +1,10 @@
+namespace Vanadium.Note.Web.Services;
+
+/// <summary>
+/// An in-progress editor draft (title + content) stashed in the browser's
+/// <c>sessionStorage</c> when a save fails mid-session (e.g. an auth-expiry 401),
+/// so the unsaved work can be restored when the same note is reopened after
+/// re-login (issue #117). <see cref="NoteId"/> is <c>null</c> for a new,
+/// not-yet-persisted note.
+/// </summary>
+public record EditorDraft(Guid? NoteId, string Title, string Content);


### PR DESCRIPTION
## 개요
세션 도중 JWT가 만료되어 401이 발생하면 `AuthTokenHandler`가 `returnUrl` 없이 `/login`으로 리다이렉트했다. 이때 편집 중이던 내용과 원래 위치(컨텍스트)가 유실됐다. 이 PR은 (1) 로그인 리다이렉트에 `returnUrl`을 붙여 원위치로 복귀하고, (2) 저장 실패 시 편집 내용을 `sessionStorage`에 보관했다가 복원하도록 한다.

Closes #117

## 변경 사항
- **`AuthTokenHandler`** — 401 리다이렉트 시 현재 상대 경로를 `returnUrl` 쿼리로 붙인다. 이미 `/login`이면 붙이지 않아 리다이렉트 루프를 방지한다. `Login.razor`는 기존에 이미 `ReturnUrl`을 읽어 성공 시 해당 위치로 이동한다(변경 불필요).
- **`DraftStore` (신규) + `EditorDraft` (신규)** — `TokenStore`와 동일한 패턴으로 `sessionStorage`를 감싼 스코프 서비스. 노트 id로 키잉된 단일 드래프트 슬롯을 저장/조회/삭제한다.
- **`NoteEditor.razor`** — 저장 실패(`SaveCoreAsync`의 `!result.IsSuccess`, 401 포함) 시 드래프트를 보관하고, 저장 성공 시 삭제한다. `OnParametersSetAsync`에서 서버 로드 후 같은 노트의 드래프트가 있으면 복원한다(아카이브 노트는 읽기 전용이므로 제외).
- **`Program.cs`** — `DraftStore` DI 등록.

## 완료 조건 검증
- [x] **401 리다이렉트 시 `returnUrl` 포함 → 원화면 복귀** — `AuthTokenHandler.BuildLoginUrl()`이 `login?returnUrl=<현재 경로>`를 생성. `Login.razor`가 성공 시 그 경로로 이동.
- [x] **세션 만료 저장 실패 시 내용 유실 없이 복원** — 실패 시 `DraftStore.SaveAsync`로 보관(원 저장·dispose flush 재저장 양쪽 경로에서 동작), 재로그인 후 `returnUrl`로 같은 노트에 복귀하면 `OnParametersSetAsync`가 복원. 성공 저장 시 `DraftStore.ClearAsync`로 정리.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고/오류 신규 없음(기존 NU1903 4건만). `dotnet test Vanadium.slnx` 55 통과.

## 범위
- 리프레시 토큰 미도입, 백엔드 인증/JWT 로직 무변경 — 모든 변경은 `Vanadium.Note.Web`에 한정.

## 검증 참고
- 영향 범위(Blazor WASM 컴포넌트 + `DelegatingHandler`, `NavigationManager`/`IJSRuntime` 의존)를 커버하는 테스트 프로젝트가 없어(Web 프로젝트 무테스트) 자동 회귀 테스트는 추가하지 못했다. 빌드/기존 테스트로 검증했으며, 실제 401 만료 시나리오는 수동 확인이 필요하다.
