### PR TITLE
#111 PBKDF2 반복 횟수를 해시 저장 포맷에 인코딩

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Before reporting work as done:
 
 Single-user, **password-only** (no user identity). There is no `User` entity and no `UserId`/`Username` ownership column on any table — the whole database belongs to one owner. Login verifies a password against a configured hash; a successful login mints a JWT carrying only a fixed `ClaimTypes.Name` = `AuthController.OwnerName` (`"owner"`) claim.
 
-- `POST /api/auth/login` (body `{ password }`) verifies against `Auth:PasswordHash` (PBKDF2-SHA256, `base64salt:base64hash`, same format as `Auth:JwtSecret` — supplied via config/env, never stored in the DB) and returns a JWT; no refresh tokens — JWT expiry defaults to 1440 min.
+- `POST /api/auth/login` (body `{ password }`) verifies against `Auth:PasswordHash` (PBKDF2-SHA256, `base64salt:base64hash:iterations` — supplied via config/env, never stored in the DB; legacy two-part `base64salt:base64hash` values verify at 100k for backward compatibility) and returns a JWT; no refresh tokens — JWT expiry defaults to 1440 min.
 - `POST /api/auth/hash` (dev-only, body `{ password }`) returns the storage hash for a password so it can be pasted into `Auth:PasswordHash`. It persists nothing (replaces the old user-provisioning `setup` endpoint).
 - Personal access tokens (`ApiToken`) still work; they no longer carry a `UserId`. `ApiTokenAuthHandler` matches the token hash and emits the same single `Name` claim.
 - Frontend stores JWT in `TokenStore` (scoped service wrapping `localStorage`), injects it via `AuthTokenHandler` (delegating `HttpMessageHandler`).
@@ -163,7 +163,7 @@ When adding new middleware, place it AFTER `CorrelationIdMiddleware` so logs car
 ### Rate limiting & security
 
 - `/api/auth/login` is fixed-window rate-limited at 10 req/min. Do not remove without discussion.
-- Passwords are hashed with PBKDF2-SHA256, 100k iterations. Never weaken these parameters.
+- Passwords are hashed with PBKDF2-SHA256 in `Security/PasswordHasher.cs`; new hashes use 600k iterations (OWASP guidance) and encode the count in the storage format (`salt:hash:iterations`) so it can be raised without rehashing. Legacy two-part hashes verify at 100k. Never weaken these parameters.
 - JWT validation does NOT check issuer/audience by design (single-tenant). Keep it that way unless deployment changes.
 - File uploads enforce a 13-MIME whitelist and 100 MB cap; new types must be added explicitly to both the controller and any frontend validation.
 

--- a/Vanadium.Note.REST.Tests/PasswordHasherTests.cs
+++ b/Vanadium.Note.REST.Tests/PasswordHasherTests.cs
@@ -1,0 +1,110 @@
+using System.Security.Cryptography;
+using System.Text;
+using Vanadium.Note.REST.Security;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// PBKDF2 password hashing (issue #111): the storage format encodes the iteration count
+/// (<c>salt:hash:iterations</c>) so it can be raised without rehashing, verification uses the
+/// stored count, and legacy two-part hashes remain accepted at 100k iterations.
+/// </summary>
+public class PasswordHasherTests
+{
+    [Fact]
+    public void Hash_ProducesThreePartFormat_WithDefaultIterations()
+    {
+        var stored = PasswordHasher.Hash("correct horse battery staple");
+
+        var parts = stored.Split(':');
+        Assert.Equal(3, parts.Length);
+        Assert.Equal(PasswordHasher.DefaultIterations, int.Parse(parts[2]));
+        // salt and hash are valid base64.
+        Assert.NotEmpty(Convert.FromBase64String(parts[0]));
+        Assert.NotEmpty(Convert.FromBase64String(parts[1]));
+    }
+
+    [Fact]
+    public void DefaultIterations_MeetsOwaspGuidance()
+    {
+        Assert.True(PasswordHasher.DefaultIterations >= 600_000);
+    }
+
+    [Fact]
+    public void Hash_SamePasswordTwice_ProducesDifferentHashes()
+    {
+        // Random salt per hash: identical passwords must not collide.
+        Assert.NotEqual(PasswordHasher.Hash("same"), PasswordHasher.Hash("same"));
+    }
+
+    [Fact]
+    public void Verify_CorrectPassword_ReturnsTrue()
+    {
+        var stored = PasswordHasher.Hash("s3cret-pass");
+        Assert.True(PasswordHasher.Verify("s3cret-pass", stored));
+    }
+
+    [Fact]
+    public void Verify_WrongPassword_ReturnsFalse()
+    {
+        var stored = PasswordHasher.Hash("s3cret-pass");
+        Assert.False(PasswordHasher.Verify("wrong-pass", stored));
+    }
+
+    [Fact]
+    public void Hash_WithExplicitIterations_EncodesThatCount()
+    {
+        var stored = PasswordHasher.Hash("pw", 250_000);
+
+        Assert.Equal("250000", stored.Split(':')[2]);
+        Assert.True(PasswordHasher.Verify("pw", stored));
+    }
+
+    [Fact]
+    public void Verify_UsesStoredIterationCount_NotTheDefault()
+    {
+        // A hash produced at a non-default iteration count must still verify — proving the
+        // count is read from the stored value rather than assumed to be DefaultIterations.
+        var stored = PasswordHasher.Hash("migrate-me", 100_000);
+
+        Assert.NotEqual(PasswordHasher.DefaultIterations, int.Parse(stored.Split(':')[2]));
+        Assert.True(PasswordHasher.Verify("migrate-me", stored));
+    }
+
+    [Fact]
+    public void Verify_LegacyTwoPartHash_VerifiesAt100k()
+    {
+        // Reproduce the pre-#111 format (salt:hash, implicitly 100k iterations) exactly.
+        var salt = RandomNumberGenerator.GetBytes(16);
+        var hash = Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes("legacy-pw"),
+            salt,
+            PasswordHasher.LegacyIterations,
+            HashAlgorithmName.SHA256,
+            32);
+        var legacyStored = $"{Convert.ToBase64String(salt)}:{Convert.ToBase64String(hash)}";
+
+        Assert.True(PasswordHasher.Verify("legacy-pw", legacyStored));
+        Assert.False(PasswordHasher.Verify("not-the-pw", legacyStored));
+    }
+
+    [Theory]
+    [InlineData("")]                                 // empty
+    [InlineData("onlyonepart")]                      // 1 part
+    [InlineData("a:b:c:d")]                          // 4 parts
+    [InlineData("c2FsdA==:aGFzaA==:notanumber")]     // non-numeric iterations
+    [InlineData("c2FsdA==:aGFzaA==:0")]              // zero iterations
+    [InlineData("c2FsdA==:aGFzaA==:-5")]             // negative iterations
+    [InlineData("not_base64:aGFzaA==:600000")]       // invalid base64 salt
+    public void Verify_MalformedHash_ReturnsFalse(string storedHash)
+    {
+        Assert.False(PasswordHasher.Verify("anything", storedHash));
+    }
+
+    [Fact]
+    public void Hash_NonPositiveIterations_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => PasswordHasher.Hash("pw", 0));
+    }
+}

