### PR TITLE
#122 프론트엔드 키보드 접근성 갭 해소

### DIFF
--- a/Vanadium.Note.Web/Components/QuickNavDialog.razor
+++ b/Vanadium.Note.Web/Components/QuickNavDialog.razor
@@ -9,7 +9,11 @@
 @if (Open)
 {
     <div class="quicknav-backdrop" @onclick="Close">
-        <div class="quicknav-panel" @onclick:stopPropagation="true">
+        <div class="quicknav-panel"
+             role="dialog"
+             aria-modal="true"
+             aria-label="Quick note navigation"
+             @onclick:stopPropagation="true">
             <input @ref="_input"
                    class="quicknav-input"
                    type="text"

--- a/Vanadium.Note.Web/Pages/Board.razor
+++ b/Vanadium.Note.Web/Pages/Board.razor
@@ -109,7 +109,12 @@
 @if (showDialog)
 {
     <div class="board-dialog-overlay" @onclick="CancelDialog">
-        <div class="board-dialog" @onclick:stopPropagation="true">
+        <div class="board-dialog"
+             role="dialog"
+             aria-modal="true"
+             aria-label="Add a note"
+             @ref="_dialogRef"
+             @onclick:stopPropagation="true">
             <div class="board-dialog-header">
                 <h4>New note in &ldquo;<strong>@dialogLabel?.Name</strong>&rdquo;</h4>
                 <button class="board-dialog-close" @onclick="CancelDialog">×</button>
@@ -117,10 +122,10 @@
             <input class="board-dialog-input"
                    type="text"
                    placeholder="Note title"
+                   @ref="_dialogInput"
                    @bind="newNoteTitle"
                    @bind:event="oninput"
-                   @onkeydown="OnDialogKeyDown"
-                   autofocus />
+                   @onkeydown="OnDialogKeyDown" />
             @if (string.IsNullOrWhiteSpace(newNoteTitle))
             {
                 <div class="board-dialog-hint">Title is empty — will be saved as <em>(No title)</em></div>
@@ -151,6 +156,9 @@
     private string newNoteTitle = "";
     private string? dialogError;
     private bool isAdding = false;
+    private ElementReference _dialogRef;
+    private ElementReference _dialogInput;
+    private bool _trapQueued;
 
     private LabelCategory? selectedCategory =>
         categories.FirstOrDefault(c => c.Id == selectedCategoryId);
@@ -188,6 +196,13 @@
         {
             _dotNetRef = DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("boardDragDrop.init", _dotNetRef);
+        }
+
+        if (_trapQueued)
+        {
+            _trapQueued = false;
+            await JS.InvokeVoidAsync("focusTrap.activate", _dialogRef);
+            try { await _dialogInput.FocusAsync(); } catch { /* dialog may have closed */ }
         }
     }
 
@@ -282,15 +297,17 @@
         dialogError = null;
         isAdding = false;
         showDialog = true;
+        _trapQueued = true;
     }
 
-    private void CancelDialog()
+    private async Task CancelDialog()
     {
         if (isAdding) return;
         showDialog = false;
         dialogLabel = null;
         newNoteTitle = "";
         dialogError = null;
+        await JS.InvokeVoidAsync("focusTrap.deactivate");
     }
 
     private async Task ConfirmAddNote()
@@ -312,6 +329,7 @@
                 showDialog = false;
                 dialogLabel = null;
                 newNoteTitle = "";
+                await JS.InvokeVoidAsync("focusTrap.deactivate");
             }
             else
             {
@@ -334,11 +352,13 @@
     private async Task OnDialogKeyDown(KeyboardEventArgs e)
     {
         if (e.Key == "Enter") await ConfirmAddNote();
-        else if (e.Key == "Escape") CancelDialog();
+        else if (e.Key == "Escape") await CancelDialog();
     }
 
     public async ValueTask DisposeAsync()
     {
+        if (showDialog)
+            await JS.InvokeVoidAsync("focusTrap.deactivate");
         await JS.InvokeVoidAsync("boardDragDrop.dispose");
         _dotNetRef?.Dispose();
     }

--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -66,12 +66,12 @@
                            checked="@IsAllSelected"
                            @onchange="ToggleSelectAll" />
                 </div>
-                <div class="col-title sortable" @onclick="() => SetSort(SortColumn.Title)">
+                <button type="button" class="col-title sortable" @onclick="() => SetSort(SortColumn.Title)">
                     Title @SortIcon(SortColumn.Title)
-                </div>
-                <div class="col-date sortable" @onclick="() => SetSort(SortColumn.Date)">
+                </button>
+                <button type="button" class="col-date sortable" @onclick="() => SetSort(SortColumn.Date)">
                     Modified @SortIcon(SortColumn.Date)
-                </div>
+                </button>
             </div>
             @foreach (var note in notes)
             {
@@ -105,9 +105,11 @@
                             {
                                 <span class="expand-btn-placeholder"></span>
                             }
-                            <div class="note-title-text">
+                            <a class="note-title-text"
+                               href="/editor/@note.Id"
+                               @onclick:stopPropagation="true">
                                 @(string.IsNullOrWhiteSpace(note.Title) ? "(No title)" : note.Title)
-                            </div>
+                            </a>
                             @if (note.IsArchived)
                             {
                                 <span class="archived-badge">Archived</span>
@@ -170,9 +172,11 @@
                                 <div class="col-title" @onclick="() => EditNote(child.Id)">
                                     <div class="note-title-row note-child-indent">
                                         <span class="child-indicator">└</span>
-                                        <div class="note-title-text">
+                                        <a class="note-title-text"
+                                           href="/editor/@child.Id"
+                                           @onclick:stopPropagation="true">
                                             @(string.IsNullOrWhiteSpace(child.Title) ? "(No title)" : child.Title)
-                                        </div>
+                                        </a>
                                         @if (child.ChildCount > 0)
                                         {
                                             <span class="child-count-badge">+@child.ChildCount</span>

--- a/Vanadium.Note.Web/Pages/Home.razor.css
+++ b/Vanadium.Note.Web/Pages/Home.razor.css
@@ -93,6 +93,25 @@
     color: #1b6ec2;
 }
 
+/* Sort headers are <button> for keyboard operation; strip native button chrome
+   so they render identically to the surrounding header cells. */
+button.sortable {
+    appearance: none;
+    -webkit-appearance: none;
+    background: none;
+    border: none;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    font-family: inherit;
+    font-weight: inherit;
+    color: inherit;
+}
+
+button.col-title.sortable {
+    text-align: left;
+}
+
 .col-check {
     display: flex;
     align-items: center;
@@ -300,6 +319,17 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+/* Note titles are anchors for keyboard focus/Enter; inherit list styling
+   instead of the default link color/underline. */
+a.note-title-text {
+    color: inherit;
+    text-decoration: none;
+}
+
+a.note-title-text:hover {
+    text-decoration: underline;
 }
 
 .note-parent-crumb {

--- a/Vanadium.Note.Web/wwwroot/index.html
+++ b/Vanadium.Note.Web/wwwroot/index.html
@@ -32,6 +32,7 @@
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script src="js/keyboard-shortcuts.js"></script>
+    <script src="js/focus-trap.js"></script>
     <script src="js/quick-nav.js"></script>
     <script src="js/unsaved-changes.js"></script>
     <script type="module" src="js/tiptap-editor.js"></script>

--- a/Vanadium.Note.Web/wwwroot/js/focus-trap.js
+++ b/Vanadium.Note.Web/wwwroot/js/focus-trap.js
@@ -1,0 +1,66 @@
+// Keyboard focus trap for custom (non-MudBlazor) dialogs.
+// Keeps Tab / Shift+Tab focus cycling within a container element while it is
+// active, and restores focus to the previously focused element on release.
+// Only one trap is active at a time (the app never stacks these dialogs).
+window.focusTrap = (function () {
+    let activeElement = null;
+    let previouslyFocused = null;
+
+    const FOCUSABLE_SELECTOR = [
+        'a[href]',
+        'button:not([disabled])',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        'textarea:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])'
+    ].join(',');
+
+    function getFocusable(container) {
+        return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR))
+            .filter(el => el.offsetParent !== null || el.getClientRects().length > 0);
+    }
+
+    function onKeyDown(e) {
+        if (e.key !== 'Tab' || activeElement === null) return;
+
+        const focusable = getFocusable(activeElement);
+        if (focusable.length === 0) {
+            // Nothing focusable inside — keep focus pinned to the container.
+            e.preventDefault();
+            return;
+        }
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const current = document.activeElement;
+
+        if (e.shiftKey) {
+            if (current === first || !activeElement.contains(current)) {
+                e.preventDefault();
+                last.focus();
+            }
+        } else {
+            if (current === last || !activeElement.contains(current)) {
+                e.preventDefault();
+                first.focus();
+            }
+        }
+    }
+
+    return {
+        activate: function (element) {
+            if (element === null || element === activeElement) return;
+            previouslyFocused = document.activeElement;
+            activeElement = element;
+            document.addEventListener('keydown', onKeyDown, true);
+        },
+        deactivate: function () {
+            document.removeEventListener('keydown', onKeyDown, true);
+            activeElement = null;
+            if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+                try { previouslyFocused.focus(); } catch { /* element may be gone */ }
+            }
+            previouslyFocused = null;
+        }
+    };
+})();


### PR DESCRIPTION
## 개요
Closes #122

프론트엔드 UI의 키보드 접근성 갭 4건을 해소한다. 백엔드/스키마 변경 없이 마크업·접근성 속성·포커스 처리에 한정했다.

## 변경 사항
- **Home 노트 제목 → anchor**: `note-title-text`를 `div @onclick`에서 `<a href="/editor/{id}">`로 변경(상위/하위 노트 모두). 키보드로 포커스하고 Enter로 열 수 있다. 셀 전체 클릭(마우스) 동작은 유지하되 anchor는 `@onclick:stopPropagation`으로 중복 이동을 막았다.
- **정렬 헤더 → button**: `col-title sortable` / `col-date sortable`를 `<button type="button">`으로 변경해 키보드(Enter/Space)로 정렬 토글이 가능. 스코프 CSS에서 네이티브 버튼 크롬을 제거해 기존 헤더와 동일하게 렌더된다.
- **Quick Nav 팔레트**: `quicknav-panel`에 `role="dialog"` / `aria-modal="true"` / `aria-label` 부여.
- **Board 다이얼로그 focus trap**: 신규 `wwwroot/js/focus-trap.js` 헬퍼로 Tab/Shift+Tab을 다이얼로그 내부에 순환시키고, 닫을 때 직전 포커스를 복원. 다이얼로그에 `role="dialog"`/`aria-modal`도 추가하고, 열릴 때 제목 입력에 포커스를 준다(기존 `autofocus` 대체).

## 완료 조건 검증
- [x] Home 노트 제목이 anchor로 렌더되어 키보드 포커스/Enter로 열림 — `note-title-text`가 `href` 있는 `<a>`로 변경됨(Blazor 라우터가 클라이언트 내비게이션 처리)
- [x] 정렬 헤더가 button으로 렌더되어 키보드로 정렬 토글 — `<button>` + `SetSort` 유지
- [x] QuickNavDialog에 `role="dialog"`/`aria-modal` 속성 존재
- [x] Board 다이얼로그 열림 중 Tab 포커스가 내부 유지 — `focusTrap.activate/deactivate`
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 증가(기존 NU1903 4건 동일), `dotnet test` 81 통과/0 실패

## 참고
- Web 프로젝트에는 테스트 인프라가 없어 자동화 테스트는 추가하지 않았다(REST 테스트 81건은 회귀 없음 확인). 키보드 조작은 수동 확인이 필요하다.
