### PR TITLE
#119 노트 로드 실패를 404와 일시적 오류로 구분

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -72,6 +72,16 @@
     </div>
 }
 
+@if (_loadFailed)
+{
+    <div class="load-error-banner">
+        <span>⚠ Couldn't load this note — it may be a temporary problem. The note has not been deleted.</span>
+        <div class="load-error-banner-actions">
+            <button class="btn btn-sm btn-primary" @onclick="RetryLoad">Retry</button>
+        </div>
+    </div>
+}
+
 <div class="editor-body">
     <input class="editor-title"
            type="text"
@@ -291,6 +301,7 @@
     private bool _isSaving = false;
     private bool _isDisposing = false;
     private bool _hasConflict = false;
+    private bool _loadFailed = false;
     private DateTime _serverUpdatedAt;
     private string saveStatusText = string.Empty;
     private string saveStatusCss = string.Empty;
@@ -324,6 +335,7 @@
         childCount = 0;
         noteLabels = [];
         _hasConflict = false;
+        _loadFailed = false;
         _isSaving = false;
         _serverUpdatedAt = default;
 
@@ -350,12 +362,22 @@
                     VisitedAt = DateTime.UtcNow
                 });
             }
-            else
+            else if (result.IsNotFound)
             {
                 // A stale Recents entry can point at a deleted note (E3/E4) — prune it.
+                // Only a genuine 404 gets here; transient errors fall through below (#119).
                 await QuickNav.RemoveRecentAsync(Id.Value);
                 Snackbar.Add("That note no longer exists.", Severity.Error);
                 Nav.NavigateTo("/");
+                return;
+            }
+            else
+            {
+                // Transient failure (5xx / network). The note may still exist, so do NOT
+                // prune the Recents entry or bounce to Home — show a retry affordance and
+                // keep the user in place (#119).
+                _loadFailed = true;
+                Snackbar.Add("Couldn't load the note. Please try again.", Severity.Error);
                 return;
             }
         }
@@ -414,7 +436,7 @@
             var token = await TokenStore.GetAsync() ?? string.Empty;
             try
             {
-                await JS.InvokeVoidAsync("tiptapInterop.init", _editorId, _objRef, content, apiBase, token, !IsArchived);
+                await JS.InvokeVoidAsync("tiptapInterop.init", _editorId, _objRef, content, apiBase, token, !IsArchived && !_loadFailed);
                 _editorMounted = true;
                 await ShortcutService.RegisterAsync("ctrl+s", "Save note", () => InvokeAsync(SaveNote));
             }
@@ -452,7 +474,7 @@
 
     private void ScheduleAutoSave()
     {
-        if (_hasConflict || IsArchived) return;
+        if (_hasConflict || IsArchived || _loadFailed) return;
         HasPendingChanges = true;
         SetStatus("Writing...", "status-pending");
         _debounceCts?.Cancel();
@@ -589,6 +611,18 @@
         _hasConflict = false;
         HasPendingChanges = true;
         await DoAutoSave();
+    }
+
+    /// <summary>Re-runs the note load after a transient failure (#119). Clears the
+    /// cached id so <see cref="OnParametersSetAsync"/> re-fetches instead of short-circuiting;
+    /// on success it sets <c>_contentJustLoaded</c>, so the post-render hook re-applies the
+    /// content and re-enables the editor.</summary>
+    private async Task RetryLoad()
+    {
+        _loadFailed = false;
+        _currentId = null;
+        _currentParentId = null;
+        await OnParametersSetAsync();
     }
 
     private async Task ReloadNote()

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor.css
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor.css
@@ -590,3 +590,24 @@
     gap: 0.5rem;
     flex-shrink: 0;
 }
+
+.load-error-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.6rem 1rem;
+    margin-bottom: 0.75rem;
+    background: var(--vn-conflict-bg);
+    border: 1px solid var(--vn-conflict-border);
+    border-radius: 6px;
+    color: var(--vn-conflict-color);
+    font-size: 0.88rem;
+    flex-wrap: wrap;
+}
+
+.load-error-banner-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}

