### PR TITLE
#131 async void 인증 상태 핸들러를 try/catch로 감싸 안전하게 처리

### DIFF
--- a/Vanadium.Note.Web/Layout/MainLayout.razor
+++ b/Vanadium.Note.Web/Layout/MainLayout.razor
@@ -5,6 +5,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @inject KeyboardShortcutService ShortcutService
 @inject NavigationManager Nav
+@inject ILogger<MainLayout> Logger
 @implements IAsyncDisposable
 
 <MudThemeProvider IsDarkMode="_isDarkMode" />
@@ -122,13 +123,22 @@
         InvokeAsync(StateHasChanged);
     }
 
+    // async void handler: exceptions cannot be observed by a caller, so they
+    // must be caught here — an unhandled throw would tear down the renderer.
     private async void OnAuthStateChanged(Task<AuthenticationState> task)
     {
-        var state = await task;
-        if (state.User.Identity?.IsAuthenticated == true)
-            await LoadThemeAsync();
-        else
-            await ApplyThemeAsync("system");
+        try
+        {
+            var state = await task;
+            if (state.User.Identity?.IsAuthenticated == true)
+                await LoadThemeAsync();
+            else
+                await ApplyThemeAsync("system");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to handle authentication state change.");
+        }
     }
 
     private async Task LoadThemeAsync()

--- a/Vanadium.Note.Web/Layout/NavMenu.razor
+++ b/Vanadium.Note.Web/Layout/NavMenu.razor
@@ -3,6 +3,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @inject Vanadium.Note.Web.Auth.AuthService AuthService
 @inject NavigationManager Navigation
+@inject ILogger<NavMenu> Logger
 
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
@@ -83,11 +84,20 @@
         await UpdateUsernameAsync();
     }
 
+    // async void handler: exceptions cannot be observed by a caller, so they
+    // must be caught here — an unhandled throw would tear down the renderer.
     private async void OnAuthStateChanged(Task<AuthenticationState> task)
     {
-        var state = await task;
-        _username = GetUsername(state);
-        await InvokeAsync(StateHasChanged);
+        try
+        {
+            var state = await task;
+            _username = GetUsername(state);
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to handle authentication state change.");
+        }
     }
 
     private async Task UpdateUsernameAsync()


### PR DESCRIPTION
## 개요
`MainLayout` 과 `NavMenu` 의 `async void OnAuthStateChanged` 인증 상태 핸들러를 try/catch 로 감싸, `async void` 특성상 관찰되지 않던 예외를 잡아 로깅하고 안전하게 처리하도록 수정합니다.

`async void` 핸들러에서 던져진 예외는 호출자가 관찰할 수 없어 처리되지 않은 채 전파되면 Blazor 렌더러/서킷을 불안정하게 만들 수 있습니다. 두 핸들러 모두 예외를 삼키고 `ILogger.LogError` 로 기록해 앱이 계속 동작하도록 합니다.

## 변경 내용
- `Vanadium.Note.Web/Layout/MainLayout.razor` — `OnAuthStateChanged` 본문을 try/catch 로 래핑, `@inject ILogger<MainLayout>` 추가
- `Vanadium.Note.Web/Layout/NavMenu.razor` — `OnAuthStateChanged` 본문을 try/catch 로 래핑, `@inject ILogger<NavMenu>` 추가

기존 프로젝트의 로깅 컨벤션(`@inject ILogger<T>` + `Logger.LogError(ex, ...)`, Archive/Board/Home.razor)을 따랐습니다.

## 완료 조건 검증
- [x] 두 핸들러 본문이 try/catch로 감싸져 예외가 처리된다 — 두 파일 모두 try/catch 래핑 확인
- [x] 인증 상태 변경 중 예외가 발생해도 앱이 계속 동작한다 — catch 블록에서 `LogError` 후 반환, 예외가 렌더러로 전파되지 않음
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0개 / 오류 0개
- 추가로 `dotnet test Vanadium.slnx` 통과(85 통과, 3 스킵 = 기존 PostgreSQL 전용)

## 범위
- 구독/해제 로직 미변경, `async void` → `EventCallback` 등 구조 변경 없음 (요청된 최소 변경: try/catch 래핑)
- 변경 파일은 대상 2개 razor 파일뿐

## 참고
Web 프로젝트는 테스트 프로젝트가 없어 razor 컴포넌트 단위 테스트는 추가하지 않았습니다(CLAUDE.md 명시).

Closes #131
