### PR TITLE
#135 무제한 문자열 컬럼에 MaxLength 적용

### DIFF
--- a/Vanadium.Note.REST.Tests/StringColumnMaxLengthTests.cs
+++ b/Vanadium.Note.REST.Tests/StringColumnMaxLengthTests.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Guards the length caps added in issue #135 so string columns that were previously
+/// mapped to unbounded Postgres <c>text</c> stay bounded. If a <c>[MaxLength]</c> is
+/// dropped or its value changes, these assertions fail and remind the reviewer that a
+/// matching EF Core migration is required.
+/// </summary>
+public class StringColumnMaxLengthTests
+{
+    [Theory]
+    [InlineData(typeof(FileAttachment), nameof(FileAttachment.OriginalName), 255)]
+    [InlineData(typeof(FileAttachment), nameof(FileAttachment.ContentType), 100)]
+    [InlineData(typeof(ApiToken), nameof(ApiToken.TokenHash), 64)]
+    public void StringColumn_HasExpectedMaxLength(Type entity, string propertyName, int expectedLength)
+    {
+        var property = entity.GetProperty(propertyName);
+        Assert.NotNull(property);
+
+        var maxLength = property!.GetCustomAttribute<MaxLengthAttribute>();
+        Assert.NotNull(maxLength);
+        Assert.Equal(expectedLength, maxLength!.Length);
+    }
+}

--- a/Vanadium.Note.REST/Migrations/20260709022844_AddStringColumnMaxLengths.Designer.cs
+++ b/Vanadium.Note.REST/Migrations/20260709022844_AddStringColumnMaxLengths.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Vanadium.Note.REST.Data;
@@ -11,9 +12,11 @@ using Vanadium.Note.REST.Data;
 namespace Vanadium.Note.REST.Migrations
 {
     [DbContext(typeof(NoteDbContext))]
-    partial class NoteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709022844_AddStringColumnMaxLengths")]
+    partial class AddStringColumnMaxLengths
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Vanadium.Note.REST/Migrations/20260709022844_AddStringColumnMaxLengths.cs
+++ b/Vanadium.Note.REST/Migrations/20260709022844_AddStringColumnMaxLengths.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Vanadium.Note.REST.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStringColumnMaxLengths : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "OriginalName",
+                table: "FileAttachments",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ContentType",
+                table: "FileAttachments",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "TokenHash",
+                table: "ApiTokens",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "OriginalName",
+                table: "FileAttachments",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ContentType",
+                table: "FileAttachments",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "TokenHash",
+                table: "ApiTokens",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64);
+        }
+    }
+}

--- a/Vanadium.Note.REST/Models/ApiToken.cs
+++ b/Vanadium.Note.REST/Models/ApiToken.cs
@@ -16,6 +16,7 @@ public class ApiToken
     public string Name { get; set; } = string.Empty;
 
     /// <summary>Base64-encoded SHA-256 hash of the plaintext token.</summary>
+    [MaxLength(64)]
     public string TokenHash { get; set; } = string.Empty;
 
     /// <summary>Last 4 characters of the plaintext token, for UI identification.</summary>

--- a/Vanadium.Note.REST/Models/FileAttachment.cs
+++ b/Vanadium.Note.REST/Models/FileAttachment.cs
@@ -1,9 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Vanadium.Note.REST.Models;
 
 public class FileAttachment
 {
     public Guid Id { get; set; } = Guid.NewGuid();
+
+    [MaxLength(255)]
     public string OriginalName { get; set; } = string.Empty;
+
+    [MaxLength(100)]
     public string ContentType { get; set; } = string.Empty;
+
     public DateTime UploadedAt { get; set; } = DateTime.UtcNow;
 }


### PR DESCRIPTION
## 개요
길이 제한이 없어 Postgres `text`로 매핑되던 문자열 컬럼 세 곳에 `[MaxLength]`를 추가하고 EF Core 마이그레이션을 생성한다.

Closes #135

## 변경 내용
- `FileAttachment.OriginalName` → `[MaxLength(255)]` (파일명)
- `FileAttachment.ContentType` → `[MaxLength(100)]` (MIME 타입)
- `ApiToken.TokenHash` → `[MaxLength(64)]` (Base64 SHA-256 해시, 실제 44자)
- 마이그레이션 `20260709022844_AddStringColumnMaxLengths` 추가 (`text` → `varchar`)
- 세 컬럼의 MaxLength 값을 검증하는 회귀 테스트 추가

## 완료 조건 검증
- [x] 세 컬럼에 `[MaxLength]` 적용 — 위 모델 변경
- [x] EF Core 마이그레이션 추가 — `20260709022844_AddStringColumnMaxLengths`; 로컬 dev DB에 `dotnet ef database update`로 적용 성공
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고/오류 없음(기존 NU1903 4건 외 신규 없음), `dotnet test` 80 통과

## 범위 준수
- 이미 제한된 `ApiToken.Name`/`ApiToken.TokenSuffix`는 변경하지 않음
- 기존 데이터 절단 마이그레이션 없음(신규 제한 값이 실제 데이터보다 크므로 무손실)