### PR TITLE
#124 프론트엔드 중복 컴포넌트/로직을 공용 컴포넌트·서비스로 추출

### DIFF
--- a/Vanadium.Note.Web/Components/LabelPicker.razor
+++ b/Vanadium.Note.Web/Components/LabelPicker.razor
@@ -1,0 +1,123 @@
+@* Shared label chips + "+ Label" picker dropdown extracted from NoteEditor and
+   SubNoteDialog (issue #124). The picker's open/closed state is owned here; the
+   parent supplies the label data and toggle/remove callbacks. NoteEditor passes a
+   <Footer> (its "Manage labels..." link) and reacts to OnPickerOpened; SubNoteDialog
+   uses neither. *@
+<div class="@BarClass">
+    @foreach (var label in NoteLabels)
+    {
+        <span class="label-chip @(label.CategoryId.HasValue ? "label-chip-cat" : "")">
+            @if (label.CategoryId.HasValue)
+            {
+                <span class="label-cat-prefix">@label.CategoryName:</span>
+            }
+            <span>@label.Name</span>
+            @if (!ReadOnly)
+            {
+                <button class="label-chip-remove" @onclick="() => Remove(label.Id)">×</button>
+            }
+        </span>
+    }
+
+    @if (!ReadOnly)
+    {
+        <div class="label-add-wrapper">
+            <button class="label-add-btn @(_showPicker ? "label-add-btn-active" : "")" @onclick="TogglePicker">
+                + Label
+            </button>
+
+            @if (_showPicker)
+            {
+                <div class="label-picker-backdrop" @onclick="ClosePicker"></div>
+                <div class="label-picker">
+                    @{
+                        var generalLabels = AvailableLabels.Where(l => !l.CategoryId.HasValue).ToList();
+                    }
+
+                    @if (generalLabels.Any())
+                    {
+                        <div class="label-picker-section">
+                            <div class="label-picker-section-title">General</div>
+                            @foreach (var lbl in generalLabels)
+                            {
+                                var isAdded = NoteLabels.Any(nl => nl.Id == lbl.Id);
+                                <div class="label-picker-item @(isAdded ? "is-added" : "")" @onclick="() => Toggle(lbl)">
+                                    <span class="label-picker-check">@(isAdded ? "✓" : "")</span>
+                                    <span>@lbl.Name</span>
+                                </div>
+                            }
+                        </div>
+                    }
+
+                    @foreach (var cat in LabelCategories)
+                    {
+                        var catLabels = AvailableLabels.Where(l => l.CategoryId == cat.Id).ToList();
+                        if (!catLabels.Any()) continue;
+                        <div class="label-picker-section">
+                            <div class="label-picker-section-title">@cat.Name</div>
+                            @foreach (var lbl in catLabels)
+                            {
+                                var isAdded = NoteLabels.Any(nl => nl.Id == lbl.Id);
+                                <div class="label-picker-item @(isAdded ? "is-added" : "")" @onclick="() => Toggle(lbl)">
+                                    <span class="label-picker-check">@(isAdded ? "✓" : "")</span>
+                                    <span>@lbl.Name</span>
+                                </div>
+                            }
+                        </div>
+                    }
+
+                    @if (!AvailableLabels.Any())
+                    {
+                        <div class="label-picker-empty">No labels</div>
+                    }
+
+                    @Footer
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public List<Label> NoteLabels { get; set; } = [];
+    [Parameter, EditorRequired] public List<Label> AvailableLabels { get; set; } = [];
+    [Parameter, EditorRequired] public List<LabelCategory> LabelCategories { get; set; } = [];
+
+    /// <summary>When true, hides the remove buttons and the whole "+ Label" affordance
+    /// (archived, read-only notes).</summary>
+    [Parameter] public bool ReadOnly { get; set; }
+
+    /// <summary>CSS class for the outer bar — <c>label-bar</c> in the full editor,
+    /// <c>dialog-label-bar</c> in the sub-note dialog.</summary>
+    [Parameter] public string BarClass { get; set; } = "label-bar";
+
+    [Parameter] public EventCallback<Label> OnToggleLabel { get; set; }
+    [Parameter] public EventCallback<Guid> OnRemoveLabel { get; set; }
+
+    /// <summary>Rendered at the bottom of the open picker (e.g. the "Manage labels..." link).</summary>
+    [Parameter] public RenderFragment? Footer { get; set; }
+
+    /// <summary>Raised when the picker is opened, so the parent can close any conflicting UI
+    /// (NoteEditor closes its label manager).</summary>
+    [Parameter] public EventCallback OnPickerOpened { get; set; }
+
+    private bool _showPicker;
+
+    private async Task TogglePicker()
+    {
+        _showPicker = !_showPicker;
+        if (_showPicker)
+            await OnPickerOpened.InvokeAsync();
+    }
+
+    /// <summary>Closes the picker from the parent (e.g. when opening the label manager).</summary>
+    public void ClosePicker()
+    {
+        if (!_showPicker) return;
+        _showPicker = false;
+        StateHasChanged();
+    }
+
+    private Task Toggle(Label label) => OnToggleLabel.InvokeAsync(label);
+    private Task Remove(Guid labelId) => OnRemoveLabel.InvokeAsync(labelId);
+}

--- a/Vanadium.Note.Web/Components/Pagination.razor
+++ b/Vanadium.Note.Web/Components/Pagination.razor
@@ -1,0 +1,28 @@
+@* Shared pager extracted from Home/Archive/RecycleBin (issue #124). Renders
+   nothing when there is a single page, so callers no longer need their own guard. *@
+@if (TotalPages > 1)
+{
+    <div class="pagination-bar">
+        <div class="pagination-controls">
+            <button class="page-btn" disabled="@(CurrentPage == 1)" @onclick="() => Go(1)">«</button>
+            <button class="page-btn" disabled="@(CurrentPage == 1)" @onclick="() => Go(CurrentPage - 1)">‹</button>
+            @for (int i = Math.Max(1, CurrentPage - 2); i <= Math.Min(TotalPages, CurrentPage + 2); i++)
+            {
+                var p = i;
+                <button class="page-btn @(p == CurrentPage ? "page-btn-active" : "")" @onclick="() => Go(p)">@p</button>
+            }
+            <button class="page-btn" disabled="@(CurrentPage == TotalPages)" @onclick="() => Go(CurrentPage + 1)">›</button>
+            <button class="page-btn" disabled="@(CurrentPage == TotalPages)" @onclick="() => Go(TotalPages)">»</button>
+        </div>
+        <span class="pagination-info">@InfoText</span>
+    </div>
+}
+
+@code {
+    [Parameter, EditorRequired] public int CurrentPage { get; set; }
+    [Parameter, EditorRequired] public int TotalPages { get; set; }
+    [Parameter, EditorRequired] public string InfoText { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public EventCallback<int> OnPageChanged { get; set; }
+
+    private Task Go(int page) => OnPageChanged.InvokeAsync(page);
+}

--- a/Vanadium.Note.Web/Pages/Archive.razor
+++ b/Vanadium.Note.Web/Pages/Archive.razor
@@ -3,7 +3,7 @@
 @inject NoteService NoteService
 @inject NavigationManager Nav
 @inject ISnackbar Snackbar
-@inject IDialogService DialogService
+@inject ConfirmService Confirm
 @inject ILogger<Archive> Logger
 
 <PageTitle>Archive</PageTitle>
@@ -58,23 +58,10 @@
             }
         </div>
 
-        @if (TotalPages > 1)
-        {
-            <div class="pagination-bar">
-                <div class="pagination-controls">
-                    <button class="page-btn" disabled="@(currentPage == 1)" @onclick="() => LoadPage(1)">«</button>
-                    <button class="page-btn" disabled="@(currentPage == 1)" @onclick="() => LoadPage(currentPage - 1)">‹</button>
-                    @for (int i = Math.Max(1, currentPage - 2); i <= Math.Min(TotalPages, currentPage + 2); i++)
-                    {
-                        var p = i;
-                        <button class="page-btn @(p == currentPage ? "page-btn-active" : "")" @onclick="() => LoadPage(p)">@p</button>
-                    }
-                    <button class="page-btn" disabled="@(currentPage == TotalPages)" @onclick="() => LoadPage(currentPage + 1)">›</button>
-                    <button class="page-btn" disabled="@(currentPage == TotalPages)" @onclick="() => LoadPage(TotalPages)">»</button>
-                </div>
-                <span class="pagination-info">@totalCount note(s)</span>
-            </div>
-        }
+        <Pagination CurrentPage="currentPage"
+                    TotalPages="TotalPages"
+                    InfoText="@($"{totalCount} note(s)")"
+                    OnPageChanged="LoadPage" />
     }
 </div>
 
@@ -138,7 +125,7 @@
         var message = item.ChildCount > 0
             ? $"Move \"{title}\" and its sub-note(s) to the Recycle Bin? Items in the Recycle Bin are deleted permanently after 30 days."
             : $"Move \"{title}\" to the Recycle Bin? Items in the Recycle Bin are deleted permanently after 30 days.";
-        if (!await ConfirmAsync("Move to Recycle Bin", message, "Move to Recycle Bin")) return;
+        if (!await Confirm.ConfirmAsync("Move to Recycle Bin", message, "Move to Recycle Bin")) return;
 
         var result = await NoteService.DeleteAsync(item.Id);
         if (!result.IsSuccess)
@@ -149,18 +136,5 @@
         Logger.LogInformation("Archived note moved to recycle bin from archive page.");
         Snackbar.Add("Note moved to the Recycle Bin.", Severity.Normal);
         await ReloadAfterRemoval();
-    }
-
-    private async Task<bool> ConfirmAsync(string title, string message, string confirmText)
-    {
-        var parameters = new DialogParameters<ConfirmDialog>
-        {
-            { x => x.Message, message },
-            { x => x.ConfirmText, confirmText },
-            { x => x.ConfirmColor, Color.Error }
-        };
-        var dialog = await DialogService.ShowAsync<ConfirmDialog>(title, parameters);
-        var dialogResult = await dialog.Result;
-        return dialogResult is not null && !dialogResult.Canceled;
     }
 }

