### PR TITLE
#168 인라인 페이지 다이얼로그에서 Ctrl+S 시 하위 노트를 저장하도록 수정

### DIFF
--- a/Vanadium.Note.Web/Pages/SubNoteDialog.razor
+++ b/Vanadium.Note.Web/Pages/SubNoteDialog.razor
@@ -8,6 +8,7 @@
 @inject TokenStore TokenStore
 @inject ISnackbar Snackbar
 @inject ILogger<SubNoteDialog> Logger
+@inject KeyboardShortcutService ShortcutService
 
 <MudDialog>
     <TitleContent>
@@ -59,6 +60,7 @@
 
     private readonly string _editorId = "tiptap-" + Guid.NewGuid().ToString("N")[..8];
     private DotNetObjectReference<SubNoteDialog>? _objRef;
+    private IAsyncDisposable? _ctrlSOverride;
     private readonly AutoSaveDebouncer _autoSave = new();
     private bool _hasPendingChanges = false;
     private bool _isSaving = false;
@@ -104,6 +106,10 @@
             {
                 await JS.InvokeVoidAsync("tiptapInterop.init", _editorId, _objRef, content, apiBase, !_isArchived);
                 _editorMounted = true;
+                // Claim Ctrl+S while the dialog is open so it saves THIS sub-note instead of the
+                // underlying page's note (which would navigate away). The prior binding is restored
+                // on dispose (#168).
+                _ctrlSOverride = await ShortcutService.OverrideAsync("ctrl+s", "Save note", OnSaveShortcut);
             }
             catch (Exception ex)
             {
@@ -133,8 +139,9 @@
     public async Task<string> GetAuthTokenAsync()
         => await TokenStore.GetAsync() ?? string.Empty;
 
-    [JSInvokable]
-    public async Task OnSaveShortcut() => await InvokeAsync(DoAutoSave);
+    // Ctrl+S handler wired via ShortcutService.OverrideAsync while the dialog is open (#168).
+    // The dialog already auto-saves on a debounce, so this just flushes immediately.
+    private async Task OnSaveShortcut() => await InvokeAsync(DoAutoSave);
 
     [JSInvokable]
     public async Task<List<JsMentionItem>> SearchNotes(string query)
@@ -312,6 +319,11 @@
 
     public async ValueTask DisposeAsync()
     {
+        // Hand Ctrl+S back to the underlying page before anything else so the shortcut is never
+        // left pointing at this disposed dialog (#168).
+        if (_ctrlSOverride is not null)
+            await _ctrlSOverride.DisposeAsync();
+
         // Esc/backdrop closes bypass Close() and only reach here, so flush pending edits on this
         // path too. Use SaveCoreAsync (no StateHasChanged) since the component is being disposed.
         _autoSave.Dispose();

--- a/Vanadium.Note.Web/Services/KeyboardShortcutService.cs
+++ b/Vanadium.Note.Web/Services/KeyboardShortcutService.cs
@@ -43,6 +43,36 @@ public sealed class KeyboardShortcutService : IAsyncDisposable
             await UnregisterAsync(key);
     }
 
+    /// <summary>
+    /// Temporarily takes over <paramref name="key"/> with a new handler and returns a token that,
+    /// when disposed, restores the previously registered handler (or clears the binding if there
+    /// was none). Modal dialogs use this to claim Ctrl+S for their own note while open and hand it
+    /// back to the underlying page on close (#168).
+    /// </summary>
+    public async Task<IAsyncDisposable> OverrideAsync(string key, string description, Func<Task> handler)
+    {
+        _handlers.TryGetValue(key, out var previous);
+        await RegisterAsync(key, description, handler);
+        return new ShortcutOverride(this, key, previous);
+    }
+
+    private sealed class ShortcutOverride(KeyboardShortcutService owner, string key, HandlerEntry? previous)
+        : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+        {
+            if (previous is not null)
+            {
+                owner._handlers[key] = previous;
+                await owner._js.InvokeVoidAsync("keyboardShortcuts.register", key);
+            }
+            else
+            {
+                await owner.UnregisterAsync(key);
+            }
+        }
+    }
+
     [JSInvokable]
     public async Task HandleShortcut(string key)
     {


### PR DESCRIPTION
## 개요

인라인 페이지 다이얼로그(`SubNoteDialog`)가 열려 있을 때 `Ctrl+S`를 누르면 다이얼로그의 하위 노트가 아니라 **뒤에 깔린 상위 노트가 저장**되고, 상위 `NoteEditor.SaveNote`가 `Nav.NavigateTo(BackUrl)`로 이동하면서 에디터가 닫히던 문제를 수정한다.

Closes #168

## 원인

- 상위 `NoteEditor`가 `document` 레벨 전역 `ctrl+s` 단축키를 등록해 둔다(`NoteEditor.razor:381`). 다이얼로그가 열려도 이 전역 리스너는 그대로 살아 있어, 다이얼로그 안에서 `Ctrl+S`를 눌러도 전역 핸들러가 잡아 상위 노트를 저장 후 이동한다.
- `SubNoteDialog.OnSaveShortcut`(구 137행)는 어디에서도 호출되지 않는 **죽은 코드**였다.
- `SubNoteDialog`는 `NoteEditor`뿐 아니라 `QuickNavDialog`(Ctrl+K)에서도 열리므로, 수정은 상위 에디터가 아니라 다이얼로그 자체에 두어 두 경로 모두를 커버한다.

## 변경 내용

- **`KeyboardShortcutService.OverrideAsync`** 추가: 단축키를 임시로 새 핸들러로 가로채고, 반환된 토큰을 dispose하면 **이전 핸들러를 복원**(없었으면 해제)한다.
- **`SubNoteDialog`**: 에디터 마운트 시 `ctrl+s`를 자신의 저장(`OnSaveShortcut` → `DoAutoSave`)으로 가로채고, `DisposeAsync`에서 이전 바인딩을 복원한다. 미연결이던 `OnSaveShortcut`을 실제 핸들러로 연결하고 불필요한 `[JSInvokable]`을 제거했다.
- 상위 `NoteEditor`는 변경하지 않는다 — 등록돼 있던 `ctrl+s` 핸들러가 override 토큰에 캡처되어 다이얼로그가 닫힐 때 자동 복원된다.

## 완료 조건 검증

- [x] 다이얼로그가 열린 상태에서 `Ctrl+S`를 눌러도 상위 노트가 저장되지 않는다 — 다이얼로그가 `ctrl+s`를 자신의 `OnSaveShortcut`으로 가로채므로 상위 `SaveNote`가 호출되지 않는다.
- [x] `Ctrl+S` 후에도 상위 에디터와 다이얼로그가 닫히지 않고 유지된다 — `DoAutoSave`에는 이동/닫기 부작용이 없다(상위 `SaveNote`의 `Nav.NavigateTo`가 실행되지 않음).
- [x] 다이얼로그 안 `Ctrl+S`는 현재 하위 노트를 저장한다 — `OnSaveShortcut` → `DoAutoSave` → `SaveCoreAsync`로 즉시 flush.
- [x] 다이얼로그를 닫은 뒤 상위 에디터의 `Ctrl+S`가 정상 복구된다 — override 토큰이 `DisposeAsync`에서 이전 핸들러를 복원(NoteEditor/QuickNav 양쪽 경로).
- [x] 빌드 클린 (`dotnet build Vanadium.slnx` — 신규 경고 없음).

## 범위 / 테스트

- 자동 저장 디바운스·낙관적 동시성(`_serverUpdatedAt`), `Ctrl+K` 등 다른 전역 단축키, 스키마/백엔드는 변경하지 않았다.
- 프론트엔드(Blazor + JS interop) 단축키 동작이라 Web 프로젝트에 테스트 인프라가 없어 자동 회귀 테스트는 추가하지 못했다(CLAUDE.md 명시). `dotnet test Vanadium.slnx` 기존 81개 통과(3 skip은 PostgreSQL 전용 기존 테스트). 실제 동작은 앱 실행으로 수동 확인이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
