### PR TITLE
#127 에러 응답을 RFC 7807 ProblemDetails로 표준화

### DIFF
--- a/Vanadium.Note.REST.Tests/ArchiveControllerTests.cs
+++ b/Vanadium.Note.REST.Tests/ArchiveControllerTests.cs
@@ -91,7 +91,9 @@ public class ArchiveControllerTests
         var result = await controller.Create(
             new NoteItem { Title = "Orphan", Content = "", ParentNoteId = parent.Id });
 
-        Assert.IsType<BadRequestObjectResult>(result.Result);
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+        Assert.IsType<ProblemDetails>(objectResult.Value);
     }
 
     [Fact]
@@ -111,7 +113,9 @@ public class ArchiveControllerTests
             UpdatedAt = default
         });
 
-        Assert.IsType<BadRequestObjectResult>(result.Result);
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+        Assert.IsType<ProblemDetails>(objectResult.Value);
     }
 
     [Fact]
@@ -146,7 +150,9 @@ public class ArchiveControllerTests
 
         var result = await controller.DeletePermanent(note.Id);
 
-        Assert.IsType<ConflictObjectResult>(result);
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status409Conflict, objectResult.StatusCode);
+        Assert.IsType<ProblemDetails>(objectResult.Value);
     }
 
     [Fact]