--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -206,23 +206,10 @@
             }
         </div>
 
-        @if (TotalPages > 1)
-        {
-            <div class="pagination-bar">
-                <div class="pagination-controls">
-                    <button class="page-btn" disabled="@(currentPage == 1)" @onclick="() => OnPageChanged(1)">«</button>
-                    <button class="page-btn" disabled="@(currentPage == 1)" @onclick="() => OnPageChanged(currentPage - 1)">‹</button>
-                    @for (int i = Math.Max(1, currentPage - 2); i <= Math.Min(TotalPages, currentPage + 2); i++)
-                    {
-                        var p = i;
-                        <button class="page-btn @(p == currentPage ? "page-btn-active" : "")" @onclick="() => OnPageChanged(p)">@p</button>
-                    }
-                    <button class="page-btn" disabled="@(currentPage == TotalPages)" @onclick="() => OnPageChanged(currentPage + 1)">›</button>
-                    <button class="page-btn" disabled="@(currentPage == TotalPages)" @onclick="() => OnPageChanged(TotalPages)">»</button>
-                </div>
-                <span class="pagination-info">@totalCount notes</span>
-            </div>
-        }
+        <Pagination CurrentPage="currentPage"
+                    TotalPages="TotalPages"
+                    InfoText="@($"{totalCount} notes")"
+                    OnPageChanged="OnPageChanged" />
     }
 </div>
 

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -91,81 +91,20 @@
            @oninput="OnTitleInput"
            @onkeydown="OnTitleKeyDown" />
 
