### PR TITLE
#118 로그인 실패 원인(401/429/네트워크·서버)을 구분해 안내

### DIFF
--- a/Vanadium.Note.Web/Auth/AuthService.cs
+++ b/Vanadium.Note.Web/Auth/AuthService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 
 namespace Vanadium.Note.Web.Auth;
@@ -8,7 +9,7 @@ public class AuthService(
     JwtAuthenticationStateProvider authProvider,
     ILogger<AuthService> logger)
 {
-    public async Task<bool> LoginAsync(string password)
+    public async Task<LoginOutcome> LoginAsync(string password)
     {
         logger.LogInformation("Login attempt.");
         try
@@ -17,25 +18,30 @@ public class AuthService(
             if (!response.IsSuccessStatusCode)
             {
                 logger.LogWarning("Login failed: HTTP {StatusCode}.", (int)response.StatusCode);
-                return false;
+                return response.StatusCode switch
+                {
+                    HttpStatusCode.Unauthorized => LoginOutcome.InvalidPassword,
+                    HttpStatusCode.TooManyRequests => LoginOutcome.RateLimited,
+                    _ => LoginOutcome.ServerError,
+                };
             }
 
             var result = await response.Content.ReadFromJsonAsync<LoginResult>();
             if (result?.Token is null)
             {
                 logger.LogWarning("Login failed: response contained no token.");
-                return false;
+                return LoginOutcome.ServerError;
             }
 
             await tokenStore.SetAsync(result.Token);
             authProvider.NotifyAuthStateChanged();
             logger.LogInformation("Logged in successfully.");
-            return true;
+            return LoginOutcome.Success;
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Login request failed.");
-            return false;
+            return LoginOutcome.NetworkError;
         }
     }
 

--- a/Vanadium.Note.Web/Auth/LoginOutcome.cs
+++ b/Vanadium.Note.Web/Auth/LoginOutcome.cs
@@ -1,0 +1,23 @@
+namespace Vanadium.Note.Web.Auth;
+
+/// <summary>
+/// Distinguishes the possible outcomes of a login attempt so the UI can show a
+/// cause-specific message instead of collapsing every failure into "Invalid password".
+/// </summary>
+public enum LoginOutcome
+{
+    /// <summary>Login succeeded and a token was stored.</summary>
+    Success,
+
+    /// <summary>The server rejected the password (HTTP 401).</summary>
+    InvalidPassword,
+
+    /// <summary>The login endpoint is rate-limited (HTTP 429).</summary>
+    RateLimited,
+
+    /// <summary>The server returned an unexpected error (HTTP 5xx or a missing token).</summary>
+    ServerError,
+
+    /// <summary>The request never reached the server (offline, DNS, TLS, timeout).</summary>
+    NetworkError,
+}

--- a/Vanadium.Note.Web/Pages/Login.razor
+++ b/Vanadium.Note.Web/Pages/Login.razor
@@ -42,16 +42,22 @@
         _isLoading = true;
         _errorMessage = null;
 
-        var success = await AuthService.LoginAsync(_model.Password);
+        var outcome = await AuthService.LoginAsync(_model.Password);
 
-        if (success)
+        if (outcome == LoginOutcome.Success)
         {
             var target = string.IsNullOrEmpty(ReturnUrl) ? "/" : Uri.UnescapeDataString(ReturnUrl);
             Nav.NavigateTo(target);
         }
         else
         {
-            _errorMessage = "Invalid password.";
+            _errorMessage = outcome switch
+            {
+                LoginOutcome.InvalidPassword => "Invalid password.",
+                LoginOutcome.RateLimited => "Too many attempts. Please wait a moment and try again.",
+                LoginOutcome.NetworkError => "Cannot reach the server. Check your connection and try again.",
+                _ => "Something went wrong on the server. Please try again later.",
+            };
             _isLoading = false;
         }
     }


### PR DESCRIPTION
Closes #118

## 문제
로그인 실패 시 원인과 무관하게 항상 "Invalid password."로 안내했다. `AuthService.LoginAsync`가 성공/실패를 `bool`로만 반환하며 예외·비성공 응답을 모두 `false`로 뭉뚱그렸기 때문에, rate-limited(429)이거나 네트워크 오프라인/서버 오류인 사용자도 "비밀번호가 틀렸다"는 안내를 받았다.

## 변경 내용
- **`LoginOutcome`(신규)** — `Success` / `InvalidPassword` / `RateLimited` / `ServerError` / `NetworkError` 판별 결과 타입 추가.
- **`AuthService.LoginAsync`** — 반환 타입을 `bool` → `LoginOutcome`로 변경. HTTP 401 → `InvalidPassword`, 429 → `RateLimited`, 그 외 비성공/토큰 누락 → `ServerError`, 요청 예외 → `NetworkError`로 매핑.
- **`Login.razor`** — 결과별로 서로 다른 사용자 안내 메시지 표시.

## 완료 조건 검증
- [x] **401/429/네트워크·서버 오류가 서로 다른 메시지로 구분** — `Login.razor`의 `outcome switch`가 각 상황에 개별 메시지를 매핑(잘못된 비밀번호 / 잠시 후 재시도 / 서버 연결 실패 / 서버 오류).
- [x] **`LoginAsync`가 원인을 구분 가능한 결과를 반환** — `Task<LoginOutcome>` 반환으로 변경. 단일 호출부(`Login.razor`)도 함께 수정.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 오류 0개(기존 NU1903 경고 4개 외 신규 경고 없음). `dotnet test Vanadium.slnx` 55개 통과.

## 범위
- 프론트엔드(`Vanadium.Note.Web`)만 변경. rate limit 정책·백엔드 인증 방식은 건드리지 않음(범위 밖 준수).
- `Vanadium.Note.Web`에는 테스트 프로젝트가 없어(REST만 존재) 단위 테스트는 추가하지 못했으며 빌드/기존 테스트로 검증함.