### PR TITLE
#113 프록시 신뢰 및 보안 응답 헤더 추가

### DIFF
--- a/Vanadium.Note.REST.Tests/SecurityHeadersMiddlewareTests.cs
+++ b/Vanadium.Note.REST.Tests/SecurityHeadersMiddlewareTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Http;
+using Vanadium.Note.REST.Middleware;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Unit coverage for <see cref="SecurityHeadersMiddleware"/> (issue #113).
+/// The ForwardedHeaders / HSTS wiring in Program.cs relies on framework
+/// built-ins configured in the middleware pipeline and cannot be exercised
+/// here without an integration host (no WebApplicationFactory harness exists,
+/// and adding one is out of scope); it is verified manually instead.
+/// </summary>
+public class SecurityHeadersMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_SetsNosniffHeader()
+    {
+        var context = new DefaultHttpContext();
+        var called = false;
+        var middleware = new SecurityHeadersMiddleware(_ =>
+        {
+            called = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(called);
+        Assert.Equal("nosniff", context.Response.Headers["X-Content-Type-Options"]);
+    }
+}

--- a/Vanadium.Note.REST/Middleware/SecurityHeadersMiddleware.cs
+++ b/Vanadium.Note.REST/Middleware/SecurityHeadersMiddleware.cs
@@ -1,0 +1,16 @@
+namespace Vanadium.Note.REST.Middleware;
+
+/// <summary>
+/// Adds baseline security response headers. Currently emits
+/// <c>X-Content-Type-Options: nosniff</c> to stop browsers from MIME-sniffing
+/// responses away from their declared Content-Type. Broader headers (CSP, etc.)
+/// are intentionally left for a separate change (see issue #113 scope).
+/// </summary>
+public class SecurityHeadersMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+        await next(context);
+    }
+}

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi;
 using Microsoft.IdentityModel.Tokens;
@@ -28,6 +29,19 @@ builder.Host.UseSerilog((context, services, config) =>
         config.WriteTo.Seq(seqUrl, apiKey: seqApiKey);
 });
 
+
+// TLS terminates at an upstream reverse proxy (nginx etc.); the app itself
+// serves HTTP inside the container. Trust the proxy's X-Forwarded-For /
+// X-Forwarded-Proto so the real client IP and request scheme are restored
+// (also fixes the login rate limiter's per-IP partitioning). KnownNetworks /
+// KnownProxies are cleared because the proxy's container IP is not stable or
+// known ahead of time — the app port must only be reachable by the proxy.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+});
 
 var allowedOrigins = builder.Configuration["Cors:AllowedOrigins"]
     ?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -99,8 +113,8 @@ builder.Services.AddRateLimiter(options =>
 {
     // Partition the login limiter by client IP so a single (anonymous) IP cannot
     // exhaust a shared global bucket and lock out the legitimate owner. Each IP gets
-    // its own 10 req/min fixed window. Correct behaviour behind a proxy additionally
-    // depends on UseForwardedHeaders (issue #113), which is out of scope here.
+    // its own 10 req/min fixed window. Behind a proxy the real client IP is restored
+    // by UseForwardedHeaders (configured above, runs first in the pipeline).
     options.AddPolicy("login", context =>
     {
         var partitionKey = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
@@ -195,6 +209,20 @@ using (var scope = app.Services.CreateScope())
     startupLogger.LogInformation("Database migrations applied.");
 }
 
+// Must run before any middleware that reads the client IP or request scheme
+// (rate limiter, logging, HSTS) so they observe the values the proxy forwarded.
+app.UseForwardedHeaders();
+
+// HSTS instructs browsers to stick to HTTPS. Skipped in Development (where the
+// app is hit over plain HTTP) and emitted only once ForwardedHeaders has
+// restored scheme=https from the proxy. HTTPS *redirection* is deliberately NOT
+// enabled here: the app is HTTP-only inside the container and redirection is the
+// reverse proxy's responsibility — UseHttpsRedirection would need an HTTPS port
+// and would otherwise cause redirect loops behind the proxy.
+if (!app.Environment.IsDevelopment())
+    app.UseHsts();
+
+app.UseMiddleware<SecurityHeadersMiddleware>();
 app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseCors();
 app.UseRateLimiter();


### PR DESCRIPTION
Closes #113

## 목적
리버스 프록시(nginx 등)가 TLS를 종단하는 배포를 가정하여, 앱이 인식하는 클라이언트 IP/scheme을 복원하고 기본 보안 응답 헤더를 추가한다.

## 변경 사항
- **UseForwardedHeaders**: 파이프라인 최상단(다른 미들웨어보다 먼저)에 추가. `X-Forwarded-For` / `X-Forwarded-Proto`를 신뢰해 실제 클라이언트 IP와 요청 scheme을 복원한다. 컨테이너 배포에서 프록시의 컨테이너 IP가 고정/사전 예측 불가하므로 `KnownIPNetworks`/`KnownProxies`는 비운다(앱 포트는 프록시만 접근 가능해야 함).
- **X-Content-Type-Options: nosniff**: 신규 `SecurityHeadersMiddleware`로 모든 응답에 추가.
- **HSTS**: 비개발 환경에서 `UseHsts` 적용. ForwardedHeaders가 scheme=https를 복원한 뒤 실행되도록 배치.
- **HTTPS 리다이렉트**: 앱은 컨테이너 내부에서 HTTP로 동작하고 TLS 종단은 프록시 책임이므로 **명시적으로 보류**(`UseHttpsRedirection` 미사용 — HTTPS 포트가 없으면 리다이렉트 루프 유발). 코드 주석으로 사유 명시.
- 로그인 rate limiter의 IP 파티셔닝이 복원된 실제 클라이언트 IP를 사용하게 되므로 관련 주석 갱신.

## 완료 조건 검증
- [x] `UseForwardedHeaders`가 파이프라인 최상단에 추가되어 프록시 뒤에서 IP/scheme 복원 — `Program.cs`에서 `app.UseForwardedHeaders()`가 첫 미들웨어. `Connection.RemoteIpAddress`가 갱신되어 rate limiter 파티셔닝에도 반영.
- [x] `X-Content-Type-Options: nosniff` 응답 포함 — `SecurityHeadersMiddleware` + 회귀 테스트 `SecurityHeadersMiddlewareTests`.
- [x] HSTS / HTTPS 리다이렉트 결정 반영 — HSTS 적용, HTTPS 리다이렉트 보류(프록시 담당) 문서화.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 신규 경고 없음. `dotnet test Vanadium.slnx` 통과(81 passed, 3 skipped).

## 범위 밖
- 로그인 rate limiter의 IP 파티셔닝 구현 자체(#112)는 이미 반영되어 있어 로직은 손대지 않음(주석만 갱신).
- CSP 등 그 외 보안 헤더는 별도 논의.

## 수동 확인 필요
- ForwardedHeaders / HSTS 배선은 프레임워크 빌트인이라 통합 호스트(WebApplicationFactory) 없이는 단위 테스트가 불가하여 수동 검증 대상. 실제 프록시 뒤 배포 시 클라이언트 IP 로그와 응답 헤더(`X-Content-Type-Options`, `Strict-Transport-Security`)를 확인할 것.