-    <div class="label-bar">
-        @foreach (var label in noteLabels)
-        {
-            <span class="label-chip @(label.CategoryId.HasValue ? "label-chip-cat" : "")">
-                @if (label.CategoryId.HasValue)
-                {
-                    <span class="label-cat-prefix">@label.CategoryName:</span>
-                }
-                <span>@label.Name</span>
-                @if (!IsArchived)
-                {
-                    <button class="label-chip-remove" @onclick="() => RemoveLabel(label.Id)">×</button>
-                }
-            </span>
-        }
-
-        @if (!IsArchived)
-        {
-        <div class="label-add-wrapper">
-            <button class="label-add-btn @(showLabelPicker ? "label-add-btn-active" : "")" @onclick="ToggleLabelPicker">
-                + Label
-            </button>
-
-            @if (showLabelPicker)
-            {
-                <div class="label-picker-backdrop" @onclick="CloseLabelPicker"></div>
-                <div class="label-picker">
-                    @{
-                        var generalLabels = availableLabels.Where(l => !l.CategoryId.HasValue).ToList();
-                    }
-
-                    @if (generalLabels.Any())
-                    {
-                        <div class="label-picker-section">
-                            <div class="label-picker-section-title">General</div>
-                            @foreach (var lbl in generalLabels)
-                            {
-                                var isAdded = noteLabels.Any(nl => nl.Id == lbl.Id);
-                                <div class="label-picker-item @(isAdded ? "is-added" : "")" @onclick="() => ToggleLabel(lbl)">
-                                    <span class="label-picker-check">@(isAdded ? "✓" : "")</span>
-                                    <span>@lbl.Name</span>
-                                </div>
-                            }
-                        </div>
-                    }
-
-                    @foreach (var cat in labelCategories)
-                    {
-                        var catLabels = availableLabels.Where(l => l.CategoryId == cat.Id).ToList();
-                        if (!catLabels.Any()) continue;
-                        <div class="label-picker-section">
-                            <div class="label-picker-section-title">@cat.Name</div>
-                            @foreach (var lbl in catLabels)
-                            {
-                                var isAdded = noteLabels.Any(nl => nl.Id == lbl.Id);
-                                <div class="label-picker-item @(isAdded ? "is-added" : "")" @onclick="() => ToggleLabel(lbl)">
-                                    <span class="label-picker-check">@(isAdded ? "✓" : "")</span>
-                                    <span>@lbl.Name</span>
-                                </div>
-                            }
-                        </div>
-                    }
-
-                    @if (!availableLabels.Any())
-                    {
-                        <div class="label-picker-empty">No labels</div>
-                    }
-
-                    <div class="label-picker-divider"></div>
-                    <div class="label-picker-manage-btn" @onclick="ToggleLabelManager">Manage labels...</div>
-                </div>
-            }
-        </div>
-        }
-    </div>
+    <LabelPicker @ref="_labelPicker"
+                 BarClass="label-bar"
+                 NoteLabels="noteLabels"
+                 AvailableLabels="availableLabels"
+                 LabelCategories="labelCategories"
+                 ReadOnly="IsArchived"
+                 OnToggleLabel="ToggleLabel"
+                 OnRemoveLabel="RemoveLabel"
+                 OnPickerOpened="OnLabelPickerOpened">
+        <Footer>
+            <div class="label-picker-divider"></div>
+            <div class="label-picker-manage-btn" @onclick="ToggleLabelManager">Manage labels...</div>
+        </Footer>
+    </LabelPicker>
 
     @if (showLabelManager)
     {
@@ -267,7 +206,7 @@
     private bool _contentJustLoaded = false;
     private readonly string _editorId = "tiptap-" + Guid.NewGuid().ToString("N")[..8];
     private DotNetObjectReference<NoteEditor>? _objRef;
-    private CancellationTokenSource? _debounceCts;
+    private readonly AutoSaveDebouncer _autoSave = new();
     private bool _hasPendingChanges = false;
 
     /// <summary>
@@ -310,7 +249,7 @@
     private List<Label> noteLabels = [];
     private List<Label> availableLabels = [];
     private List<LabelCategory> labelCategories = [];
-    private bool showLabelPicker = false;
+    private LabelPicker? _labelPicker;
     private bool showLabelManager = false;
     private string newLabelName = "";
     private string newLabelCategoryStr = "";
@@ -487,20 +426,7 @@
         if (_hasConflict || IsArchived || _loadFailed) return;
         HasPendingChanges = true;
         SetStatus("Writing...", "status-pending");
-        _debounceCts?.Cancel();
-        _debounceCts?.Dispose();
-        _debounceCts = new CancellationTokenSource();
-        _ = DebounceAndSave(_debounceCts.Token);
-    }
-
-    private async Task DebounceAndSave(CancellationToken token)
-    {
-        try
-        {
-            await Task.Delay(1500, token);
-            await InvokeAsync(DoAutoSave);
-        }
-        catch (TaskCanceledException) { }
+        _autoSave.Schedule(() => InvokeAsync(DoAutoSave));
     }
 
     // Single save entry point. Auto-save and manual save (Ctrl+S) both funnel
