### PR TITLE
#120 자동/수동 저장을 단일 가드로 통합해 경합 409 방지

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -615,6 +615,14 @@
                 StateHasChanged();
             return;
         }
+        // A joined save persisted the snapshot from when the in-flight save STARTED,
+        // and cancelling the debounce above dropped the pending re-save. Flush any edits
+        // made since before leaving, so trailing keystrokes are not silently lost (#120).
+        // Skip for isNew: after the auto-save's create+navigate, Id isn't rebound yet, so
+        // a second save here would create a duplicate note (creation is the auto-save's job).
+        if (joinedInFlight && !isNew && HasPendingChanges && !_hasConflict)
+            saved = await SaveCoreAsync() ?? saved;
+
         // When we joined an in-flight save, the originating auto-save already added
         // the new note's labels and navigated — don't repeat that work here.
         if (isNew && !joinedInFlight)

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -298,7 +298,7 @@
         catch (InvalidOperationException) { }
     }
 
-    private bool _isSaving = false;
+    private Task<NoteItem?>? _saveInFlight;
     private bool _isDisposing = false;
     private bool _hasConflict = false;
     private bool _loadFailed = false;
@@ -336,7 +336,7 @@
         noteLabels = [];
         _hasConflict = false;
         _loadFailed = false;
-        _isSaving = false;
+        _saveInFlight = null;
         _serverUpdatedAt = default;
 
         if (Id is not null)
@@ -493,7 +493,19 @@
         catch (TaskCanceledException) { }
     }
 
