### PR TITLE
#136 오펀 파일 판정을 GUID별 DB 조회로 전환

### DIFF
--- a/Vanadium.Note.REST/Services/FileCleanupService.cs
+++ b/Vanadium.Note.REST/Services/FileCleanupService.cs
@@ -50,14 +50,8 @@ public class FileCleanupService(
         logger.LogDebug("On-delete orphan check: {FileCount} file(s) and {ImageCount} image(s) referenced in deleted content.",
             fileIds.Count, imageIds.Count);
 
-        // Combine all surviving notes' content into one string for fast lookup.
-        // IgnoreQueryFilters: soft-deleted notes still reference their files — their
-        // attachments must NOT be treated as orphans until they are purged.
-        var survivingContent = string.Join(' ',
-            await db.Notes.IgnoreQueryFilters().Select(n => n.Content).ToListAsync(ct));
-
-        var filesRemoved  = await DeleteFileAttachmentsAsync(fileIds, survivingContent, ct);
-        var imagesRemoved = DeleteImageFiles(imageIds, survivingContent);
+        var filesRemoved  = await DeleteFileAttachmentsAsync(fileIds, ct);
+        var imagesRemoved = await DeleteImageFilesAsync(imageIds, ct);
 
         if (filesRemoved > 0 || imagesRemoved > 0)
             logger.LogInformation(
@@ -77,11 +71,6 @@ public class FileCleanupService(
         var graceMinutes = config.GetValue("FileCleanup:GraceMinutes", DefaultGraceMinutes);
         var graceCutoff = DateTime.UtcNow.AddMinutes(-graceMinutes);
 
-        // IgnoreQueryFilters: content of soft-deleted notes still counts as a live
-        // file reference until the recycle bin purge actually deletes the note.
-        var allContent = string.Join(' ',
-            await db.Notes.IgnoreQueryFilters().Select(n => n.Content).ToListAsync(ct));
-
         // --- File attachments (have DB records) ---
         var attachments = await db.FileAttachments.ToListAsync(ct);
 
@@ -93,7 +82,7 @@ public class FileCleanupService(
 
         foreach (var attachment in attachments)
         {
-            if (allContent.Contains(attachment.Id.ToString(), StringComparison.OrdinalIgnoreCase))
+            if (await IsReferencedInAnyNoteAsync(attachment.Id, ct))
                 continue;
 
             // Skip recently uploaded attachments still within the grace window.
@@ -132,10 +121,10 @@ public class FileCleanupService(
                 continue;
 
             var guidStr = Path.GetFileNameWithoutExtension(file.Name);
-            if (!Guid.TryParse(guidStr, out _))
+            if (!Guid.TryParse(guidStr, out var imageId))
                 continue;
 
-            if (allContent.Contains(guidStr, StringComparison.OrdinalIgnoreCase))
+            if (await IsReferencedInAnyNoteAsync(imageId, ct))
                 continue;
 
             // Disk-only images have no DB record, so fall back to the file's
@@ -161,13 +150,13 @@ public class FileCleanupService(
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private async Task<int> DeleteFileAttachmentsAsync(
-        IEnumerable<Guid> ids, string survivingContent, CancellationToken ct)
+        IEnumerable<Guid> ids, CancellationToken ct)
     {
         int removed = 0;
 
         foreach (var id in ids)
         {
-            if (survivingContent.Contains(id.ToString(), StringComparison.OrdinalIgnoreCase))
+            if (await IsReferencedInAnyNoteAsync(id, ct))
                 continue;
 
             var attachment = await db.FileAttachments.FindAsync([id], ct);
@@ -186,7 +175,7 @@ public class FileCleanupService(
         return removed;
     }
 
-    private int DeleteImageFiles(IEnumerable<Guid> ids, string survivingContent)
+    private async Task<int> DeleteImageFilesAsync(IEnumerable<Guid> ids, CancellationToken ct)
     {
         if (!Directory.Exists(UploadsPath)) return 0;
 
@@ -194,7 +183,7 @@ public class FileCleanupService(
 
         foreach (var id in ids)
         {
-            if (survivingContent.Contains(id.ToString(), StringComparison.OrdinalIgnoreCase))
+            if (await IsReferencedInAnyNoteAsync(id, ct))
                 continue;
 
             var file = new DirectoryInfo(UploadsPath)
@@ -209,6 +198,28 @@ public class FileCleanupService(
         }
 
         return removed;
+    }
+
+    /// <summary>
+    /// Returns whether any note still references <paramref name="id"/> in its content,
+    /// queried per-GUID against the DB so the full note corpus is never loaded into memory.
+    /// <para>
+    /// IgnoreQueryFilters: content of soft-deleted (recycle-bin) notes still counts as a
+    /// live file reference until the recycle bin purge actually deletes the note — their
+    /// attachments must NOT be treated as orphans early.
+    /// </para>
+    /// <para>
+    /// The content side is lowered before matching so this reproduces the previous
+    /// in-memory <see cref="StringComparison.OrdinalIgnoreCase"/> <c>Contains</c> semantics
+    /// (<see cref="Guid.ToString()"/> is already lowercase, and GUIDs are ASCII hex).
+    /// </para>
+    /// </summary>
+    private Task<bool> IsReferencedInAnyNoteAsync(Guid id, CancellationToken ct)
+    {
+        var needle = id.ToString();
+        return db.Notes
+                 .IgnoreQueryFilters()
+                 .AnyAsync(n => n.Content.ToLower().Contains(needle), ct);
     }
 
     private void DeletePhysicalFile(string path)


### PR DESCRIPTION
Closes #136

## 배경
`FileCleanupService`가 오펀(참조되지 않는) 파일을 판별할 때, 모든 노트의 `Content`를 DB에서 가져와 `string.Join(' ', ...)`으로 하나의 거대한 문자열로 합친 뒤 in-memory `Contains`로 참조 여부를 확인했다. 노트/콘텐츠가 늘어나면 메모리 확장성 문제가 된다.

## 변경 내용
- 전체 콘텐츠를 메모리에 로드하는 대신, GUID별로 DB에서 참조 여부를 조회하는 `IsReferencedInAnyNoteAsync(Guid, ct)` 헬퍼를 추가하고 두 경로 모두 이를 사용하도록 전환:
  - `DeleteOrphanedFromContentAsync` (노트 삭제 직후) — `survivingContent` 문자열 제거
  - `DeleteAllOrphansAsync` (주기적 백그라운드 스캔) — `allContent` 문자열 제거
- `DeleteImageFiles` → `DeleteImageFilesAsync`로 전환 (DB 조회를 위해 async화)

## 시맨틱 보존
- **`IgnoreQueryFilters()` 유지**: 헬퍼가 `db.Notes.IgnoreQueryFilters()`로 조회하므로 soft-deleted(휴지통) 노트 콘텐츠도 여전히 live 참조로 취급된다 (조기 GC 방지 — CLAUDE.md 경고 준수).
- **대소문자 무시 매칭 유지**: 기존 코드는 `StringComparison.OrdinalIgnoreCase`를 사용했다. 단순 `Contains`는 PostgreSQL에서 대소문자를 구분하므로, `n.Content.ToLower().Contains(needle)`로 콘텐츠 측을 소문자화하여 기존 시맨틱을 그대로 재현한다 (`Guid.ToString()`은 소문자, GUID는 ASCII hex이므로 결과 동일). 이 방식은 PostgreSQL(`lower()`+`strpos`)과 SQLite(`lower()`+`instr`) 양쪽에서 번역되므로 기존 SQLite 단위 테스트가 그대로 통과한다.
- **URL 포맷/정규식 추출 로직 변경 없음** (범위 밖 준수).

## 완료 조건 검증
- [x] 전체 노트 콘텐츠를 단일 문자열로 로드하지 않고 per-GUID DB 조회로 판정 — `string.Join`/`survivingContent`/`allContent` 모두 제거 확인
- [x] soft-deleted 노트 콘텐츠를 live 참조로 취급 (`IgnoreQueryFilters()` 보존) — 헬퍼에서 유지
- [x] 오펀 정리 동작 회귀 없음 — `dotnet test Vanadium.slnx` 전체 통과 (실패 0, 통과 77, 건너뜀 3). `FileCleanupGraceTests`가 새 per-GUID 경로를 SQLite에서 실제로 검증
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 오류 0 (기존 NU1903 경고 4개 외 신규 경고 없음)