### PR TITLE
#110 JwtSecret 시작 시점 fail-fast 검증

### DIFF
--- a/Vanadium.Note.REST.Tests/JwtSecretValidatorTests.cs
+++ b/Vanadium.Note.REST.Tests/JwtSecretValidatorTests.cs
@@ -1,0 +1,64 @@
+using System.Text;
+using Vanadium.Note.REST.Auth;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Startup fail-fast validation for <c>Auth:JwtSecret</c> (issue #110): a missing, empty,
+/// or shorter-than-32-byte secret must throw a clear exception; a valid secret passes through.
+/// </summary>
+public class JwtSecretValidatorTests
+{
+    [Fact]
+    public void Validate_NullSecret_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => JwtSecretValidator.Validate(null));
+        Assert.Contains("Auth:JwtSecret", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_EmptySecret_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => JwtSecretValidator.Validate(string.Empty));
+        Assert.Contains("Auth:JwtSecret", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_TooShortSecret_ThrowsWithByteLength()
+    {
+        // 31 ASCII bytes — one short of the 32-byte HS256 minimum.
+        var secret = new string('a', JwtSecretValidator.MinimumByteLength - 1);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => JwtSecretValidator.Validate(secret));
+        Assert.Contains("32 bytes", ex.Message);
+        Assert.Contains("31 byte", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_MultiByteCharsCountedByBytes_Throws()
+    {
+        // 'é' is 2 bytes in UTF-8: 15 chars = 30 bytes < 32, so the check must count
+        // bytes (not chars) to reject this even though it is 30 characters long.
+        var secret = new string('é', 15);
+
+        Assert.Equal(30, Encoding.UTF8.GetByteCount(secret));
+        Assert.Throws<InvalidOperationException>(() => JwtSecretValidator.Validate(secret));
+    }
+
+    [Fact]
+    public void Validate_ExactMinimumLength_ReturnsSecret()
+    {
+        var secret = new string('a', JwtSecretValidator.MinimumByteLength); // exactly 32 bytes
+
+        Assert.Equal(secret, JwtSecretValidator.Validate(secret));
+    }
+
+    [Fact]
+    public void Validate_LongerSecret_ReturnsSecret()
+    {
+        var secret = new string('a', 64);
+
+        Assert.Equal(secret, JwtSecretValidator.Validate(secret));
+    }
+}

--- a/Vanadium.Note.REST/Auth/JwtSecretValidator.cs
+++ b/Vanadium.Note.REST/Auth/JwtSecretValidator.cs
@@ -1,0 +1,43 @@
+using System.Text;
+
+namespace Vanadium.Note.REST.Auth;
+
+/// <summary>
+/// Validates the configured <c>Auth:JwtSecret</c> at application startup so a missing,
+/// empty, or too-short secret fails fast with a clear message instead of surfacing as an
+/// opaque error later. HS256 signing requires a key of at least 256 bits (32 bytes); a
+/// shorter secret weakens the signature and is rejected.
+/// </summary>
+public static class JwtSecretValidator
+{
+    /// <summary>Minimum secret length in bytes required for HS256 (a 256-bit key).</summary>
+    public const int MinimumByteLength = 32;
+
+    /// <summary>
+    /// Ensures <paramref name="secret"/> is present and at least <see cref="MinimumByteLength"/>
+    /// bytes long. Returns the validated secret unchanged so callers can assign it inline.
+    /// </summary>
+    /// <param name="secret">The raw <c>Auth:JwtSecret</c> value read from configuration.</param>
+    /// <returns>The validated secret.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the secret is null, empty, or shorter than <see cref="MinimumByteLength"/> bytes.
+    /// </exception>
+    public static string Validate(string? secret)
+    {
+        if (string.IsNullOrEmpty(secret))
+        {
+            throw new InvalidOperationException(
+                "Auth:JwtSecret is not configured. Set Auth:JwtSecret in appsettings.");
+        }
+
+        var byteLength = Encoding.UTF8.GetByteCount(secret);
+        if (byteLength < MinimumByteLength)
+        {
+            throw new InvalidOperationException(
+                $"Auth:JwtSecret must be at least {MinimumByteLength} bytes for HS256 signing, " +
+                $"but the configured value is {byteLength} byte(s). Configure a longer secret in appsettings.");
+        }
+
+        return secret;
+    }
+}

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -53,8 +53,7 @@ builder.Services.AddDbContext<NoteDbContext>(options =>
     }
 });
 
-var jwtSecret = builder.Configuration["Auth:JwtSecret"]
-    ?? throw new InvalidOperationException("Auth:JwtSecret is not configured. Set Auth:JwtSecret in appsettings.");
+var jwtSecret = JwtSecretValidator.Validate(builder.Configuration["Auth:JwtSecret"]);
 
 const string smartScheme = "Smart";
 


### PR DESCRIPTION
## 배경
`Auth:JwtSecret`가 빈 문자열 기본값이면 null 체크(`?? throw`)를 통과한 뒤 나중에 불투명한 에러로 실패하고, 32바이트 미만의 짧은 시크릿은 HS256 서명을 약화시켰다. 시작 시점에 fail-fast 검증을 도입한다.

## 변경 내용
- `Auth/JwtSecretValidator.cs` 추가: `Auth:JwtSecret`의 UTF-8 바이트 길이가 32바이트(HS256 최소 256비트) 이상인지 검증. null/빈 값이면 미설정 메시지로, 짧으면 실제 바이트 길이를 담은 메시지로 즉시 `InvalidOperationException` 발생.
- `Program.cs`: 기존 `?? throw` 를 `JwtSecretValidator.Validate(...)` 호출로 교체해 시작 시점에 검증하도록 수정.
- `JwtSecretValidatorTests.cs` 추가: null/빈 값/31바이트/멀티바이트 30바이트 → 예외, 정확히 32바이트/64바이트 → 통과 검증.

## 완료 조건 검증
- [x] 시작 시 `Auth:JwtSecret`가 없거나 32바이트 미만이면 명확한 예외로 기동 실패 — `Program.cs`가 인증 구성 전에 `JwtSecretValidator.Validate` 호출, null/빈 값/31바이트/멀티바이트 30바이트 케이스가 예외를 던지는 것을 단위 테스트로 확인.
- [x] 유효한 시크릿이면 정상 기동 — 32바이트/64바이트 시크릿이 그대로 반환되는 것을 단위 테스트로 확인.
- [x] 빌드 클린 (`dotnet build Vanadium.slnx`) — 신규 경고 없음(기존 NU1903 4건 외 없음), `dotnet test` 61 통과.

## 범위 밖 (미변경)
- JWT issuer/audience 검증 미도입 유지.
- PBKDF2 파라미터 및 비밀번호 해시 저장 방식 변경 없음.

Closes #110