### PR TITLE
#128 Home/Board 로드 실패·로딩 상태 UI 추가

### DIFF
--- a/Vanadium.Note.Web/Pages/Board.razor
+++ b/Vanadium.Note.Web/Pages/Board.razor
@@ -32,7 +32,11 @@
         </div>
     </div>
 
-    @if (selectedCategory is null || !selectedCategory.Labels.Any())
+    @if (isLoading && !notes.Any())
+    {
+        <p class="board-loading-msg">Loading...</p>
+    }
+    else if (selectedCategory is null || !selectedCategory.Labels.Any())
     {
         <p class="board-empty-msg">
             @if (!categories.Any())
@@ -148,6 +152,7 @@
     private IReadOnlyList<NoteSummary> notes = [];
     private List<LabelCategory> categories = [];
     private Guid? selectedCategoryId;
+    private bool isLoading = false;
     private DotNetObjectReference<Board>? _dotNetRef;
 
     // ── Dialog state ──────────────────────────────────────────────────────────
@@ -165,6 +170,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        isLoading = true;
         var catResult = await LabelService.GetCategoriesAsync();
         if (!catResult.IsSuccess)
             Snackbar.Add(catResult.Error ?? "Failed to load categories.", Severity.Error);
@@ -174,6 +180,7 @@
             selectedCategoryId = categories[0].Id;
             await LoadNotesForCurrentCategory();
         }
+        isLoading = false;
     }
 
     private async Task LoadNotesForCurrentCategory()
@@ -181,13 +188,17 @@
         if (selectedCategory is null || !selectedCategory.Labels.Any())
         {
             notes = [];
+            isLoading = false;
             return;
         }
+        isLoading = true;
+        StateHasChanged();
         var labelIds = selectedCategory.Labels.Select(l => l.Id);
         var notesResult = await NoteService.GetAllSummariesAsync(labelIds);
         if (!notesResult.IsSuccess)
             Snackbar.Add(notesResult.Error ?? "Failed to load notes.", Severity.Error);
         notes = notesResult.Value ?? [];
+        isLoading = false;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/Vanadium.Note.Web/Pages/Board.razor.css
+++ b/Vanadium.Note.Web/Pages/Board.razor.css
@@ -63,6 +63,12 @@
     font-size: 0.9rem;
 }
 
+.board-loading-msg {
+    color: #888;
+    margin-top: 1rem;
+    font-size: 0.9rem;
+}
+
 /* ── Columns container ───────────────────────────────────────────────────── */
 
 .board-columns {

--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -48,6 +48,13 @@
     {
         <p class="empty-message">Loading...</p>
     }
+    else if (loadFailed && !notes.Any())
+    {
+        <div class="load-error">
+            <p class="load-error-text">Couldn't load your notes. Please try again.</p>
+            <button class="btn btn-primary" @onclick="RetryLoad">Retry</button>
+        </div>
+    }
     else if (!isLoading && !notes.Any())
     {
         <p class="empty-message">
@@ -233,6 +240,7 @@
     private int totalCount = 0;
     private const int PageSize = 30;
     private bool isLoading = false;
+    private bool loadFailed = false;
 
     private enum SortColumn { Title, Date }
     private SortColumn currentSort = SortColumn.Date;
@@ -249,33 +257,11 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _loadCts = new CancellationTokenSource();
-        var token = _loadCts.Token;
-        isLoading = true;
-
-        var result = await NoteService.GetAllAsync(
-            currentPage, PageSize, null,
-            currentSort == SortColumn.Title ? "title" : "date",
-            sortAscending ? "asc" : "desc",
-            null,
-            includeLabels: true,
-            cancellationToken: token);
-
-        if (result.IsSuccess)
-        {
-            allLabels = result.Value!.Labels ?? [];
-            notes = result.Value!.Items;
-            totalCount = result.Value!.TotalCount;
-            if (currentPage > TotalPages && TotalPages > 0)
-                currentPage = TotalPages;
-        }
-        else
-        {
-            Snackbar.Add(result.Error ?? "Failed to load notes.", Severity.Error);
-        }
-
-        isLoading = false;
+        await LoadNotes(includeLabels: true);
     }
+
+    // Retry after a failed load. Reload labels too if the initial load never delivered them.
+    private async Task RetryLoad() => await LoadNotes(includeLabels: allLabels.Count == 0);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -283,7 +269,7 @@
             await ShortcutService.RegisterAsync("delete", "Delete selected notes", () => InvokeAsync(OnDeleteKeyPressed));
     }
 
