### PR TITLE
#126 에디터가 캡처된 토큰 대신 작업 시점 최신 토큰 사용

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -433,10 +433,11 @@
         {
             _objRef = DotNetObjectReference.Create(this);
             var apiBase = Http.BaseAddress?.ToString().TrimEnd('/') ?? string.Empty;
-            var token = await TokenStore.GetAsync() ?? string.Empty;
+            // The editor pulls the current token on demand via GetAuthTokenAsync
+            // rather than being seeded with a captured token here (issue #126).
             try
             {
-                await JS.InvokeVoidAsync("tiptapInterop.init", _editorId, _objRef, content, apiBase, token, !IsArchived && !_loadFailed);
+                await JS.InvokeVoidAsync("tiptapInterop.init", _editorId, _objRef, content, apiBase, !IsArchived && !_loadFailed);
                 _editorMounted = true;
                 await ShortcutService.RegisterAsync("ctrl+s", "Save note", () => InvokeAsync(SaveNote));
             }
@@ -459,6 +460,15 @@
         content = html;
         ScheduleAutoSave();
     }
+
+    // The editor captures no token in its JS closure; instead it calls back here
+    // for the current token at every authenticated image load/upload, so a
+    // re-login after JWT expiry immediately takes effect in an already-open
+    // editor (issue #126). TokenStore.SetAsync refreshes its cache on login,
+    // so this always returns the latest token for the current SPA session.
+    [JSInvokable]
+    public async Task<string> GetAuthTokenAsync()
+        => await TokenStore.GetAsync() ?? string.Empty;
 
     private void OnTitleInput(ChangeEventArgs e)
     {

--- a/Vanadium.Note.Web/Pages/SubNoteDialog.razor
+++ b/Vanadium.Note.Web/Pages/SubNoteDialog.razor
@@ -153,10 +153,11 @@
         {
             _objRef = DotNetObjectReference.Create(this);
             var apiBase = Http.BaseAddress?.ToString().TrimEnd('/') ?? string.Empty;
-            var token = await TokenStore.GetAsync() ?? string.Empty;
+            // The editor pulls the current token on demand via GetAuthTokenAsync
+            // rather than being seeded with a captured token here (issue #126).
             try
             {
-                await JS.InvokeVoidAsync("tiptapInterop.init", _editorId, _objRef, content, apiBase, token, !_isArchived);
+                await JS.InvokeVoidAsync("tiptapInterop.init", _editorId, _objRef, content, apiBase, !_isArchived);
                 _editorMounted = true;
             }
             catch (Exception ex)
@@ -179,6 +180,13 @@
         content = html;
         ScheduleAutoSave();
     }
+
+    // The editor calls back here for the current token at each authenticated
+    // image load/upload, so a re-login after JWT expiry is picked up without
+    // re-initializing the editor (issue #126).
+    [JSInvokable]
+    public async Task<string> GetAuthTokenAsync()
+        => await TokenStore.GetAsync() ?? string.Empty;
 
     [JSInvokable]
     public async Task OnSaveShortcut() => await InvokeAsync(DoAutoSave);

--- a/Vanadium.Note.Web/wwwroot/js/tiptap-editor.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap-editor.js
@@ -1675,10 +1675,15 @@ function runCommand(editor, cmd) {
 // responsible for revoking its entries (and clearing blobUrlCache) when the
 // editor is destroyed or content is replaced.
 
-async function resolveAuthenticatedImages(editorDom, apiBaseUrl, authToken, blobUrls, blobUrlCache) {
+// getAuthToken is an async callback that returns the CURRENT token at call
+// time (not a value captured when the editor was created), so a re-login after
+// JWT expiry is picked up here without re-initializing the editor (issue #126).
+// It is invoked lazily, only on a cache miss that actually needs the network,
+// so the cache-hit hot path stays free of Blazor interop round-trips.
+async function resolveAuthenticatedImages(editorDom, apiBaseUrl, getAuthToken, blobUrls, blobUrlCache) {
     const prefix = `${apiBaseUrl}/api/images/`;
-    const headers = authToken ? { 'Authorization': `Bearer ${authToken}` } : {};
     const imgs = editorDom.querySelectorAll(`img[src^="${CSS.escape(prefix)}"], img[src^="${prefix}"]`);
+    let headers = null;
 
     for (const img of imgs) {
         const src = img.getAttribute('src');
@@ -1691,6 +1696,13 @@ async function resolveAuthenticatedImages(editorDom, apiBaseUrl, authToken, blob
         if (cached) {
             img.src = cached;
             continue;
+        }
+
+        // First real fetch this pass — resolve the current token once and reuse
+        // its headers for the remaining images.
+        if (headers === null) {
+            const authToken = await getAuthToken();
+            headers = authToken ? { 'Authorization': `Bearer ${authToken}` } : {};
         }
 
         try {
@@ -1713,12 +1725,17 @@ async function resolveAuthenticatedImages(editorDom, apiBaseUrl, authToken, blob
 // ── Public API ───────────────────────────────────────────────────────────────
 
 window.tiptapInterop = {
-    async init(elementId, dotnetRef, initialContent, apiBaseUrl, authToken, editable = true) {
+    async init(elementId, dotnetRef, initialContent, apiBaseUrl, editable = true) {
         const el = document.getElementById(elementId);
         if (!el) {
             console.error(`[tiptap] Element not found: '${elementId}'`);
             return;
         }
+
+        // Resolve the current auth token on demand rather than capturing it once,
+        // so image load/upload after a JWT expiry + re-login uses the fresh token
+        // (issue #126). Blazor's TokenStore returns the latest token for the session.
+        const getAuthToken = () => dotnetRef.invokeMethodAsync('GetAuthTokenAsync');
 
         const bubbleMenuEl = createBubbleMenu(elementId);
         const linkPopover  = createLinkPopover(elementId);
@@ -1813,6 +1830,7 @@ window.tiptapInterop = {
 
                     const formData = new FormData();
                     formData.append('file', file);
+                    const authToken = await getAuthToken();
                     const headers = authToken ? { 'Authorization': `Bearer ${authToken}` } : {};
                     const toast = createProgressToast(file.name || 'image');
 
@@ -1828,7 +1846,7 @@ window.tiptapInterop = {
                         // the newly inserted <img> to a Blob URL immediately after insertion.
                         const entry = _editors[elementId];
                         if (entry) {
-                            await resolveAuthenticatedImages(editor.view.dom, apiBaseUrl, authToken, entry.blobUrls, entry.blobUrlCache);
+                            await resolveAuthenticatedImages(editor.view.dom, apiBaseUrl, getAuthToken, entry.blobUrls, entry.blobUrlCache);
                         }
                     } catch (err) {
                         toast.error();
@@ -1902,6 +1920,7 @@ window.tiptapInterop = {
             const pos = editor.view.posAtCoords({ left: e.clientX, top: e.clientY });
             const insertPos = pos ? pos.pos : editor.state.doc.content.size;
 
+            const authToken = await getAuthToken();
             const headers = authToken ? { 'Authorization': `Bearer ${authToken}` } : {};
 
             for (const file of files) {
@@ -1925,7 +1944,7 @@ window.tiptapInterop = {
                         // Resolve the newly inserted <img> to a Blob URL immediately.
                         const entry = _editors[elementId];
                         if (entry) {
-                            await resolveAuthenticatedImages(editor.view.dom, apiBaseUrl, authToken, entry.blobUrls, entry.blobUrlCache);
+                            await resolveAuthenticatedImages(editor.view.dom, apiBaseUrl, getAuthToken, entry.blobUrls, entry.blobUrlCache);
                         }
                     } else {
                         // Other files are inserted as file attachment links
@@ -1949,7 +1968,7 @@ window.tiptapInterop = {
 
         const blobUrls = [];
         const blobUrlCache = new Map();
-        _editors[elementId] = { editor, bubbleMenuEl, linkPopover, apiBaseUrl, authToken, blobUrls, blobUrlCache };
+        _editors[elementId] = { editor, bubbleMenuEl, linkPopover, apiBaseUrl, getAuthToken, blobUrls, blobUrlCache };
         console.log(`[tiptap] Editor initialized: ${elementId}`);
 
         // Re-apply blob URLs after every doc-mutating transaction. ProseMirror's
@@ -1959,12 +1978,12 @@ window.tiptapInterop = {
         // image looks broken. The cache hit path is synchronous and fires no
         // network calls, so this is cheap on the keystroke hot path.
         editor.on('update', () => {
-            resolveAuthenticatedImages(editor.view.dom, apiBaseUrl, authToken, blobUrls, blobUrlCache);
+            resolveAuthenticatedImages(editor.view.dom, apiBaseUrl, getAuthToken, blobUrls, blobUrlCache);
         });
 
         // Resolve any images that were injected with initialContent.
         if (initialContent) {
-            await resolveAuthenticatedImages(editor.view.dom, apiBaseUrl, authToken, blobUrls, blobUrlCache);
+            await resolveAuthenticatedImages(editor.view.dom, apiBaseUrl, getAuthToken, blobUrls, blobUrlCache);
         }
     },
 
@@ -1986,7 +2005,7 @@ window.tiptapInterop = {
         entry.blobUrls = [];
         entry.blobUrlCache.clear();
         entry.editor.commands.setContent(content, false);
-        await resolveAuthenticatedImages(entry.editor.view.dom, entry.apiBaseUrl, entry.authToken, entry.blobUrls, entry.blobUrlCache);
+        await resolveAuthenticatedImages(entry.editor.view.dom, entry.apiBaseUrl, entry.getAuthToken, entry.blobUrls, entry.blobUrlCache);
     },
 
     setInputValue(elementId, value) {


### PR DESCRIPTION
## 개요
에디터가 `tiptapInterop.init` 시점의 JWT를 JS 클로저(`authToken`)에 캡처해, 토큰 만료 후 재로그인해도 이미 열려 있던 에디터가 오래된 토큰으로 이미지 로드/업로드를 조용히 실패시키던 문제를 수정한다.

Closes #126

## 원인
`init`에 `authToken`이 값으로 전달되어 paste/drop 핸들러, `resolveAuthenticatedImages`, `_editors[elementId]`, `update` 훅 등 모든 인증 경로가 최초 1회 캡처된 토큰을 재사용했다. 재로그인으로 `localStorage`의 토큰이 갱신되어도 클로저 값은 그대로였다.

## 변경 내용
- `init` 인자에서 `authToken`을 제거하고, `dotnetRef.invokeMethodAsync('GetAuthTokenAsync')`로 **작업 시점마다** 최신 토큰을 페치하는 `getAuthToken` 콜백으로 대체.
- `NoteEditor.razor` / `SubNoteDialog.razor`에 `[JSInvokable] GetAuthTokenAsync` 추가 — `TokenStore.GetAsync()` 반환. 재로그인 시 `AuthService`가 `TokenStore.SetAsync`로 캐시를 갱신하므로 세션 내 최신 토큰이 반환된다.
- 두 컴포넌트의 `init` 호출부에서 캡처 토큰 전달 제거.
- `resolveAuthenticatedImages`는 캐시 미스로 실제 네트워크 요청이 필요할 때만 토큰을 lazily 페치 → blob 캐시 히트 핫패스(키 입력 시 재렌더)는 Blazor interop 왕복 없이 유지.

## 완료 조건 검증
- [x] 이미지 로드/업로드가 캡처된 토큰이 아니라 작업 시점 최신 토큰 사용 — 모든 auth 경로가 `getAuthToken()`을 통해 호출 시점에 토큰을 페치.
- [x] 토큰 만료+재로그인 후에도 이미 열린 에디터에서 이미지 로드/업로드 성공 — 재로그인이 `TokenStore` 캐시를 갱신하고, 다음 이미지 작업이 그 값을 페치.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 4개(기존 NU1903 baseline)/오류 0개. `dotnet test` 55 통과, 3 스킵(PostgreSQL 전용).

## 범위 / 비고
- 백엔드·스키마 변경 없음, 리프레시 토큰 미도입(범위 밖).
- Web 프로젝트에는 테스트 프로젝트가 없어(=JS interop 커버 불가) 자동 회귀 테스트는 추가하지 않았다. 수동 확인 필요: 만료→재로그인 후 열린 에디터에서 이미지 붙여넣기/드롭 및 기존 이미지 로드.
