### PR TITLE
#130 노트 동시성 검사를 DB 레벨 토큰으로 전환

### DIFF
--- a/Vanadium.Note.REST.Tests/NoteConcurrencyTests.cs
+++ b/Vanadium.Note.REST.Tests/NoteConcurrencyTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Vanadium.Note.REST.Data;
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Concurrency tests for issue #130: NoteItem.UpdatedAt is a DB-level EF Core
+/// concurrency token (<see cref="System.ComponentModel.DataAnnotations.ConcurrencyCheckAttribute"/>),
+/// so a stale write is rejected by the UPDATE's WHERE clause rather than an
+/// in-memory read-then-write compare. Behavior is provider-independent (the
+/// token rides in the generated SQL), so the SQLite in-memory host is faithful.
+/// </summary>
+public class NoteConcurrencyTests
+{
+    // ── The token is enforced by the database, not by an in-memory compare ────
+
+    [Fact]
+    public async Task ConcurrencyToken_ConcurrentModification_ThrowsDbUpdateConcurrencyException()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NoteDbContext>().UseSqlite(connection).Options;
+
+        Guid id;
+        using (var seed = new NoteDbContext(options))
+        {
+            seed.Database.EnsureCreated();
+            var n = new NoteItem
+            {
+                Title = "Seed",
+                UpdatedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            };
+            seed.Notes.Add(n);
+            await seed.SaveChangesAsync();
+            id = n.Id;
+        }
+
+        // Context A loads the row; its original token value is the seeded one.
+        using var ctxA = new NoteDbContext(options);
+        var a = await ctxA.Notes.FirstAsync(n => n.Id == id);
+
+        // A concurrent writer (context B) wins the race and bumps UpdatedAt.
+        using (var ctxB = new NoteDbContext(options))
+        {
+            var b = await ctxB.Notes.FirstAsync(n => n.Id == id);
+            b.Title = "Won the race";
+            b.UpdatedAt = new DateTime(2026, 2, 2, 0, 0, 0, DateTimeKind.Utc);
+            await ctxB.SaveChangesAsync();
+        }
+
+        // A now saves its stale copy: the token in the WHERE clause matches 0 rows.
+        a.Title = "Lost the race";
+        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => ctxA.SaveChangesAsync());
+    }
+
+    // ── Service surface: the 409 Conflict path is preserved ──────────────────
+
+    [Fact]
+    public async Task Update_StaleClientVersion_ReturnsConflict_AndLeavesNoteUnchanged()
+    {
+        using var h = new TestHost();
+        var note = await h.CreateNoteAsync("Original", content: "<p>original</p>");
+
+        // The client claims a version the server row never had.
+        var stale = note.UpdatedAt.AddSeconds(-5);
+        var (updated, conflict, archived) = await h.Notes.Update(note.Id,
+            new NoteItem { Title = "Changed", Content = "<p>changed</p>", UpdatedAt = stale });
+
+        Assert.Null(updated);
+        Assert.True(conflict);
+        Assert.False(archived);
+
+        var fresh = await h.FindAsync(note.Id);
+        Assert.Equal("Original", fresh!.Title);
+    }
+
+    [Fact]
+    public async Task Update_MatchingClientVersion_Succeeds_AndAdvancesVersion()
+    {
+        using var h = new TestHost();
+        var note = await h.CreateNoteAsync("Original", content: "<p>original</p>");
+
+        var (updated, conflict, archived) = await h.Notes.Update(note.Id,
+            new NoteItem { Title = "Changed", Content = "<p>changed</p>", UpdatedAt = note.UpdatedAt });
+
+        Assert.False(conflict);
+        Assert.False(archived);
+        Assert.NotNull(updated);
+        Assert.Equal("Changed", updated!.Title);
+        // The version stamp is refreshed on save and never moves backward.
+        // (Not asserted strictly greater: DateTime.UtcNow can return the same
+        // tick for two saves that land within the system timer's resolution.)
+        Assert.True(updated.UpdatedAt >= note.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task Update_DefaultVersion_ForceSaves_BypassingTheConflictCheck()
+    {
+        using var h = new TestHost();
+        var note = await h.CreateNoteAsync("Original", content: "<p>original</p>");
+
+        // A default UpdatedAt is the intentional force-save bypass.
+        var (updated, conflict, archived) = await h.Notes.Update(note.Id,
+            new NoteItem { Title = "Force", Content = "<p>f</p>", UpdatedAt = default });
+
+        Assert.False(conflict);
+        Assert.False(archived);
+        Assert.NotNull(updated);
+        Assert.Equal("Force", updated!.Title);
+    }
+}

--- a/Vanadium.Note.REST/Migrations/20260709082457_AddNoteConcurrencyToken.Designer.cs
+++ b/Vanadium.Note.REST/Migrations/20260709082457_AddNoteConcurrencyToken.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Vanadium.Note.REST.Data;
@@ -11,9 +12,11 @@ using Vanadium.Note.REST.Data;
 namespace Vanadium.Note.REST.Migrations
 {
     [DbContext(typeof(NoteDbContext))]
-    partial class NoteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709082457_AddNoteConcurrencyToken")]
+    partial class AddNoteConcurrencyToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Vanadium.Note.REST/Migrations/20260709082457_AddNoteConcurrencyToken.cs
+++ b/Vanadium.Note.REST/Migrations/20260709082457_AddNoteConcurrencyToken.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Vanadium.Note.REST.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNoteConcurrencyToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Vanadium.Note.REST/Models/NoteItem.cs
+++ b/Vanadium.Note.REST/Models/NoteItem.cs
@@ -13,6 +13,11 @@ public class NoteItem
     public string Content { get; set; } = string.Empty;
     [JsonIgnore]
     public string ContentText { get; set; } = string.Empty;
+    // DB-level optimistic concurrency token: EF Core appends UpdatedAt to the
+    // WHERE clause of every UPDATE/DELETE, so a stale write affects 0 rows and
+    // raises DbUpdateConcurrencyException instead of silently clobbering a
+    // concurrent edit (closes the read-then-write TOCTOU window in Update).
+    [ConcurrencyCheck]
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>Null = active. Non-null marks the note as soft-deleted and is the purge clock.</summary>

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -238,17 +238,13 @@ public class NoteService(
             return (null, false, true);
         }
 
-        // Optimistic concurrency: reject if the client's known version differs from DB,
-        // unless UpdatedAt is default (force-save bypass).
-        if (note.UpdatedAt != default && existing.UpdatedAt != note.UpdatedAt)
-        {
-            logger.LogWarning(
-                "Conflict on note {NoteId}: client has {ClientVersion}, server has {ServerVersion}.",
-                id, note.UpdatedAt, existing.UpdatedAt);
-            return (null, true, false);
-        }
-
         var titleChanged = existing.Title != note.Title;
+
+        // Capture the client's claimed version before mutating the tracked row:
+        // callers may hand us the tracked entity itself as `note`, so reading
+        // note.UpdatedAt after the stamp below would read the new value, not the
+        // version the client actually knew.
+        var clientVersion = note.UpdatedAt;
 
         existing.Title = note.Title;
         // Sanitize on the update path too — a leaked PAT could otherwise store a
@@ -258,7 +254,28 @@ public class NoteService(
         existing.ContentText = StripHtml(note.Content);
         existing.ParentNoteId = note.ParentNoteId;
         existing.UpdatedAt = UtcNowMicroseconds();
-        await db.SaveChangesAsync();
+
+        // Optimistic concurrency: when the client sent the version it last saw,
+        // pin it as the concurrency token's original value so EF enforces the
+        // check in the UPDATE's WHERE clause at the DB level — the DB, not an
+        // in-memory compare, decides the conflict, so a write racing between our
+        // read and save can no longer be lost. A default version is the
+        // force-save bypass: leave the token at the freshly-read DB value so the
+        // save proceeds (only a genuine mid-flight race can still conflict it).
+        if (clientVersion != default)
+            db.Entry(existing).Property(e => e.UpdatedAt).OriginalValue = clientVersion;
+
+        try
+        {
+            await db.SaveChangesAsync();
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            logger.LogWarning(
+                "Conflict on note {NoteId}: client version {ClientVersion} no longer matches the server row.",
+                id, note.UpdatedAt);
+            return (null, true, false);
+        }
 
         if (titleChanged)
             await UpdatePageLinkReferences(id, note.Title);


### PR DESCRIPTION
## 목적
`NoteService.Update`의 낙관적 동시성 검사가 애플리케이션 레벨의 인메모리 read-then-write 비교였다. DB에서 행을 읽어 온 뒤 메모리에서 `existing.UpdatedAt != note.UpdatedAt`를 비교했기 때문에, 읽기와 쓰기 사이 TOCTOU 구간에서 동시 수정(lost update)을 놓칠 수 있었다. 이를 DB 레벨 동시성 토큰으로 전환한다.

## 변경 내용
- `NoteItem.UpdatedAt`에 `[ConcurrencyCheck]`를 추가 → EF Core가 UPDATE/DELETE의 `WHERE` 절에 `UpdatedAt`을 포함시켜, stale 쓰기는 0행에 매칭되어 `DbUpdateConcurrencyException`을 던진다.
- `NoteService.Update`: 클라이언트가 알고 있던 버전을 토큰의 `OriginalValue`로 지정하고 `DbUpdateConcurrencyException`을 잡아 기존과 동일한 409 Conflict 경로로 변환한다. 인메모리 비교를 제거하고 판정을 DB에 위임했다.
  - 클라이언트가 tracked 엔티티를 그대로 넘기는 호출 패턴을 고려해, 스탬프를 갱신하기 **전에** 클라이언트 버전을 캡처한다.
  - `UpdatedAt`이 `default`인 강제 저장은 토큰을 DB 값 그대로 두어 기존 우회 동작을 유지한다(실제 mid-flight 경쟁일 때만 충돌).
- 마이그레이션 `AddNoteConcurrencyToken` 추가. 토큰은 모델 메타데이터라 DDL은 없고, 모델 스냅샷에 `IsConcurrencyToken`을 기록한다.

## 완료 조건 검증
- [x] `NoteItem.UpdatedAt`이 EF Core 동시성 토큰으로 구성됨 — `[ConcurrencyCheck]` 적용, 스냅샷에 `.IsConcurrencyToken()` 기록. `ConcurrencyToken_ConcurrentModification_ThrowsDbUpdateConcurrencyException` 테스트가 두 컨텍스트 경쟁에서 DB 레벨 예외 발생을 확인.
- [x] 동시 수정 시 DB 레벨 동시성 검사로 409 Conflict 경로 유지/보강 — `Update_StaleClientVersion_ReturnsConflict_AndLeavesNoteUnchanged`(오래된 버전 → conflict), `Update_MatchingClientVersion_Succeeds_AndAdvancesVersion`(일치 → 성공), `Update_DefaultVersion_ForceSaves_...`(강제 저장 유지). 컨트롤러의 `conflict → Conflict(...)` 경로 불변.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 통과(신규 경고 없음).
- [x] EF Core 마이그레이션 추가 — `20260709082457_AddNoteConcurrencyToken`.

전체 테스트: `dotnet test Vanadium.slnx` → 85 통과 / 3 스킵(PostgreSQL 전용).

## 범위 밖 (준수)
- 프론트엔드 충돌 UX 변경 없음.
- 다른 엔티티(Label/Settings 등) 동시성 처리 미변경.

Closes #130