-    private async Task LoadNotes()
+    private async Task LoadNotes(bool includeLabels = false)
     {
         // Cancel any in-flight request so only the latest call updates the UI
         _loadCts?.Cancel();
@@ -292,6 +278,7 @@
         var token = _loadCts.Token;
 
         isLoading = true;
+        loadFailed = false;
         StateHasChanged();
 
         try
@@ -305,14 +292,18 @@
                     currentSort == SortColumn.Title ? "title" : "date",
                     sortAscending ? "asc" : "desc",
                     activeFilters.Count > 0 ? activeFilters : null,
+                    includeLabels: includeLabels,
                     cancellationToken: token);
 
                 if (!result.IsSuccess)
                 {
+                    loadFailed = true;
                     Snackbar.Add(result.Error ?? "Failed to load notes.", Severity.Error);
                     break;
                 }
 
+                if (includeLabels)
+                    allLabels = result.Value!.Labels ?? [];
                 notes = result.Value!.Items;
                 totalCount = result.Value!.TotalCount;
 

--- a/Vanadium.Note.Web/Pages/Home.razor.css
+++ b/Vanadium.Note.Web/Pages/Home.razor.css
@@ -38,6 +38,18 @@
     color: #888;
 }
 
+.load-error {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.load-error-text {
+    color: var(--mud-palette-error);
+    margin: 0;
+}
+
 .note-table {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## 요약
Closes #128

Home(`/`)과 Board(`/board`)의 로드 상태 UX를 개선한다.

- **Home**: 노트 로드 실패 시 빈 상태 메시지("No notes yet...")로 흘러가 사용자가 "노트 없음"으로 오인하던 문제를 해결한다. 실패 시 전용 에러 상태(에러 문구 + **Retry** 버튼)를 노출한다. Snackbar 토스트는 그대로 유지한다.
- **Board**: 데이터 fetch 중 로딩 표시가 전혀 없던 문제를 해결한다. 카테고리/노트 로딩 중 "Loading..." 인디케이터를 표시한다.

## 변경 내용
- `Home.razor`: `loadFailed` 플래그 추가, 로드 실패 시(그리고 표시할 노트가 없을 때) 에러 상태 렌더링. `OnInitializedAsync`와 `LoadNotes`의 중복 로드 로직을 `LoadNotes(includeLabels)` 하나로 통합하고, `RetryLoad`는 라벨 미로딩 시 라벨까지 함께 재요청한다.
- `Home.razor.css`: `.load-error` / `.load-error-text` 스타일 추가.
- `Board.razor`: `isLoading` 필드 추가, `OnInitializedAsync`/`LoadNotesForCurrentCategory`에서 토글. 표시할 노트가 없는 최초 로드 시 "Loading..." 표시(기존 노트가 있는 카테고리 전환·드래그 롤백 등에서는 깜빡임 없음 — Home과 동일한 `isLoading && !notes.Any()` 패턴).
- `Board.razor.css`: `.board-loading-msg` 스타일 추가.

## 완료 조건 검증
- [x] **Home에서 로드 실패 시 빈 상태 메시지가 아닌 에러 상태가 표시된다** — 마크업에 `loadFailed && !notes.Any()` 분기 추가, `LoadNotes`/초기 로드 실패 시 `loadFailed=true`. 재시도 버튼으로 복구 가능.
- [x] **Board에서 데이터 로딩 중 로딩 인디케이터가 표시된다** — `isLoading && !notes.Any()` 분기로 "Loading..." 표시.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0개/오류 0개, `dotnet test` 85 통과.

## 범위
Archive/RecycleBin 등 다른 페이지는 건드리지 않음(범위 밖). 변경 파일은 Home/Board 4개뿐.

## 참고
Web 프로젝트는 테스트 프로젝트가 없어(문서화된 알려진 제약) 자동 테스트를 추가하지 않았다. UI 동작은 수동 확인이 필요하다.