@@ -609,9 +535,7 @@
 
     private async Task SaveNote()
     {
-        _debounceCts?.Cancel();
-        _debounceCts?.Dispose();
-        _debounceCts = null;
+        _autoSave.Cancel();
 
         // If an auto-save is already in flight, join it rather than racing it — a
         // second concurrent PUT on the same UpdatedAt is what caused false 409s (#120).
@@ -681,7 +605,7 @@
 
     private async Task DeleteNote()
     {
-        _debounceCts?.Cancel();
+        _autoSave.Cancel();
         if (Id is not null)
         {
             var parts = new List<string>();
@@ -724,7 +648,7 @@
         if (IsArchived) return;
         archivedAt = DateTime.UtcNow; // marker only; the server holds the real value
         HasPendingChanges = false;
-        _debounceCts?.Cancel();
+        _autoSave.Cancel();
         Snackbar.Add("This note has been archived and is now read-only.", Severity.Warning);
         if (_editorMounted)
             await JS.InvokeVoidAsync("tiptapInterop.setEditable", _editorId, false);
@@ -740,7 +664,7 @@
         if (!confirmed) return;
 
         // Flush any pending edits before the note becomes read-only.
-        _debounceCts?.Cancel();
+        _autoSave.Cancel();
         if (HasPendingChanges)
             await SaveCoreAsync();
 
@@ -808,7 +732,7 @@
             if (!string.IsNullOrEmpty(newContent))
             {
                 content = newContent;
-                _debounceCts?.Cancel();
+                _autoSave.Cancel();
                 await DoAutoSave();
             }
         }
@@ -841,7 +765,7 @@
             if (!string.IsNullOrEmpty(newContent))
             {
                 content = newContent;
-                _debounceCts?.Cancel();
+                _autoSave.Cancel();
                 await DoAutoSave();
             }
         }
@@ -872,21 +796,13 @@
 
     // ── Label actions ─────────────────────────────────────────────────────────
 
-    private void ToggleLabelPicker()
-    {
-        showLabelPicker = !showLabelPicker;
-        if (showLabelPicker) showLabelManager = false;
-    }
-
-    private void CloseLabelPicker()
-    {
-        showLabelPicker = false;
-    }
+    // Opening the label picker closes the manager (they overlap the same space).
+    private void OnLabelPickerOpened() => showLabelManager = false;
 
     private void ToggleLabelManager()
     {
         showLabelManager = !showLabelManager;
-        showLabelPicker = false;
+        _labelPicker?.ClosePicker();
     }
 
     private async Task ToggleLabel(Label label)
@@ -1002,8 +918,7 @@
     public async ValueTask DisposeAsync()
     {
         _isDisposing = true;
-        _debounceCts?.Cancel();
-        _debounceCts?.Dispose();
+        _autoSave.Dispose();
 
         if (HasPendingChanges && !_hasConflict && !IsArchived)
             await SaveCoreAsync();

--- a/Vanadium.Note.Web/Pages/RecycleBin.razor
+++ b/Vanadium.Note.Web/Pages/RecycleBin.razor
@@ -2,7 +2,7 @@
 @attribute [Authorize]
 @inject NoteService NoteService
 @inject ISnackbar Snackbar
-@inject IDialogService DialogService
+@inject ConfirmService Confirm
 @inject ILogger<RecycleBin> Logger
 
 <PageTitle>Recycle Bin</PageTitle>
@@ -63,23 +63,10 @@
             }
         </div>
 
-        @if (TotalPages > 1)
-        {
-            <div class="pagination-bar">
-                <div class="pagination-controls">
-                    <button class="page-btn" disabled="@(currentPage == 1)" @onclick="() => LoadPage(1)">«</button>
-                    <button class="page-btn" disabled="@(currentPage == 1)" @onclick="() => LoadPage(currentPage - 1)">‹</button>
-                    @for (int i = Math.Max(1, currentPage - 2); i <= Math.Min(TotalPages, currentPage + 2); i++)
-                    {
-                        var p = i;
-                        <button class="page-btn @(p == currentPage ? "page-btn-active" : "")" @onclick="() => LoadPage(p)">@p</button>
-                    }
-                    <button class="page-btn" disabled="@(currentPage == TotalPages)" @onclick="() => LoadPage(currentPage + 1)">›</button>
-                    <button class="page-btn" disabled="@(currentPage == TotalPages)" @onclick="() => LoadPage(TotalPages)">»</button>
-                </div>
-                <span class="pagination-info">@totalCount note(s)</span>
-            </div>
-        }
+        <Pagination CurrentPage="currentPage"
+                    TotalPages="TotalPages"
+                    InfoText="@($"{totalCount} note(s)")"
+                    OnPageChanged="LoadPage" />
     }
 </div>
 
