### PR TITLE
#138 프로덕션 JS 경로의 console.log를 console.debug로 낮춤

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/board-drag-drop.js
+++ b/Vanadium.Note.Web/wwwroot/js/board-drag-drop.js
@@ -104,7 +104,7 @@ window.boardDragDrop = (() => {
         init(dotNetRef) {
             _dotNetRef = dotNetRef;
             document.addEventListener('dragstart',  _h.dragstart);
-            console.log('[board] Drag-drop initialized.');
+            console.debug('[board] Drag-drop initialized.');
             document.addEventListener('dragend',    _h.dragend);
             document.addEventListener('dragover',   _h.dragover);
             document.addEventListener('dragenter',  _h.dragenter);
@@ -119,7 +119,7 @@ window.boardDragDrop = (() => {
             document.removeEventListener('dragleave',  _h.dragleave);
             document.removeEventListener('drop',       _h.drop);
             _dotNetRef = null;
-            console.log('[board] Drag-drop disposed.');
+            console.debug('[board] Drag-drop disposed.');
         }
     };
 })();

--- a/Vanadium.Note.Web/wwwroot/js/tiptap-editor.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap-editor.js
@@ -1840,7 +1840,7 @@ window.tiptapInterop = {
                             (ratio) => toast.update(ratio)
                         );
                         toast.done();
-                        console.log(`[tiptap] Image pasted and uploaded: ${file.name} (${file.size}B)`);
+                        console.debug(`[tiptap] Image pasted and uploaded: ${file.name} (${file.size}B)`);
                         editor.chain().focus().setImage({ src: `${apiBaseUrl}${url}` }).run();
                         // The browser cannot load /api/images/* without a JWT, so resolve
                         // the newly inserted <img> to a Blob URL immediately after insertion.
@@ -1936,7 +1936,7 @@ window.tiptapInterop = {
                             (ratio) => toast.update(ratio)
                         );
                         toast.done();
-                        console.log(`[tiptap] Image dropped and uploaded: ${file.name} (${file.size}B) -> ${url}`);
+                        console.debug(`[tiptap] Image dropped and uploaded: ${file.name} (${file.size}B) -> ${url}`);
                         editor.chain().focus().insertContentAt(insertPos, {
                             type: 'image',
                             attrs: { src: `${apiBaseUrl}${url}`, class: 'tiptap-image' },
@@ -1953,7 +1953,7 @@ window.tiptapInterop = {
                             (ratio) => toast.update(ratio)
                         );
                         toast.done();
-                        console.log(`[tiptap] File dropped and uploaded: ${file.name} (${file.size}B) -> ${url}`);
+                        console.debug(`[tiptap] File dropped and uploaded: ${file.name} (${file.size}B) -> ${url}`);
                         editor.chain().focus().insertContentAt(insertPos, {
                             type: 'fileAttachment',
                             attrs: { href: `${apiBaseUrl}${url}`, filename },
@@ -1969,7 +1969,7 @@ window.tiptapInterop = {
         const blobUrls = [];
         const blobUrlCache = new Map();
         _editors[elementId] = { editor, bubbleMenuEl, linkPopover, apiBaseUrl, getAuthToken, blobUrls, blobUrlCache };
-        console.log(`[tiptap] Editor initialized: ${elementId}`);
+        console.debug(`[tiptap] Editor initialized: ${elementId}`);
 
         // Re-apply blob URLs after every doc-mutating transaction. ProseMirror's
         // view layer patches <img src> back to the canonical /api/images/* URL
@@ -2106,7 +2106,7 @@ window.tiptapInterop = {
             entry.bubbleMenuEl.remove();
             entry.linkPopover.popover.remove();
             delete _editors[elementId];
-            console.log(`[tiptap] Editor destroyed: ${elementId}`);
+            console.debug(`[tiptap] Editor destroyed: ${elementId}`);
         }
     },
 };


### PR DESCRIPTION
## 개요
프로덕션에서도 로드되는 프런트엔드 JS 경로(에디터/보드)의 정보성 `console.log` 호출을 기본적으로 숨겨지는 `console.debug`로 낮춰 프로덕션 브라우저 콘솔 노이즈를 줄인다.

Closes #138

## 변경 내용
정보성 `console.log` 7개를 `console.debug`로 변경:
- `board-drag-drop.js` — `[board] Drag-drop initialized.`, `[board] Drag-drop disposed.`
- `tiptap-editor.js` — image pasted / image dropped / file dropped 업로드 로그, `[tiptap] Editor initialized`, `[tiptap] Editor destroyed`

진짜 경고·오류 로그(`console.warn` / `console.error`)는 전부 그대로 유지.

## 완료 조건 검증
- ✅ **위 JS 경로의 `console.log` 호출이 모두 `console.debug`로 교체됨** — `wwwroot/js` 전체 `console.log` grep 결과 0건.
- ✅ **`console.warn` / `console.error`는 변경되지 않음** — diff는 `console.log` → `console.debug` 7줄만 포함.
- ✅ **빌드 클린** — `dotnet build Vanadium.slnx` 오류 0개(사전 존재하던 NU1903 경고 4개 외 신규 경고 없음). `dotnet test` 77 통과/3 건너뜀/0 실패.

## 참고
프런트엔드(Web) 프로젝트에는 테스트 프로젝트가 없고 정적 JS 자산만 변경하므로 추가 단위 테스트는 없음.