### PR TITLE
#123 확인 UX를 공유 ConfirmDialog로 통일

### DIFF
--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -2,7 +2,7 @@
 @attribute [Authorize]
 @inject NoteService NoteService
 @inject NavigationManager Nav
-@inject IJSRuntime JS
+@inject ConfirmService Confirm
 @inject ILogger<Home> Logger
 @inject ISnackbar Snackbar
 @inject KeyboardShortcutService ShortcutService
@@ -442,8 +442,7 @@
             ? $"Move {selectedIds.Count} note(s) to the Recycle Bin? Sub-notes will be moved too. Items in the Recycle Bin are deleted permanently after 30 days."
             : $"Move {selectedIds.Count} selected note(s) to the Recycle Bin?";
 
-        var confirmed = await JS.InvokeAsync<bool>("confirm", message);
-        if (!confirmed) return;
+        if (!await Confirm.ConfirmAsync("Move to Recycle Bin", message, "Move to Recycle Bin")) return;
 
         Logger.LogInformation("Moving {Count} note(s) to recycle bin.", selectedIds.Count);
         var deletedIds = new List<Guid>();
@@ -501,8 +500,7 @@
         var message = note.ChildCount > 0
             ? "Archive this note? Sub-notes will be archived too. Archived notes are read-only and kept indefinitely."
             : "Archive this note? Archived notes are read-only and kept indefinitely.";
-        var confirmed = await JS.InvokeAsync<bool>("confirm", message);
-        if (!confirmed) return;
+        if (!await Confirm.ConfirmAsync("Archive note", message, "Archive", Color.Warning)) return;
 
         var result = await NoteService.ArchiveAsync(note.Id);
         if (!result.IsSuccess)

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -12,6 +12,7 @@
 @inject ILogger<NoteEditor> Logger
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
+@inject ConfirmService Confirm
 @inject KeyboardShortcutService ShortcutService
 @inject QuickNavService QuickNav
 @inject DraftStore DraftStore
@@ -608,16 +609,11 @@
         _autoSave.Cancel();
         if (Id is not null)
         {
-            var parts = new List<string>();
-            if (childCount > 0)
-                parts.Add($"This note has {childCount} sub-note(s) that will be moved to the Recycle Bin too.");
-
-            if (parts.Count > 0)
-            {
-                parts.Add("Move this note to the Recycle Bin? Items in the Recycle Bin are deleted permanently after 30 days.");
-                var confirmed = await JS.InvokeAsync<bool>("confirm", string.Join("\n\n", parts));
-                if (!confirmed) return;
-            }
+            var message = childCount > 0
+                ? $"This note has {childCount} sub-note(s) that will be moved to the Recycle Bin too. Move this note to the Recycle Bin? Items in the Recycle Bin are deleted permanently after 30 days."
+                : "Move this note to the Recycle Bin? Items in the Recycle Bin are deleted permanently after 30 days.";
+            if (!await Confirm.ConfirmAsync("Move to Recycle Bin", message, "Move to Recycle Bin"))
+                return;
 
             var noteId = Id.Value;
             var result = await NoteService.DeleteAsync(noteId);
@@ -659,9 +655,10 @@
     {
         if (Id is null) return;
 
-        var confirmed = await JS.InvokeAsync<bool>("confirm",
-            "Archive this note? Sub-notes will be archived too. Archived notes are read-only and kept indefinitely.");
-        if (!confirmed) return;
+        if (!await Confirm.ConfirmAsync("Archive note",
+            "Archive this note? Sub-notes will be archived too. Archived notes are read-only and kept indefinitely.",
+            "Archive", Color.Warning))
+            return;
 
         // Flush any pending edits before the note becomes read-only.
         _autoSave.Cancel();


### PR DESCRIPTION
Closes #123

## 목적
확인(confirmation) UX가 네이티브 `window.confirm()`과 스타일드 `ConfirmDialog`로 갈려 있어 일관성이 없었다. 모든 확인 흐름을 공유 `ConfirmService`(스타일드 `ConfirmDialog` 래퍼)로 통일한다.

## 변경 사항
- `Home.razor`, `NoteEditor.razor`에 남아 있던 네이티브 `window.confirm()` 호출 4곳을 모두 `ConfirmService.ConfirmAsync(...)`로 교체 (`ConfirmService`는 이슈 #124에서 도입된 기존 공유 서비스이며 Archive/RecycleBin/Settings가 이미 사용 중).
- `NoteEditor.DeleteNote`가 자식(sub-note) 유무와 관계없이 항상 확인 다이얼로그를 노출하도록 변경 (기존에는 `childCount > 0`일 때만 확인).
- 확인 메시지가 사라져 미사용이 된 `Home.razor`의 `@inject IJSRuntime JS` 제거.
- 삭제 계열은 기본 `Color.Error`, 아카이브(되돌릴 수 있는 동작)는 `Color.Warning` 버튼으로 노출.

## 범위
- 프론트엔드 확인 흐름 한정. 백엔드/스키마 변경 없음.
- "단어 입력형" 특수 확인(`DeleteAllDataDialog`)은 그대로 유지.

## 완료 조건 검증
- [x] 확인 다이얼로그가 공유 `ConfirmService`/`ConfirmDialog`를 통해 일관된 스타일로 노출 — 변경된 4곳 모두 `Confirm.ConfirmAsync` 경유
- [x] 네이티브 `window.confirm` 호출 제거 — `grep '"confirm"' Vanadium.Note.Web/**/*.razor` 결과 없음
- [x] 자식 없는 노트 삭제 시에도 확인 — `DeleteNote`에서 메시지를 무조건 계산하고 `ConfirmAsync`를 항상 호출
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0개 / `dotnet test Vanadium.slnx` 85 통과, 3 스킵(PostgreSQL 전용)

> 참고: Web(Blazor) 프로젝트에는 테스트 프로젝트가 없어(문서화된 알려진 한계) 프론트엔드 회귀 테스트는 추가하지 않았다.