--- a/Vanadium.Note.Web/Services/NoteService.cs
+++ b/Vanadium.Note.Web/Services/NoteService.cs
@@ -72,13 +72,27 @@ public class NoteService(HttpClient http, ILogger<NoteService> logger)
     {
         try
         {
-            var result = await http.GetFromJsonAsync<NoteItem>($"api/notes/{id}");
+            var response = await http.GetAsync($"api/notes/{id}");
+
+            // A genuine 404 means the note no longer exists — callers may safely
+            // prune stale references. Any other non-success (5xx, network handled
+            // below) is transient and must NOT be treated as a deletion.
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return ServiceResult<NoteItem>.NotFound("Note not found.");
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogError("Failed to load note {NoteId}: {StatusCode}.", id, (int)response.StatusCode);
+                return ServiceResult<NoteItem>.Fail("Failed to load note.");
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<NoteItem>();
             return result is not null
                 ? ServiceResult<NoteItem>.Ok(result)
-                : ServiceResult<NoteItem>.Fail("Note not found.");
+                : ServiceResult<NoteItem>.Fail("Failed to load note.");
         }
         catch (Exception ex)
         {
+            // Network failure / timeout — transient, not a 404.
             logger.LogError(ex, "Failed to load note {NoteId}.", id);
             return ServiceResult<NoteItem>.Fail("Failed to load note.");
         }

--- a/Vanadium.Note.Web/Services/ServiceResult.cs
+++ b/Vanadium.Note.Web/Services/ServiceResult.cs
@@ -9,14 +9,21 @@ public sealed class ServiceResult<T>
     /// e.g. a mutation against an archived (read-only) note.</summary>
     public bool IsForbidden { get; }
 
+    /// <summary>True when the server responded with 404 — the resource genuinely
+    /// does not exist. Distinct from a transient 5xx/network failure, which is
+    /// reported as a plain <see cref="Fail"/> so callers do not misjudge an
+    /// existing resource as deleted.</summary>
+    public bool IsNotFound { get; }
+
     public T? Value { get; }
     public string? Error { get; }
 
-    private ServiceResult(bool isSuccess, T? value, string? error, bool isConflict = false, bool isForbidden = false)
+    private ServiceResult(bool isSuccess, T? value, string? error, bool isConflict = false, bool isForbidden = false, bool isNotFound = false)
     {
         IsSuccess = isSuccess;
         IsConflict = isConflict;
         IsForbidden = isForbidden;
+        IsNotFound = isNotFound;
         Value = value;
         Error = error;
     }
@@ -25,4 +32,5 @@ public sealed class ServiceResult<T>
     public static ServiceResult<T> Fail(string error) => new(false, default, error);
     public static ServiceResult<T> Conflict() => new(false, default, null, isConflict: true);
     public static ServiceResult<T> Forbidden() => new(false, default, null, isForbidden: true);
+    public static ServiceResult<T> NotFound(string error) => new(false, default, error, isNotFound: true);
 }


### PR DESCRIPTION
## 개요
`NoteEditor`가 노트 로드에 실패하면 원인(HTTP 상태)을 구분하지 않고, 일시적 500/네트워크 blip에도 Recents 항목을 정리한 뒤 홈으로 리다이렉트하던 문제(#119)를 해결한다.

## 원인
`NoteService.GetAsync`가 `GetFromJsonAsync`를 사용해 404·5xx·네트워크 오류를 모두 예외로 잡아 일반 `Fail`로만 반환했다. 편집기 쪽에서 "실제 404(존재하지 않는 노트)"와 "일시적 오류"를 구분할 수 없었다.

## 변경 사항
- `ServiceResult<T>`: `IsNotFound` 상태와 `NotFound(...)` 팩토리 추가 (기존 `Conflict`/`Forbidden` 패턴과 동일).
- `NoteService.GetAsync`: `GetAsync`로 응답을 받아 상태 인식 처리 — HTTP 404만 `NotFound`, 그 외 비성공(5xx)과 네트워크 예외는 일시적 실패(`Fail`)로 구분.
- `NoteEditor.razor`:
  - 실제 404(`IsNotFound`)에서만 Recents 정리 + 홈 리다이렉트.
  - 일시적 오류에서는 Recents를 유지하고 리다이렉트하지 않으며, 재시도 배너를 표시(`Retry` 버튼 → `RetryLoad`).
  - 실패 상태(`_loadFailed`) 동안 자동 저장과 편집을 차단해 빈 편집기가 실제 노트를 덮어쓰지 않도록 보호.
- `NoteEditor.razor.css`: `load-error-banner` 스타일 추가(기존 `conflict-banner` 패턴 재사용).

## 완료 조건 검증
- [x] 실제 404에서만 Recents 정리 및 홈 리다이렉트 발생 — `else if (result.IsNotFound)` 분기에서만 수행.
- [x] 일시적 500/네트워크 오류에서 노트를 삭제된 것으로 오판하거나 Recents를 정리하지 않음 — 5xx/네트워크 예외는 `Fail`(`IsNotFound=false`)로 반환되어 재시도 배너 분기로 이동.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0개 추가(기존 NU1903 4개 baseline만), 오류 0개. `dotnet test` 55 통과/3 스킵(Postgres 전용)/0 실패.

## 테스트 노트
변경은 전부 Web 프로젝트(Blazor)에 있으며, 리포지토리에는 Web 계층(HttpClient 기반 `NoteService`)을 커버하는 테스트 프로젝트가 없어 자동 회귀 테스트를 추가하지 못했다(새 테스트 프로젝트 도입은 범위 밖). 빌드/기존 테스트로 검증했다.

## 범위 밖 (건드리지 않음)
- 백엔드 `GET /api/notes/{id}` 응답 규약.
- Quick Navigation Recents 저장 위치(클라이언트 localStorage).

Closes #119