-    private async Task<NoteItem?> SaveCoreAsync()
+    // Single save entry point. Auto-save and manual save (Ctrl+S) both funnel
+    // through here so two saves never overlap on the same _serverUpdatedAt — a
+    // concurrent PUT would surface a false 409. A caller arriving while a save is
+    // already in flight joins that save instead of issuing its own request (#120).
+    private Task<NoteItem?> SaveCoreAsync()
+    {
+        if (_saveInFlight is { IsCompleted: false })
+            return _saveInFlight;
+        _saveInFlight = SaveOnceAsync();
+        return _saveInFlight;
+    }
+
+    private async Task<NoteItem?> SaveOnceAsync()
     {
         var note = new NoteItem
         {
@@ -531,49 +543,52 @@
 
     private async Task DoAutoSave()
     {
-        if (_isSaving) return;
-        _isSaving = true;
+        // A save is already running; its tail re-schedules for any pending edits,
+        // so skip to avoid redundant status churn (SaveCoreAsync would coalesce anyway).
+        if (_saveInFlight is { IsCompleted: false }) return;
 
-        try
+        SetStatus("Saving...", "status-saving");
+        StateHasChanged();
+
+        var saved = await SaveCoreAsync();
+        if (saved is null)
         {
-            SetStatus("Saving...", "status-saving");
+            SetStatus(_hasConflict ? "Conflict" : IsArchived ? "Archived" : "Save failed", "status-error");
             StateHasChanged();
+            return;
+        }
 
-            var saved = await SaveCoreAsync();
-            if (saved is null)
-            {
-                SetStatus(_hasConflict ? "Conflict" : IsArchived ? "Archived" : "Save failed", "status-error");
-                StateHasChanged();
-                return;
-            }
+        if (isNew && !_isDisposing)
+        {
+            foreach (var label in noteLabels.ToList())
+                await LabelService.AddLabelToNoteAsync(saved.Id, label.Id);
+            // Set _currentId/_currentParentId before navigating so OnParametersSetAsync
+            // treats this as a same-note transition and skips the full state reset,
+            // preserving any content the user typed during the network round-trip.
+            _currentId = saved.Id;
+            _currentParentId = null;
+            Nav.NavigateTo($"/editor/{saved.Id}", replace: true);
+        }
 
-            if (isNew && !_isDisposing)
-            {
-                foreach (var label in noteLabels.ToList())
-                    await LabelService.AddLabelToNoteAsync(saved.Id, label.Id);
-                // Set _currentId/_currentParentId before navigating so OnParametersSetAsync
-                // treats this as a same-note transition and skips the full state reset,
-                // preserving any content the user typed during the network round-trip.
-                _currentId = saved.Id;
-                _currentParentId = null;
-                Nav.NavigateTo($"/editor/{saved.Id}", replace: true);
-            }
+        SetStatus("Saved", "status-saved");
+        StateHasChanged();
 
-            SetStatus("Saved", "status-saved");
-            StateHasChanged();
+        // Save any changes that arrived while this save was in flight — BEFORE the
+        // cosmetic delay, so the "Saved" badge never holds up the next save (#120).
+        if (HasPendingChanges && !_hasConflict && !_isDisposing)
+        {
+            ScheduleAutoSave();
+            return;
+        }
 
-            await Task.Delay(2000);
+        // Cosmetic only: clear the "Saved" badge after a short delay. This runs
+        // outside the save guard, so it cannot block a subsequent save.
+        await Task.Delay(2000);
+        if (saveStatusText == "Saved")
+        {
             SetStatus(string.Empty, string.Empty);
             StateHasChanged();
         }
-        finally
-        {
-            _isSaving = false;
-        }
-
-        // Save any changes that arrived while this save was in flight
-        if (HasPendingChanges && !_hasConflict && !_isDisposing)
-            ScheduleAutoSave();
     }
 
     private void SetStatus(string text, string css)
@@ -588,6 +603,9 @@
         _debounceCts?.Dispose();
         _debounceCts = null;
 
+        // If an auto-save is already in flight, join it rather than racing it — a
+        // second concurrent PUT on the same UpdatedAt is what caused false 409s (#120).
+        var joinedInFlight = _saveInFlight is { IsCompleted: false };
         var saved = await SaveCoreAsync();
         if (saved is null)
         {
@@ -597,7 +615,9 @@
                 StateHasChanged();
             return;
         }
-        if (isNew)
+        // When we joined an in-flight save, the originating auto-save already added
+        // the new note's labels and navigated — don't repeat that work here.
+        if (isNew && !joinedInFlight)
         {
             foreach (var label in noteLabels.ToList())
                 await LabelService.AddLabelToNoteAsync(saved.Id, label.Id);


### PR DESCRIPTION
## 개요
Closes #120

수동 저장(`Ctrl+S`)이 자동 저장의 가드를 우회해 경합하면서 잘못된 409(Conflict) 배너가 뜨고, "Saved" 2초 표시가 다음 저장을 블록하던 문제를 해결한다.

## 원인
- `SaveNote()`(수동/`Ctrl+S`)가 `_isSaving` 가드 없이 `SaveCoreAsync()`를 직접 호출 → 자동 저장이 진행 중일 때 두 저장이 같은 `_serverUpdatedAt`로 동시에 PUT하여 서버가 실제 충돌이 아님에도 409를 반환.
- `DoAutoSave()`가 성공 후의 코스메틱 `await Task.Delay(2000)`("Saved" 표시)를 `_isSaving` 해제 이전에 수행 → 2초 동안 다음 저장이 블록됨.

## 변경 내용
- `SaveCoreAsync()`를 **단일 진입점**으로 변경: 진행 중인 저장(`_saveInFlight`)이 있으면 새 요청을 만들지 않고 그 작업에 **합류**한다. 자동/수동 저장이 하나의 PUT을 공유하므로 자기 자신과의 경합 409가 발생하지 않는다.
- 중복이던 `DoAutoSave()`의 `_isSaving` 가드를 제거(단일 가드로 통합).
- "Saved" 2초 표시의 `Task.Delay(2000)`를 저장 가드 밖으로 이동 → 다음 저장을 막지 않음.
- `SaveNote()`는 진행 중 저장에 합류한 경우 신규 노트 라벨/네비게이션 중복 처리를 건너뛴다.

## 완료 조건 검증
- [x] 자동 저장 진행 중 `Ctrl+S`를 눌러도 잘못된 409 배너가 뜨지 않는다 — 코드 검증: 수동 저장이 진행 중 작업에 합류해 서버로 나가는 PUT은 항상 1건(단일 `_serverUpdatedAt`)이라 자기 충돌 불가. Blazor WASM 단일 스레드 협력 스케줄러라 플래그/작업 확인이 경합 없이 동작.
- [x] 저장 경로가 단일 가드로 통합 — 모든 저장이 `SaveCoreAsync`/`_saveInFlight`를 경유. `_isSaving` 참조 0건(grep 확인).
- [x] "Saved" 2초 표시가 다음 저장을 블록하지 않는다 — 코스메틱 `Task.Delay(2000)`를 가드 밖으로 이동, 락 미보유.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx`: 오류 0, 신규 경고 0(기존 NU1903 4건만).

## 테스트
- `dotnet test Vanadium.slnx`: 55 통과 / 0 실패 / 3 건너뜀.
- 자동 회귀 테스트 미추가: 버그가 Blazor WASM 컴포넌트(`NoteEditor.razor`)의 클라이언트 저장 오케스트레이션에 있고, Web 프로젝트에는 테스트 프로젝트가 없다(REST만 존재). 테스트하려면 bUnit + 신규 Web 테스트 프로젝트라는 새 최상위 의존성이 필요해 본 최소 수정 범위 밖. 코드 검증 + 기존 스위트 전체 통과 + 빌드 클린으로 확인.

## 범위 밖(미변경)
- 백엔드 낙관적 동시성 검증 로직
- 자동 저장 디바운스 시간(1500ms)