@@ -147,7 +134,7 @@
         var message = item.ChildCount > 0
             ? $"Permanently delete \"{title}\" and its sub-note(s)? This cannot be undone."
             : $"Permanently delete \"{title}\"? This cannot be undone.";
-        if (!await ConfirmAsync("Delete forever", message, "Delete forever")) return;
+        if (!await Confirm.ConfirmAsync("Delete forever", message, "Delete forever")) return;
 
         var result = await NoteService.DeletePermanentAsync(item.Id);
         if (!result.IsSuccess)
@@ -162,7 +149,7 @@
     private async Task EmptyRecycleBin()
     {
         var message = $"Permanently delete all {totalCount} note(s) in the recycle bin? This cannot be undone.";
-        if (!await ConfirmAsync("Empty Recycle Bin", message, "Empty Recycle Bin")) return;
+        if (!await Confirm.ConfirmAsync("Empty Recycle Bin", message, "Empty Recycle Bin")) return;
 
         var result = await NoteService.EmptyRecycleBinAsync();
         if (!result.IsSuccess)
@@ -172,18 +159,5 @@
         }
         Snackbar.Add("Recycle bin emptied.", Severity.Success);
         await LoadPage(1);
-    }
-
-    private async Task<bool> ConfirmAsync(string title, string message, string confirmText)
-    {
-        var parameters = new DialogParameters<ConfirmDialog>
-        {
-            { x => x.Message, message },
-            { x => x.ConfirmText, confirmText },
-            { x => x.ConfirmColor, Color.Error }
-        };
-        var dialog = await DialogService.ShowAsync<ConfirmDialog>(title, parameters);
-        var dialogResult = await dialog.Result;
-        return dialogResult is not null && !dialogResult.Canceled;
     }
 }

--- a/Vanadium.Note.Web/Pages/SubNoteDialog.razor
+++ b/Vanadium.Note.Web/Pages/SubNoteDialog.razor
@@ -26,67 +26,12 @@
         </div>
     </TitleContent>
     <DialogContent>