--- a/Vanadium.Note.REST/Controllers/AuthController.cs
+++ b/Vanadium.Note.REST/Controllers/AuthController.cs
@@ -44,7 +44,7 @@ public class AuthController(
         if (!PasswordHasher.Verify(request.Password, storedHash))
         {
             logger.LogWarning("Failed login attempt.");
-            return Unauthorized(new { message = "Invalid password." });
+            return Problem(detail: "Invalid password.", statusCode: StatusCodes.Status401Unauthorized);
         }
 
         var token = GenerateJwtToken();

--- a/Vanadium.Note.REST/Controllers/FilesController.cs
+++ b/Vanadium.Note.REST/Controllers/FilesController.cs
@@ -40,19 +40,19 @@ public class FilesController(IWebHostEnvironment env, NoteDbContext db, ILogger<
     public async Task<ActionResult> Upload([FromForm] FileUploadRequest request)
     {
         if (request.File is null || request.File.Length == 0)
-            return BadRequest("No file provided.");
+            return Problem(detail: "No file provided.", statusCode: StatusCodes.Status400BadRequest);
 
         if (!AllowedContentTypes.Contains(request.File.ContentType))
         {
             logger.LogWarning("File upload rejected: unsupported content type '{ContentType}'", request.File.ContentType);
-            return BadRequest($"File type '{request.File.ContentType}' is not allowed.");
+            return Problem(detail: $"File type '{request.File.ContentType}' is not allowed.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         if (!await HasValidMagicBytesAsync(request.File, request.File.ContentType))
         {
             logger.LogWarning("File upload rejected: magic bytes mismatch for '{ContentType}' ('{FileName}')",
                 request.File.ContentType, request.File.FileName);
-            return BadRequest("File content does not match the declared file type.");
+            return Problem(detail: "File content does not match the declared file type.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         var originalName = Path.GetFileName(request.File.FileName);

--- a/Vanadium.Note.REST/Controllers/ImagesController.cs
+++ b/Vanadium.Note.REST/Controllers/ImagesController.cs
@@ -22,14 +22,14 @@ public class ImagesController(IWebHostEnvironment env, ILogger<ImagesController>
     public async Task<ActionResult> Upload([FromForm] ImageUploadRequest request)
     {
         if (request.File is null || request.File.Length == 0)
-            return BadRequest("No file provided.");
+            return Problem(detail: "No file provided.", statusCode: StatusCodes.Status400BadRequest);
 
         var imageType = await DetectImageTypeAsync(request.File);
         if (imageType is null)
         {
             logger.LogWarning("Image upload rejected: unrecognized format '{FileName}' ({ContentType})",
                 request.File.FileName, request.File.ContentType);
-            return BadRequest("File is not a supported image (JPEG, PNG, GIF, WebP).");
+            return Problem(detail: "File is not a supported image (JPEG, PNG, GIF, WebP).", statusCode: StatusCodes.Status400BadRequest);
         }
 
         logger.LogInformation("Image upload requested: '{FileName}' ({Size} bytes, {ContentType})",

--- a/Vanadium.Note.REST/Controllers/LabelsController.cs
+++ b/Vanadium.Note.REST/Controllers/LabelsController.cs
@@ -28,7 +28,7 @@ public class LabelsController(LabelService labelService, ILogger<LabelsControlle
         catch (InvalidOperationException ex)
         {
             logger.LogWarning("Duplicate label category: '{Name}'", req.Name);
-            return Conflict(new { error = ex.Message });
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
         }
     }
 
@@ -62,7 +62,7 @@ public class LabelsController(LabelService labelService, ILogger<LabelsControlle
         catch (InvalidOperationException ex)
         {
             logger.LogWarning("Duplicate label: '{Name}'", req.Name);
-            return Conflict(new { error = ex.Message });
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
         }
     }
 

--- a/Vanadium.Note.REST/Controllers/NotesController.cs
+++ b/Vanadium.Note.REST/Controllers/NotesController.cs
@@ -26,7 +26,7 @@ public class NotesController(NoteService noteService, LabelService labelService,
         page = Math.Max(1, page);
         pageSize = Math.Clamp(pageSize, 1, 200);
         if (labelIds is { Length: > 50 })
-            return BadRequest("Too many label IDs (maximum 50).");
+            return Problem(detail: "Too many label IDs (maximum 50).", statusCode: StatusCodes.Status400BadRequest);
         var result = await noteService.GetPaged(page, pageSize, search, sortBy, sortDir, labelIds);
         if (includeLabels)
             result.Labels = await labelService.GetAllLabelsAsync();
@@ -60,7 +60,7 @@ public class NotesController(NoteService noteService, LabelService labelService,
         [FromQuery] Guid[]? labelIds = null)
     {
         if (labelIds is { Length: > 50 })
-            return BadRequest("Too many label IDs (maximum 50).");
+            return Problem(detail: "Too many label IDs (maximum 50).", statusCode: StatusCodes.Status400BadRequest);
         return Ok(await noteService.GetAllSummaries(labelIds));
     }
 
@@ -88,7 +88,7 @@ public class NotesController(NoteService noteService, LabelService labelService,
         if (note.ParentNoteId.HasValue && !await IsActiveNote(note.ParentNoteId.Value))
         {
             logger.LogWarning("Create rejected — parent note {ParentNoteId} not found, archived, or in recycle bin.", note.ParentNoteId);
-            return BadRequest("Parent note does not exist, is archived, or is in the recycle bin.");
+            return Problem(detail: "Parent note does not exist, is archived, or is in the recycle bin.", statusCode: StatusCodes.Status400BadRequest);
         }
         var created = await noteService.Create(note);
         logger.LogInformation("Note created: {NoteId}", created.Id);
@@ -103,17 +103,17 @@ public class NotesController(NoteService noteService, LabelService labelService,
             if (note.ParentNoteId.Value == id)
             {
                 logger.LogWarning("Update rejected — note {NoteId} cannot be its own parent.", id);
-                return BadRequest("A note cannot be its own parent.");
+                return Problem(detail: "A note cannot be its own parent.", statusCode: StatusCodes.Status400BadRequest);
             }
             if (await noteService.HasCircularReference(id, note.ParentNoteId.Value))
             {
                 logger.LogWarning("Update rejected — circular parent reference detected for note {NoteId}.", id);
-                return BadRequest("Setting this parent would create a circular reference.");
+                return Problem(detail: "Setting this parent would create a circular reference.", statusCode: StatusCodes.Status400BadRequest);
             }
             if (!await IsActiveNote(note.ParentNoteId.Value))
             {
                 logger.LogWarning("Update rejected — parent note {ParentNoteId} not found, archived, or in recycle bin.", note.ParentNoteId);
-                return BadRequest("Parent note does not exist, is archived, or is in the recycle bin.");
+                return Problem(detail: "Parent note does not exist, is archived, or is in the recycle bin.", statusCode: StatusCodes.Status400BadRequest);
             }
         }
 
@@ -123,7 +123,9 @@ public class NotesController(NoteService noteService, LabelService labelService,
                 detail: "Note is archived and read-only.",
                 statusCode: StatusCodes.Status403Forbidden);
         if (conflict)
-            return Conflict(new { message = "The note was modified by another session. Reload to get the latest version." });
+            return Problem(
+                detail: "The note was modified by another session. Reload to get the latest version.",
+                statusCode: StatusCodes.Status409Conflict);
         if (updated is null)
         {
             logger.LogWarning("Update failed — note {NoteId} not found", id);
@@ -213,7 +215,9 @@ public class NotesController(NoteService noteService, LabelService labelService,
         if (!wasInRecycleBin)
         {
             logger.LogWarning("Permanent delete rejected — note {NoteId} is not in recycle bin", id);
-            return Conflict(new { message = "Note is not in the recycle bin. Move it to the recycle bin before deleting permanently." });
+            return Problem(
+                detail: "Note is not in the recycle bin. Move it to the recycle bin before deleting permanently.",
+                statusCode: StatusCodes.Status409Conflict);
         }
         logger.LogInformation("Note permanently deleted: {NoteId}", id);
         return NoContent();

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -131,6 +131,10 @@ builder.Services.AddRateLimiter(options =>
 });
 
 builder.Services.AddControllers();
+// Unify error responses on RFC 7807 ProblemDetails: controllers already emit
+// ProblemDetails via Problem()/ValidationProblem(), and this registration lets the
+// global exception handler below render the same shape through IProblemDetailsService.
+builder.Services.AddProblemDetails();
 builder.Services.AddSingleton<IHtmlSanitizerService, HtmlSanitizerService>();
 builder.Services.AddScoped<NoteService>();
 builder.Services.AddScoped<LabelService>();
@@ -190,8 +194,32 @@ app.UseExceptionHandler(errorApp =>
         if (feature?.Error is not null)
             logger.LogError(feature.Error, "Unhandled exception: {Method} {Path}",
                 context.Request.Method, context.Request.Path);
-        context.Response.StatusCode = 500;
-        await context.Response.WriteAsJsonAsync(new { error = "An unexpected error occurred." });
+
+        context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+
+        // Respond with RFC 7807 ProblemDetails, matching the controllers' error contract.
+        // The message is deliberately generic — internal exception details are logged, not exposed.
+        var problemDetailsService = context.RequestServices.GetRequiredService<IProblemDetailsService>();
+        var written = await problemDetailsService.TryWriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = context,
+            ProblemDetails =
+            {
+                Status = StatusCodes.Status500InternalServerError,
+                Title = "An unexpected error occurred.",
+            }
+        });
+
+        // Fallback for the rare case the writer declines (e.g. no acceptable content type):
+        // still emit a ProblemDetails body so the error contract holds unconditionally.
+        if (!written)
+        {
+            await context.Response.WriteAsJsonAsync(new Microsoft.AspNetCore.Mvc.ProblemDetails
+            {
+                Status = StatusCodes.Status500InternalServerError,
+                Title = "An unexpected error occurred.",
+            }, options: (System.Text.Json.JsonSerializerOptions?)null, contentType: "application/problem+json");
+        }
     });
 });
 

--- a/Vanadium.Note.Web/Services/LabelService.cs
+++ b/Vanadium.Note.Web/Services/LabelService.cs
@@ -155,8 +155,9 @@ public class LabelService(HttpClient http, ILogger<LabelService> logger)
         try
         {
             var json = await response.Content.ReadFromJsonAsync<JsonElement>();
-            if (json.TryGetProperty("error", out var err))
-                return err.GetString() ?? "An error occurred.";
+            // Error responses are RFC 7807 ProblemDetails; the human-readable message lives in "detail".
+            if (json.TryGetProperty("detail", out var detail) && detail.ValueKind == JsonValueKind.String)
+                return detail.GetString() ?? "An error occurred.";
         }
         catch { }
         return "An error occurred.";


### PR DESCRIPTION
Closes #127

## 목적
백엔드 컨트롤러의 에러 응답 형식이 혼재되어 있어(RFC 7807 ProblemDetails, bare-string, `{ message }`, `{ error }`, 본문 없는 404) 클라이언트가 일관된 에러 계약에 의존할 수 없던 문제를 해결한다. 모든 에러 응답을 RFC 7807 `ProblemDetails`로 통일한다.

## 변경 내용
- **컨트롤러** — 비표준 에러 본문을 모두 `Problem(...)`로 통일 (HTTP 상태 코드는 그대로 유지, 본문 형식만 표준화):
  - `NotesController` — bare-string `BadRequest(...)` 6곳(400), `Conflict(new { message })` 2곳(409)
  - `AuthController` — `Unauthorized(new { message })` (401)
  - `LabelsController` — `Conflict(new { error })` 2곳(409)
  - `FilesController` — bare-string `BadRequest(...)` 3곳(400)
  - `ImagesController` — bare-string `BadRequest(...)` 2곳(400)
  - 본문 없는 `NotFound()`는 그대로 유지 — `[ApiController]` 규약이 자동으로 ProblemDetails 본문으로 매핑한다.
- **전역 예외 핸들러** (`Program.cs`) — `{ error = ... }` 500 응답을 `ProblemDetails`로 변경. `AddProblemDetails()`를 등록하고 `IProblemDetailsService`로 렌더링(콘텐츠 협상 실패 시 직접 쓰기 폴백 포함).
- **프론트엔드** (`LabelService`) — 라벨/카테고리 중복 409 메시지를 `{ error }` 대신 ProblemDetails `detail`에서 읽도록 조정.

## 완료 조건 검증
- [x] 모든 컨트롤러 에러 응답이 ProblemDetails 형식 — bare-string / `{ message }` / `{ error }` 혼재 제거 (`grep`으로 잔존 없음 확인)
- [x] 전역 500 예외 핸들러도 ProblemDetails로 응답
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0
- [x] 테스트 통과 — `dotnet test` 85 통과 / 3 스킵(PostgreSQL 전용). `ArchiveControllerTests`의 400/409 케이스를 `ProblemDetails` 본문 검증으로 강화.

## 범위 밖 준수
- HTTP 상태 코드 매핑(400/403/404/409/500)은 변경하지 않음 — 본문 형식만 표준화.
- 프론트엔드는 이슈에서 예고된 대로 ProblemDetails 스키마에 맞춰 함께 조정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)