--- a/Vanadium.Note.REST/Controllers/AuthController.cs
+++ b/Vanadium.Note.REST/Controllers/AuthController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Security.Cryptography;
 using System.Text;
 using Vanadium.Note.REST.Models;
 using Vanadium.Note.REST.Security;
@@ -42,7 +41,7 @@ public class AuthController(
                 statusCode: StatusCodes.Status500InternalServerError);
         }
 
-        if (!VerifyPassword(request.Password, storedHash))
+        if (!PasswordHasher.Verify(request.Password, storedHash))
         {
             logger.LogWarning("Failed login attempt.");
             return Unauthorized(new { message = "Invalid password." });
@@ -78,7 +77,7 @@ public class AuthController(
             });
         }
 
-        return Ok(new { hash = HashPassword(request.Password) });
+        return Ok(new { hash = PasswordHasher.Hash(request.Password) });
     }
 
     private string GenerateJwtToken()
@@ -97,39 +96,5 @@ public class AuthController(
         );
 
         return new JwtSecurityTokenHandler().WriteToken(token);
-    }
-
-    private static string HashPassword(string password)
-    {
-        var salt = RandomNumberGenerator.GetBytes(16);
-        var hash = Rfc2898DeriveBytes.Pbkdf2(
-            Encoding.UTF8.GetBytes(password),
-            salt,
-            iterations: 100_000,
-            hashAlgorithm: HashAlgorithmName.SHA256,
-            outputLength: 32);
-        return $"{Convert.ToBase64String(salt)}:{Convert.ToBase64String(hash)}";
-    }
-
-    private static bool VerifyPassword(string password, string storedHash)
-    {
-        var parts = storedHash.Split(':');
-        if (parts.Length != 2) return false;
-        try
-        {
-            var salt = Convert.FromBase64String(parts[0]);
-            var expectedHash = Convert.FromBase64String(parts[1]);
-            var actualHash = Rfc2898DeriveBytes.Pbkdf2(
-                Encoding.UTF8.GetBytes(password),
-                salt,
-                iterations: 100_000,
-                hashAlgorithm: HashAlgorithmName.SHA256,
-                outputLength: 32);
-            return CryptographicOperations.FixedTimeEquals(expectedHash, actualHash);
-        }
-        catch
-        {
-            return false;
-        }
     }
 }