-        <div class="dialog-label-bar">
-            @foreach (var label in noteLabels)
-            {
-                <span class="label-chip @(label.CategoryId.HasValue ? "label-chip-cat" : "")">
-                    @if (label.CategoryId.HasValue)
-                    {
-                        <span class="label-cat-prefix">@label.CategoryName:</span>
-                    }
-                    <span>@label.Name</span>
-                    <button class="label-chip-remove" @onclick="() => RemoveLabel(label.Id)">×</button>
-                </span>
-            }
-            <div class="label-add-wrapper">
-                <button class="label-add-btn @(showLabelPicker ? "label-add-btn-active" : "")" @onclick="ToggleLabelPicker">
-                    + Label
-                </button>
-                @if (showLabelPicker)
-                {
-                    <div class="label-picker-backdrop" @onclick="CloseLabelPicker"></div>
-                    <div class="label-picker">
-                        @{
-                            var generalLabels = availableLabels.Where(l => !l.CategoryId.HasValue).ToList();
-                        }
-                        @if (generalLabels.Any())
-                        {
-                            <div class="label-picker-section">
-                                <div class="label-picker-section-title">General</div>
-                                @foreach (var lbl in generalLabels)
-                                {
-                                    var isAdded = noteLabels.Any(nl => nl.Id == lbl.Id);
-                                    <div class="label-picker-item @(isAdded ? "is-added" : "")" @onclick="() => ToggleLabel(lbl)">
-                                        <span class="label-picker-check">@(isAdded ? "✓" : "")</span>
-                                        <span>@lbl.Name</span>
-                                    </div>
-                                }
-                            </div>
-                        }
-                        @foreach (var cat in labelCategories)
-                        {
-                            var catLabels = availableLabels.Where(l => l.CategoryId == cat.Id).ToList();
-                            if (!catLabels.Any()) continue;
-                            <div class="label-picker-section">
-                                <div class="label-picker-section-title">@cat.Name</div>
-                                @foreach (var lbl in catLabels)
-                                {
-                                    var isAdded = noteLabels.Any(nl => nl.Id == lbl.Id);
-                                    <div class="label-picker-item @(isAdded ? "is-added" : "")" @onclick="() => ToggleLabel(lbl)">
-                                        <span class="label-picker-check">@(isAdded ? "✓" : "")</span>
-                                        <span>@lbl.Name</span>
-                                    </div>
-                                }
-                            </div>
-                        }
-                        @if (!availableLabels.Any())
-                        {
-                            <div class="label-picker-empty">No labels</div>
-                        }
-                    </div>
-                }
-            </div>
-        </div>
+        <LabelPicker BarClass="dialog-label-bar"
+                     NoteLabels="noteLabels"
+                     AvailableLabels="availableLabels"
+                     LabelCategories="labelCategories"
+                     OnToggleLabel="ToggleLabel"
+                     OnRemoveLabel="RemoveLabel" />
         <div id="@_editorId" class="tiptap-wrapper dialog-tiptap"></div>
     </DialogContent>
     <DialogActions>
@@ -111,12 +56,12 @@
     private List<Label> noteLabels = [];
     private List<Label> availableLabels = [];
     private List<LabelCategory> labelCategories = [];
-    private bool showLabelPicker = false;
 
     private readonly string _editorId = "tiptap-" + Guid.NewGuid().ToString("N")[..8];
     private DotNetObjectReference<SubNoteDialog>? _objRef;
-    private CancellationTokenSource? _debounceCts;
+    private readonly AutoSaveDebouncer _autoSave = new();
     private bool _hasPendingChanges = false;
+    private bool _isSaving = false;
     private bool _editorMounted = false;
     private bool _contentJustLoaded = false;
 
