### PR TITLE
#172 Microsoft.OpenApi 2.7.5 고정으로 GHSA-v5pm-xwqc-g5wc 취약점 해소

### DIFF
--- a/Vanadium.Note.REST/Vanadium.Note.REST.csproj
+++ b/Vanadium.Note.REST/Vanadium.Note.REST.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
+    <!-- Pinned to patch GHSA-v5pm-xwqc-g5wc; Swashbuckle.AspNetCore 10.1.7 pulls in the vulnerable 2.4.1 transitively. -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Closes #172

## 목적
`Swashbuckle.AspNetCore` 10.1.7이 전이(transitive)로 끌어오는 `Microsoft.OpenApi` **2.4.1**이 높음 심각도 취약점 [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc)(Circular schema references may terminate OpenAPI parsing)에 해당한다.

## 변경 내용
- `Vanadium.Note.REST.csproj`에 패치 버전 `Microsoft.OpenApi` **2.7.5**를 명시적 `PackageReference`로 고정.
  - 2.x 라인의 최초 패치 버전이 2.7.5 (advisory: `>= 2.0.0-preview.11, <= 2.7.4` 취약).
  - Swashbuckle이 기대하는 2.x 메이저를 그대로 유지 → Swagger 호환성 리스크 최소화. (Swashbuckle 자체 업그레이드/라이브러리 교체는 하지 않음 — 범위 밖.)
  - Tests 프로젝트도 프로젝트 참조를 통해 2.7.5로 전이 해소됨.

## 완료 조건 검증
- [x] **취약 버전 미해소**: `dotnet list package --include-transitive`에서 두 프로젝트 모두 `Microsoft.OpenApi 2.7.5` 확인. 빌드의 `NU1903` 경고 4개 → 0개.
- [x] **`/swagger` 정상 동작**: `dotnet run` 후 실측 — `/swagger/index.html` HTTP 200, `/swagger/v1/swagger.json` HTTP 200 (유효한 `openapi 3.0.4`, 28개 경로 렌더링).
- [x] **빌드 클린**: `dotnet build Vanadium.slnx` 경고 0 / 오류 0. `dotnet test Vanadium.slnx` 85 통과 / 3 건너뜀 / 0 실패.