--- a/Vanadium.Note.REST/Security/PasswordHasher.cs
+++ b/Vanadium.Note.REST/Security/PasswordHasher.cs
@@ -1,0 +1,95 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Vanadium.Note.REST.Security;
+
+/// <summary>
+/// PBKDF2-SHA256 hashing for the single owner password (<c>Auth:PasswordHash</c>).
+///
+/// The storage format encodes the iteration count so it can be raised in future without
+/// rehashing already-configured values: verification always uses the iteration count read
+/// from the stored hash, while newly produced hashes use <see cref="DefaultIterations"/>.
+///
+/// Storage format: <c>base64(salt):base64(hash):iterations</c>. Legacy two-part values
+/// (<c>base64(salt):base64(hash)</c>) produced before iteration encoding are still accepted
+/// and verified at <see cref="LegacyIterations"/>, so an existing <c>Auth:PasswordHash</c>
+/// keeps working with zero downtime until it is regenerated.
+/// </summary>
+public static class PasswordHasher
+{
+    /// <summary>Iteration count for newly produced hashes (OWASP PBKDF2-SHA256 guidance).</summary>
+    public const int DefaultIterations = 600_000;
+
+    /// <summary>Iteration count assumed for legacy two-part hashes that predate iteration encoding.</summary>
+    public const int LegacyIterations = 100_000;
+
+    private const int SaltByteLength = 16;
+    private const int HashByteLength = 32;
+
+    /// <summary>Hashes <paramref name="password"/> with <see cref="DefaultIterations"/>.</summary>
+    public static string Hash(string password) => Hash(password, DefaultIterations);
+
+    /// <summary>
+    /// Hashes <paramref name="password"/> with an explicit <paramref name="iterations"/> count,
+    /// encoding that count into the returned storage string.
+    /// </summary>
+    public static string Hash(string password, int iterations)
+    {
+        if (iterations <= 0)
+            throw new ArgumentOutOfRangeException(nameof(iterations), "Iteration count must be positive.");
+
+        var salt = RandomNumberGenerator.GetBytes(SaltByteLength);
+        var hash = Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(password),
+            salt,
+            iterations,
+            HashAlgorithmName.SHA256,
+            HashByteLength);
+        return $"{Convert.ToBase64String(salt)}:{Convert.ToBase64String(hash)}:{iterations}";
+    }
+
+    /// <summary>
+    /// Verifies <paramref name="password"/> against <paramref name="storedHash"/>, using the
+    /// iteration count encoded in the hash (three-part) or <see cref="LegacyIterations"/> for a
+    /// legacy two-part hash. Returns <c>false</c> for any malformed or unparseable value rather
+    /// than throwing.
+    /// </summary>
+    public static bool Verify(string password, string storedHash)
+    {
+        if (string.IsNullOrEmpty(storedHash)) return false;
+
+        var parts = storedHash.Split(':');
+        int iterations;
+        switch (parts.Length)
+        {
+            case 2:
+                iterations = LegacyIterations;
+                break;
+            case 3:
+                if (!int.TryParse(parts[2], NumberStyles.None, CultureInfo.InvariantCulture, out iterations)
+                    || iterations <= 0)
+                    return false;
+                break;
+            default:
+                return false;
+        }
+
+        try
+        {
+            var salt = Convert.FromBase64String(parts[0]);
+            var expectedHash = Convert.FromBase64String(parts[1]);
+            var actualHash = Rfc2898DeriveBytes.Pbkdf2(
+                Encoding.UTF8.GetBytes(password),
+                salt,
+                iterations,
+                HashAlgorithmName.SHA256,
+                expectedHash.Length);
+            return CryptographicOperations.FixedTimeEquals(expectedHash, actualHash);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Closes #111

## 목적
비밀번호 해시가 PBKDF2-SHA256 100k 반복(OWASP 권고 600k 미달)을 하드코딩하고 저장 포맷이 `salt:hash` 2-part여서, 반복 횟수를 상향하려면 전체 재해싱이 필요했다. 반복 횟수를 저장 포맷에 인코딩해 무중단 상향이 가능하도록 한다.

## 변경 사항
- 해싱 로직을 테스트 가능한 `Security/PasswordHasher`(static)로 추출하고 `AuthController`가 위임하도록 변경.
- 저장 포맷을 `salt:hash:iterations`로 확장. 검증 시 저장된 반복 횟수를 읽어 사용한다(향후 재해싱 없이 마이그레이션 가능).
- 신규 해시 기본 반복 횟수를 OWASP 권고치 **600,000**으로 상향.
- **하위호환 결정**: 기존 2-part(`salt:hash`) 포맷은 그대로 **100k로 검증** — 기존 `Auth:PasswordHash` 설정이 무중단으로 계속 동작한다.
- 잘못된 포맷(part 수 불일치, 반복 횟수 파싱 실패/비양수, base64 오류)은 예외 대신 `false` 반환.
- `CLAUDE.md`의 해시 포맷/반복 횟수 설명 갱신.

## 완료 조건 검증
- [x] 저장 포맷이 `salt:hash:iterations`를 지원한다 — `Hash_ProducesThreePartFormat_WithDefaultIterations`
- [x] `VerifyPassword`가 저장된 반복 횟수로 검증한다 — `Verify_UsesStoredIterationCount_NotTheDefault`, `Hash_WithExplicitIterations_EncodesThatCount`
- [x] 기존 2-part 포맷 하위호환 — **유지하기로 결정**, `Verify_LegacyTwoPartHash_VerifiesAt100k`
- [x] 빌드 클린 (`dotnet build Vanadium.slnx`) 및 전체 테스트 통과 (77 passed, PBKDF2 해싱 테스트 신규 16건 포함)

## 범위
JWT 및 PBKDF2 알고리즘 자체는 변경하지 않음.