@@ -207,7 +152,7 @@
     public async Task OnMentionClick(string noteId)
     {
         if (!Guid.TryParse(noteId, out _)) return;
-        _debounceCts?.Cancel();
+        _autoSave.Cancel();
         await DoAutoSave();
         MudDialog.Close(DialogResult.Ok(title));
         Nav.NavigateTo($"/editor/{noteId}");
@@ -229,18 +174,11 @@
     {
         if (_isArchived) return; // archived notes are read-only
         _hasPendingChanges = true;
-        _debounceCts?.Cancel();
-        _debounceCts = new CancellationTokenSource();
-        var token = _debounceCts.Token;
         saveStatusText = "Unsaved changes";
         saveStatusCss = "status-pending";
         StateHasChanged();
 
-        _ = Task.Delay(1500, token).ContinueWith(async t =>
-        {
-            if (t.IsCanceled) return;
-            await InvokeAsync(DoAutoSave);
-        }, TaskScheduler.Default);
+        _autoSave.Schedule(() => InvokeAsync(DoAutoSave));
     }
 
     // UI-free save used by both the debounced path and the close/dispose flush. It never touches
@@ -270,41 +208,53 @@
     {
         if (_isArchived) return;
 
-        saveStatusText = "Saving…";
-        saveStatusCss = "status-saving";
-        StateHasChanged();
+        // Re-entry guard: the debounce timer and the direct flush paths (Close,
+        // ExpandToFullPage, OnMentionClick, Ctrl+S) can all fire DoAutoSave, and two
+        // concurrent PUTs on the same _serverUpdatedAt would surface a false 409 (#120/#124).
+        if (_isSaving) return;
+        _isSaving = true;
+        try
+        {
+            saveStatusText = "Saving…";
+            saveStatusCss = "status-saving";
+            StateHasChanged();
 
-        var result = await SaveCoreAsync();
+            var result = await SaveCoreAsync();
 
-        if (result.IsSuccess)
-        {
-            saveStatusText = "Saved";
-            saveStatusCss = "status-saved";
+            if (result.IsSuccess)
+            {
+                saveStatusText = "Saved";
+                saveStatusCss = "status-saved";
+            }
+            else if (result.IsForbidden)
+            {
+                _isArchived = true;
+                if (_editorMounted)
+                    await JS.InvokeVoidAsync("tiptapInterop.setEditable", _editorId, false);
+                saveStatusText = "Read-only (archived)";
+                saveStatusCss = "status-error";
+            }
+            else if (result.IsConflict)
+            {
+                saveStatusText = "Modified elsewhere — reopen to edit";
+                saveStatusCss = "status-error";
+            }
+            else
+            {
+                saveStatusText = "Save failed";
+                saveStatusCss = "status-error";
+            }
+            StateHasChanged();
         }
-        else if (result.IsForbidden)
+        finally
         {
-            _isArchived = true;
-            if (_editorMounted)
-                await JS.InvokeVoidAsync("tiptapInterop.setEditable", _editorId, false);
-            saveStatusText = "Read-only (archived)";
-            saveStatusCss = "status-error";
+            _isSaving = false;
         }
-        else if (result.IsConflict)
-        {
-            saveStatusText = "Modified elsewhere — reopen to edit";
-            saveStatusCss = "status-error";
-        }
-        else
-        {
-            saveStatusText = "Save failed";
-            saveStatusCss = "status-error";
-        }
-        StateHasChanged();
     }
 
     private async Task ExpandToFullPage()
     {
-        _debounceCts?.Cancel();
+        _autoSave.Cancel();
         await DoAutoSave();
         MudDialog.Close(DialogResult.Ok(title));
         Nav.NavigateTo($"/editor/{NoteId}");
@@ -314,17 +264,13 @@
     {
         // Cancel the pending debounce, then flush any unsaved edit before the dialog goes away so
         // the last <1.5s of typing is not silently discarded.
-        _debounceCts?.Cancel();
+        _autoSave.Cancel();
         if (_hasPendingChanges && !_isArchived)
             await DoAutoSave();
         MudDialog.Close(DialogResult.Ok(title));
     }
 
     // ── Label actions ────────────────────────────────────────────────────────
-
-    private void ToggleLabelPicker() => showLabelPicker = !showLabelPicker;
-
-    private void CloseLabelPicker() => showLabelPicker = false;
 
     private async Task ToggleLabel(Label label)
     {
@@ -368,7 +314,7 @@
     {
         // Esc/backdrop closes bypass Close() and only reach here, so flush pending edits on this
         // path too. Use SaveCoreAsync (no StateHasChanged) since the component is being disposed.
-        _debounceCts?.Cancel();
+        _autoSave.Dispose();
         if (_hasPendingChanges && !_isArchived)
             await SaveCoreAsync();
 

--- a/Vanadium.Note.Web/Program.cs
+++ b/Vanadium.Note.Web/Program.cs
@@ -46,6 +46,7 @@ namespace Vanadium.Note.Web
             builder.Services.AddScoped<KeyboardShortcutService>();
             builder.Services.AddScoped<QuickNavService>();
             builder.Services.AddScoped<DraftStore>();
+            builder.Services.AddScoped<ConfirmService>();
             builder.Services.AddMudServices();
 
             await builder.Build().RunAsync();

--- a/Vanadium.Note.Web/Services/AutoSaveDebouncer.cs
+++ b/Vanadium.Note.Web/Services/AutoSaveDebouncer.cs
@@ -1,0 +1,45 @@
+namespace Vanadium.Note.Web.Services;
+
+/// <summary>
+/// Debounces auto-save: each <see cref="Schedule"/> call cancels the previous
+/// pending timer and starts a new one, firing the supplied save callback only
+/// after <c>delayMs</c> of quiet. Extracted so the note editor and the sub-note
+/// dialog share one debounce implementation (issue #124).
+/// </summary>
+public sealed class AutoSaveDebouncer(int delayMs = 1500) : IDisposable
+{
+    private CancellationTokenSource? _cts;
+
+    /// <summary>Restarts the debounce timer; <paramref name="save"/> runs once the
+    /// delay elapses without another <see cref="Schedule"/> or <see cref="Cancel"/> call.</summary>
+    public void Schedule(Func<Task> save)
+    {
+        Cancel();
+        _cts = new CancellationTokenSource();
+        _ = RunAsync(save, _cts.Token);
+    }
+
+    private async Task RunAsync(Func<Task> save, CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(delayMs, token);
+        }
+        catch (TaskCanceledException)
+        {
+            return;
+        }
+        if (token.IsCancellationRequested) return;
+        await save();
+    }
+
+    /// <summary>Cancels any pending save so it never fires.</summary>
+    public void Cancel()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+    }
+
+    public void Dispose() => Cancel();
+}

--- a/Vanadium.Note.Web/Services/ConfirmService.cs
+++ b/Vanadium.Note.Web/Services/ConfirmService.cs
@@ -1,0 +1,29 @@
+using MudBlazor;
+using Vanadium.Note.Web.Pages;
+
+namespace Vanadium.Note.Web.Services;
+
+/// <summary>
+/// Shared wrapper around <see cref="ConfirmDialog"/> so pages don't each
+/// re-implement the show-dialog-and-read-result dance (issue #124). Returns
+/// <c>true</c> when the user confirms, <c>false</c> when they cancel or dismiss.
+/// </summary>
+public class ConfirmService(IDialogService dialogService)
+{
+    public async Task<bool> ConfirmAsync(
+        string title,
+        string message,
+        string confirmText,
+        Color confirmColor = Color.Error)
+    {
+        var parameters = new DialogParameters<ConfirmDialog>
+        {
+            { x => x.Message, message },
+            { x => x.ConfirmText, confirmText },
+            { x => x.ConfirmColor, confirmColor }
+        };
+        var dialog = await dialogService.ShowAsync<ConfirmDialog>(title, parameters);
+        var result = await dialog.Result;
+        return result is not null && !result.Canceled;
+    }
+}


### PR DESCRIPTION
Closes #124

## 배경
프론트엔드 컴포넌트/로직이 여러 페이지에 중복되어 있어 공용 컴포넌트/서비스로 추출한다. 순수 프론트엔드 리팩터링으로 백엔드/스키마/마이그레이션 변경은 없다.

## 변경 사항

### 1. 페이지네이션 → `Components/Pagination.razor`
Home / Archive / RecycleBin에 3중 복제되어 있던 페이지네이션 마크업을 단일 공용 컴포넌트로 통합. `TotalPages > 1` 가드를 컴포넌트 내부로 옮겨 호출부에서 래퍼를 제거. 정보 텍스트는 `InfoText` 파라미터로 주입("N notes" / "N note(s)").

### 2. confirm 헬퍼 → `Services/ConfirmService.cs`
Archive / RecycleBin에 동일하게 복제되어 있던 `ConfirmAsync`(ConfirmDialog 래핑)를 DI 서비스로 추출해 재사용. 두 페이지의 `IDialogService` 직접 주입 제거.

### 3. 라벨 피커 → `Components/LabelPicker.razor`
NoteEditor / SubNoteDialog에 복제된 라벨 칩 + `+ Label` 피커 드롭다운(~55줄)을 공용 컴포넌트로 추출.
- 피커 열림 상태는 컴포넌트가 소유.
- NoteEditor 전용 "Manage labels..." 링크는 `Footer` 슬롯으로 주입하고, 피커가 열릴 때 라벨 매니저를 닫는 처리는 `OnPickerOpened` 콜백 + `ClosePicker()`로 연결.
- `ReadOnly`(아카이브)로 remove 버튼/추가 버튼 노출을 제어, `BarClass`로 `label-bar` / `dialog-label-bar` 구분.

### 4. 자동 저장 → `Services/AutoSaveDebouncer.cs`
두 편집기의 디바운스 배관(이전 타이머 취소 → 1.5s 대기 → 저장 호출)을 공용 헬퍼로 통합. NoteEditor의 기존 `_saveInFlight` 코얼레싱(#120) 로직은 그대로 보존.
**SubNoteDialog의 `DoAutoSave`에 재진입 가드(`_isSaving`)를 추가** — 디바운스와 Close/Expand/멘션/Ctrl+S 플러시가 동시에 저장을 호출할 때 같은 `_serverUpdatedAt`로 두 번 PUT되어 false 409가 나던 가능성을 제거.

## 완료 조건 검증
- [x] 페이지네이션 단일 컴포넌트화 후 3개 페이지 재사용
- [x] confirm 헬퍼 공용화로 Archive/RecycleBin 중복 제거
- [x] 라벨 피커 공용 컴포넌트 추출 후 NoteEditor/SubNoteDialog 재사용
- [x] 자동 저장 공유 헬퍼 통합 + SubNoteDialog 재진입 가드
- [x] 기존 동작 회귀 없음 — 마크업/핸들러 동작을 그대로 보존, 각 커밋 독립 빌드 확인
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 0 오류, 신규 경고 없음 (기존 NU1903 4건만)

## 검증 방법
- `dotnet build Vanadium.slnx`: 0 오류, 신규 경고 없음.
- `dotnet test Vanadium.slnx`: 77 통과 / 0 실패 / 3 건너뜀 (백엔드 한정 — Web 프로젝트에는 테스트가 없음).
- 각 커밋(A: 리스트 페이지 / B: 편집기)을 분리해 독립 빌드 확인.