### PR TITLE
#112 로그인 rate limiter를 클라이언트 IP별로 파티션

### DIFF
--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -97,12 +97,21 @@ builder.Services.AddAuthentication(smartScheme)
 
 builder.Services.AddRateLimiter(options =>
 {
-    options.AddFixedWindowLimiter("login", limiter =>
+    // Partition the login limiter by client IP so a single (anonymous) IP cannot
+    // exhaust a shared global bucket and lock out the legitimate owner. Each IP gets
+    // its own 10 req/min fixed window. Correct behaviour behind a proxy additionally
+    // depends on UseForwardedHeaders (issue #113), which is out of scope here.
+    options.AddPolicy("login", context =>
     {
-        limiter.Window = TimeSpan.FromMinutes(1);
-        limiter.PermitLimit = 10;
-        limiter.QueueLimit = 0;
-        limiter.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+        var partitionKey = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(partitionKey, _ =>
+            new FixedWindowRateLimiterOptions
+            {
+                Window = TimeSpan.FromMinutes(1),
+                PermitLimit = 10,
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            });
     });
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 });


### PR DESCRIPTION
## 목적
로그인 rate limiter가 단일 전역 fixed-window 버킷(10 req/min)으로 동작하여, 익명 공격자가 junk 로그인 요청 10건/분만으로 전역 버킷을 소진시켜 정당한 소유자를 락아웃시킬 수 있었다.

## 변경 내용
- `Program.cs`의 `"login"` limiter를 `AddFixedWindowLimiter`(전역 버킷)에서 `AddPolicy` + `RateLimitPartition.GetFixedWindowLimiter`(클라이언트 IP 파티션)로 변경.
- 파티션 키는 `context.Connection.RemoteIpAddress` (없으면 `"unknown"` 폴백).
- 각 IP마다 독립적인 10 req/min fixed window를 갖는다.

## 완료 조건 검증
- [x] 로그인 rate limit이 클라이언트 IP별로 독립 적용된다 — `GetFixedWindowLimiter(partitionKey, …)`가 IP별로 별도 limiter 인스턴스를 생성 (코드 검증).
- [x] 기존 10 req/min 한도 유지 — `PermitLimit = 10`, `Window = 1분` 그대로.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고/오류 추가 없음. `dotnet test` 77 통과.

## 범위 밖 (미포함)
- `UseForwardedHeaders` / 보안 헤더는 이슈 #113 소관이라 포함하지 않음. 프록시 뒤 배포 시 IP 파티션이 정확히 동작하려면 #113 선행 필요.
- 다른 엔드포인트의 rate limit 정책은 변경하지 않음.

## 테스트 노트
Rate limiter 설정은 `Program.cs`의 DI 파이프라인에 있어 단위 테스트(EF Core SQLite in-memory) 범위 밖이며, 레포에 WebApplicationFactory 기반 통합 테스트 인프라가 없어 자동화 회귀 테스트는 추가하지 못함. 빌드 + 코드 검증으로 확인.

Closes #112