### PR TITLE
#129 검색 placeholder를 실제 범위(제목+내용)에 맞게 수정

### DIFF
--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -15,7 +15,7 @@
         <h1>Notes</h1>
         <input class="notes-search"
                type="search"
-               placeholder="Search by title..."
+               placeholder="Search by title or content..."
                value="@_searchText"
                @oninput="OnSearchInput" />
         <button class="btn btn-primary" @onclick="CreateNote">New Note</button>


### PR DESCRIPTION
Closes #129

## 문제
Home 노트 검색창의 placeholder가 `Search by title...` 로 표시되어 제목만 검색되는 것처럼 보였다. 실제 백엔드 트라이그램 검색은 제목(Title) + 내용(ContentText)을 모두 대상으로 한다.

## 변경
- `Vanadium.Note.Web/Pages/Home.razor` — placeholder 문구를 `Search by title...` → `Search by title or content...` 로 변경하여 실제 검색 범위를 반영.

## 완료 조건 검증
- [x] Home 검색창 placeholder가 제목+내용 검색을 반영하는 문구로 변경됨 — `Search by title or content...` (Home.razor:18)
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 오류 0개, 신규 경고 없음

## 범위 준수
- 백엔드 검색 로직/트라이그램 인덱스 미변경 (UI 문구만 수정)
- QuickNavDialog placeholder 미변경

## 테스트
UI 정적 문자열 변경으로 로직이 없어 회귀 테스트 대상이 아니며, Web 프로젝트에는 테스트 프로젝트가 없다.