### PR TITLE
#140 CancellationToken 배관 불일치 해소

### DIFF
--- a/Vanadium.Note.REST.Tests/ArchiveControllerTests.cs
+++ b/Vanadium.Note.REST.Tests/ArchiveControllerTests.cs
@@ -55,7 +55,7 @@ public class ArchiveControllerTests
         var controller = CreateNotesController(h);
 
         var result = await controller.Update(note.Id,
-            new NoteItem { Title = "Changed", Content = "", UpdatedAt = default });
+            new NoteItem { Title = "Changed", Content = "", UpdatedAt = default }, CancellationToken.None);
 
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(StatusCodes.Status403Forbidden, objectResult.StatusCode);
@@ -89,7 +89,7 @@ public class ArchiveControllerTests
         var controller = CreateNotesController(h);
 
         var result = await controller.Create(
-            new NoteItem { Title = "Orphan", Content = "", ParentNoteId = parent.Id });
+            new NoteItem { Title = "Orphan", Content = "", ParentNoteId = parent.Id }, CancellationToken.None);
 
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
@@ -111,7 +111,7 @@ public class ArchiveControllerTests
             Content = "",
             ParentNoteId = archivedParent.Id,
             UpdatedAt = default
-        });
+        }, CancellationToken.None);
 
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
@@ -126,8 +126,8 @@ public class ArchiveControllerTests
         await h.Notes.Delete(binned.Id);
         var controller = CreateNotesController(h);
 
-        Assert.IsType<NotFoundResult>(await controller.Archive(Guid.NewGuid()));
-        Assert.IsType<NotFoundResult>(await controller.Archive(binned.Id));
+        Assert.IsType<NotFoundResult>(await controller.Archive(Guid.NewGuid(), CancellationToken.None));
+        Assert.IsType<NotFoundResult>(await controller.Archive(binned.Id, CancellationToken.None));
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class ArchiveControllerTests
         var note = await h.CreateNoteAsync("Active");
         var controller = CreateNotesController(h);
 
-        Assert.IsType<NotFoundResult>(await controller.Unarchive(note.Id));
+        Assert.IsType<NotFoundResult>(await controller.Unarchive(note.Id, CancellationToken.None));
     }
 
     [Fact]
@@ -148,7 +148,7 @@ public class ArchiveControllerTests
         await h.Notes.Archive(note.Id);
         var controller = CreateNotesController(h);
 
-        var result = await controller.DeletePermanent(note.Id);
+        var result = await controller.DeletePermanent(note.Id, CancellationToken.None);
 
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(StatusCodes.Status409Conflict, objectResult.StatusCode);

--- a/Vanadium.Note.REST.Tests/NoteServiceCancellationTests.cs
+++ b/Vanadium.Note.REST.Tests/NoteServiceCancellationTests.cs
@@ -1,0 +1,59 @@
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Verifies that a CancellationToken handed to NoteService reaches the EF Core
+/// calls: an already-cancelled token must surface as an OperationCanceledException
+/// rather than being ignored. This guards the token plumbing (#140) — without it,
+/// the methods would run to completion regardless of the caller's cancellation.
+/// </summary>
+public class NoteServiceCancellationTests
+{
+    private static CancellationToken Cancelled()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        return cts.Token;
+    }
+
+    [Fact]
+    public async Task GetPaged_WithCancelledToken_Throws()
+    {
+        using var h = new TestHost();
+        await h.CreateNoteAsync("A");
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            h.Notes.GetPaged(1, 30, null, "date", "desc", null, Cancelled()));
+    }
+
+    [Fact]
+    public async Task Get_WithCancelledToken_Throws()
+    {
+        using var h = new TestHost();
+        var note = await h.CreateNoteAsync("A");
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            h.Notes.Get(note.Id, Cancelled()));
+    }
+
+    [Fact]
+    public async Task Create_WithCancelledToken_Throws()
+    {
+        using var h = new TestHost();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            h.Notes.Create(new NoteItem { Title = "A", Content = "" }, Cancelled()));
+    }
+
+    [Fact]
+    public async Task Delete_WithCancelledToken_Throws()
+    {
+        using var h = new TestHost();
+        var note = await h.CreateNoteAsync("A");
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            h.Notes.Delete(note.Id, Cancelled()));
+    }
+}

--- a/Vanadium.Note.REST/Controllers/NotesController.cs
+++ b/Vanadium.Note.REST/Controllers/NotesController.cs
@@ -21,13 +21,14 @@ public class NotesController(NoteService noteService, LabelService labelService,
         [FromQuery] string sortBy = "date",
         [FromQuery] string sortDir = "desc",
         [FromQuery] Guid[]? labelIds = null,
-        [FromQuery] bool includeLabels = false)
+        [FromQuery] bool includeLabels = false,
+        CancellationToken ct = default)
     {
         page = Math.Max(1, page);
         pageSize = Math.Clamp(pageSize, 1, 200);
         if (labelIds is { Length: > 50 })
             return Problem(detail: "Too many label IDs (maximum 50).", statusCode: StatusCodes.Status400BadRequest);
-        var result = await noteService.GetPaged(page, pageSize, search, sortBy, sortDir, labelIds);
+        var result = await noteService.GetPaged(page, pageSize, search, sortBy, sortDir, labelIds, ct);
         if (includeLabels)
             result.Labels = await labelService.GetAllLabelsAsync();
         return Ok(result);
@@ -35,17 +36,19 @@ public class NotesController(NoteService noteService, LabelService labelService,
 
     [HttpGet("mention-search")]
     public async Task<ActionResult<List<MentionSuggestionDto>>> MentionSearch(
-        [FromQuery][MaxLength(100)] string q = "")
+        [FromQuery][MaxLength(100)] string q = "",
+        CancellationToken ct = default)
     {
-        return Ok(await noteService.SearchForMention(q));
+        return Ok(await noteService.SearchForMention(q, ct: ct));
     }
 
     [HttpGet("quick-search")]
     public async Task<ActionResult<List<QuickNavResult>>> QuickSearch(
         [FromQuery][MaxLength(200)] string q = "",
-        [FromQuery] int limit = 20)
+        [FromQuery] int limit = 20,
+        CancellationToken ct = default)
     {
-        var results = await noteService.QuickSearch(q, limit);
+        var results = await noteService.QuickSearch(q, limit, ct);
         // Avoid logging the raw query (note content privacy, NFR-6): term + result counts only.
         var termCount = q.Trim()
             .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Length;
@@ -57,23 +60,24 @@ public class NotesController(NoteService noteService, LabelService labelService,
 
     [HttpGet("summaries")]
     public async Task<ActionResult<List<NoteSummary>>> GetSummaries(
-        [FromQuery] Guid[]? labelIds = null)
+        [FromQuery] Guid[]? labelIds = null,
+        CancellationToken ct = default)
     {
         if (labelIds is { Length: > 50 })
             return Problem(detail: "Too many label IDs (maximum 50).", statusCode: StatusCodes.Status400BadRequest);
-        return Ok(await noteService.GetAllSummaries(labelIds));
+        return Ok(await noteService.GetAllSummaries(labelIds, ct));
     }
 
     [HttpGet("{id:guid}/children")]
-    public async Task<ActionResult<List<NoteSummary>>> GetChildren(Guid id)
+    public async Task<ActionResult<List<NoteSummary>>> GetChildren(Guid id, CancellationToken ct)
     {
-        return Ok(await noteService.GetChildren(id));
+        return Ok(await noteService.GetChildren(id, ct));
     }
 
     [HttpGet("{id:guid}")]
-    public async Task<ActionResult<NoteItem>> Get(Guid id)
+    public async Task<ActionResult<NoteItem>> Get(Guid id, CancellationToken ct)
     {
-        var note = await noteService.Get(id);
+        var note = await noteService.Get(id, ct);
         if (note is null)
         {
             logger.LogWarning("Note {NoteId} not found", id);
@@ -83,20 +87,20 @@ public class NotesController(NoteService noteService, LabelService labelService,
     }
 
     [HttpPost]
-    public async Task<ActionResult<NoteItem>> Create([FromBody] NoteItem note)
+    public async Task<ActionResult<NoteItem>> Create([FromBody] NoteItem note, CancellationToken ct)
     {
-        if (note.ParentNoteId.HasValue && !await IsActiveNote(note.ParentNoteId.Value))
+        if (note.ParentNoteId.HasValue && !await IsActiveNote(note.ParentNoteId.Value, ct))
         {
             logger.LogWarning("Create rejected — parent note {ParentNoteId} not found, archived, or in recycle bin.", note.ParentNoteId);
             return Problem(detail: "Parent note does not exist, is archived, or is in the recycle bin.", statusCode: StatusCodes.Status400BadRequest);
         }
-        var created = await noteService.Create(note);
+        var created = await noteService.Create(note, ct);
         logger.LogInformation("Note created: {NoteId}", created.Id);
         return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
     }
 
     [HttpPut("{id:guid}")]
-    public async Task<ActionResult<NoteItem>> Update(Guid id, [FromBody] NoteItem note)
+    public async Task<ActionResult<NoteItem>> Update(Guid id, [FromBody] NoteItem note, CancellationToken ct)
     {
         if (note.ParentNoteId.HasValue)
         {
@@ -105,19 +109,19 @@ public class NotesController(NoteService noteService, LabelService labelService,
                 logger.LogWarning("Update rejected — note {NoteId} cannot be its own parent.", id);
                 return Problem(detail: "A note cannot be its own parent.", statusCode: StatusCodes.Status400BadRequest);
             }
-            if (await noteService.HasCircularReference(id, note.ParentNoteId.Value))
+            if (await noteService.HasCircularReference(id, note.ParentNoteId.Value, ct))
             {
                 logger.LogWarning("Update rejected — circular parent reference detected for note {NoteId}.", id);
                 return Problem(detail: "Setting this parent would create a circular reference.", statusCode: StatusCodes.Status400BadRequest);
             }
-            if (!await IsActiveNote(note.ParentNoteId.Value))
+            if (!await IsActiveNote(note.ParentNoteId.Value, ct))
             {
                 logger.LogWarning("Update rejected — parent note {ParentNoteId} not found, archived, or in recycle bin.", note.ParentNoteId);
                 return Problem(detail: "Parent note does not exist, is archived, or is in the recycle bin.", statusCode: StatusCodes.Status400BadRequest);
             }
         }
 
-        var (updated, conflict, archived) = await noteService.Update(id, note);
+        var (updated, conflict, archived) = await noteService.Update(id, note, ct);
         if (archived)
             return Problem(
                 detail: "Note is archived and read-only.",
@@ -136,9 +140,9 @@ public class NotesController(NoteService noteService, LabelService labelService,
     }
 
     [HttpDelete("{id:guid}")]
-    public async Task<IActionResult> Delete(Guid id)
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
     {
-        if (!await noteService.Delete(id))
+        if (!await noteService.Delete(id, ct))
         {
             logger.LogWarning("Delete failed — note {NoteId} not found", id);
             return NotFound();
@@ -148,9 +152,9 @@ public class NotesController(NoteService noteService, LabelService labelService,
     }
 
     [HttpPost("{id:guid}/archive")]
-    public async Task<IActionResult> Archive(Guid id)
+    public async Task<IActionResult> Archive(Guid id, CancellationToken ct)
     {
-        if (!await noteService.Archive(id))
+        if (!await noteService.Archive(id, ct))
         {
             logger.LogWarning("Archive failed — note {NoteId} not found", id);
             return NotFound();
@@ -160,9 +164,9 @@ public class NotesController(NoteService noteService, LabelService labelService,
     }
 
     [HttpPost("{id:guid}/unarchive")]
-    public async Task<IActionResult> Unarchive(Guid id)
+    public async Task<IActionResult> Unarchive(Guid id, CancellationToken ct)
     {
-        if (!await noteService.Unarchive(id))
+        if (!await noteService.Unarchive(id, ct))
         {
             logger.LogWarning("Unarchive failed — note {NoteId} not found or not archived", id);
             return NotFound();
@@ -174,27 +178,29 @@ public class NotesController(NoteService noteService, LabelService labelService,
     [HttpGet("archive")]
     public async Task<ActionResult<PagedResult<ArchivedNoteSummary>>> GetArchive(
         [FromQuery] int page = 1,
-        [FromQuery] int pageSize = 30)
+        [FromQuery] int pageSize = 30,
+        CancellationToken ct = default)
     {
         page = Math.Max(1, page);
         pageSize = Math.Clamp(pageSize, 1, 200);
-        return Ok(await noteService.GetArchive(page, pageSize));
+        return Ok(await noteService.GetArchive(page, pageSize, ct));
     }
 
     [HttpGet("recycle-bin")]
     public async Task<ActionResult<PagedResult<RecycleBinNoteSummary>>> GetRecycleBin(
         [FromQuery] int page = 1,
-        [FromQuery] int pageSize = 30)
+        [FromQuery] int pageSize = 30,
+        CancellationToken ct = default)
     {
         page = Math.Max(1, page);
         pageSize = Math.Clamp(pageSize, 1, 200);
-        return Ok(await noteService.GetRecycleBin(page, pageSize));
+        return Ok(await noteService.GetRecycleBin(page, pageSize, ct));
     }
 
     [HttpPost("{id:guid}/restore")]
-    public async Task<IActionResult> Restore(Guid id)
+    public async Task<IActionResult> Restore(Guid id, CancellationToken ct)
     {
-        if (!await noteService.Restore(id))
+        if (!await noteService.Restore(id, ct))
         {
             logger.LogWarning("Restore failed — note {NoteId} not found in recycle bin", id);
             return NotFound();
@@ -204,9 +210,9 @@ public class NotesController(NoteService noteService, LabelService labelService,
     }
 
     [HttpDelete("{id:guid}/permanent")]
-    public async Task<IActionResult> DeletePermanent(Guid id)
+    public async Task<IActionResult> DeletePermanent(Guid id, CancellationToken ct)
     {
-        var (found, wasInRecycleBin) = await noteService.DeletePermanent(id);
+        var (found, wasInRecycleBin) = await noteService.DeletePermanent(id, ct);
         if (!found)
         {
             logger.LogWarning("Permanent delete failed — note {NoteId} not found", id);
@@ -224,15 +230,15 @@ public class NotesController(NoteService noteService, LabelService labelService,
     }
 
     [HttpDelete("recycle-bin")]
-    public async Task<IActionResult> EmptyRecycleBin()
+    public async Task<IActionResult> EmptyRecycleBin(CancellationToken ct)
     {
-        var count = await noteService.EmptyRecycleBin();
+        var count = await noteService.EmptyRecycleBin(ct);
         logger.LogInformation("Recycle Bin emptied: {Count} note(s) permanently deleted", count);
         return NoContent();
     }
 
     /// <summary>Active = not soft-deleted (global filter) and not archived.
     /// Archived parents are rejected: no active note may live under an archived one.</summary>
-    private async Task<bool> IsActiveNote(Guid noteId)
-        => await db.Notes.AnyAsync(n => n.Id == noteId && n.ArchivedAt == null);
+    private async Task<bool> IsActiveNote(Guid noteId, CancellationToken ct)
+        => await db.Notes.AnyAsync(n => n.Id == noteId && n.ArchivedAt == null, ct);
 }

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -18,7 +18,8 @@ public class NoteService(
         string? search,
         string sortBy,
         string sortDir,
-        Guid[]? labelIds)
+        Guid[]? labelIds,
+        CancellationToken ct = default)
     {
         // When not searching, show active root notes only.
         // When searching, archived notes are included (flagged IsArchived for the badge).
@@ -31,7 +32,7 @@ public class NoteService(
 
         // Lean query for COUNT — no joins to label/category tables
         var countQuery = ApplyFilters(baseNotes, search, labelIds);
-        var totalCount = await countQuery.CountAsync();
+        var totalCount = await countQuery.CountAsync(ct);
 
         // Full query for data — projects to NoteSummary to avoid fetching large Content column
         var baseDataQuery = ApplyFilters(baseNotes, search, labelIds);
@@ -64,9 +65,9 @@ public class NoteService(
                     CategoryName = nl.Label.Category == null ? null : nl.Label.Category.Name
                 }).ToList()
             })
-            .ToListAsync();
+            .ToListAsync(ct);
 
-        var childCounts = await GetChildCountsAsync(summaries.Select(n => n.Id));
+        var childCounts = await GetChildCountsAsync(summaries.Select(n => n.Id), ct);
 
         // Batch-fetch parent titles for sub-notes that surfaced via search
         Dictionary<Guid, string> parentTitles = [];
@@ -80,7 +81,7 @@ public class NoteService(
             if (parentIds.Count > 0)
                 parentTitles = await db.Notes
                     .Where(n => parentIds.Contains(n.Id))
-                    .ToDictionaryAsync(n => n.Id, n => n.Title);
+                    .ToDictionaryAsync(n => n.Id, n => n.Title, ct);
         }
 
         logger.LogDebug("GetPaged: page={Page}, pageSize={PageSize}, total={Total}.", page, pageSize, totalCount);
@@ -104,7 +105,7 @@ public class NoteService(
         };
     }
 
-    public async Task<List<NoteSummary>> GetAllSummaries(Guid[]? labelIds = null)
+    public async Task<List<NoteSummary>> GetAllSummaries(Guid[]? labelIds = null, CancellationToken ct = default)
     {
         // The board never shows archived notes.
         var query = db.Notes.Where(n => n.ArchivedAt == null);
@@ -129,9 +130,9 @@ public class NoteService(
                     CategoryName = nl.Label.Category == null ? null : nl.Label.Category.Name
                 }).ToList()
             })
-            .ToListAsync();
+            .ToListAsync(ct);
 
-        var childCounts = await GetChildCountsAsync(summaries.Select(n => n.Id));
+        var childCounts = await GetChildCountsAsync(summaries.Select(n => n.Id), ct);
 
         logger.LogDebug("GetAllSummaries: {Count} note(s).", summaries.Count);
         return summaries.Select(n => new NoteSummary
@@ -145,7 +146,7 @@ public class NoteService(
         }).ToList();
     }
 
-    public async Task<List<NoteSummary>> GetChildren(Guid parentId)
+    public async Task<List<NoteSummary>> GetChildren(Guid parentId, CancellationToken ct = default)
     {
         var summaries = await db.Notes
             .Where(n => n.ParentNoteId == parentId && n.ArchivedAt == null)
@@ -164,9 +165,9 @@ public class NoteService(
                     CategoryName = nl.Label.Category == null ? null : nl.Label.Category.Name
                 }).ToList()
             })
-            .ToListAsync();
+            .ToListAsync(ct);
 
-        var childCounts = await GetChildCountsAsync(summaries.Select(n => n.Id));
+        var childCounts = await GetChildCountsAsync(summaries.Select(n => n.Id), ct);
 
         logger.LogDebug("GetChildren: parentId={ParentId}, count={Count}.", parentId, summaries.Count);
         return summaries.Select(n => new NoteSummary
@@ -180,31 +181,31 @@ public class NoteService(
         }).ToList();
     }
 
-    public async Task<NoteItem?> Get(Guid id)
+    public async Task<NoteItem?> Get(Guid id, CancellationToken ct = default)
     {
         var note = await db.Notes
             .Include(n => n.NoteLabels)
             .ThenInclude(nl => nl.Label)
             .ThenInclude(l => l.Category)
-            .FirstOrDefaultAsync(n => n.Id == id);
+            .FirstOrDefaultAsync(n => n.Id == id, ct);
 
         if (note is null) return null;
 
         PopulateLabels(note);
-        note.ChildCount = await db.Notes.CountAsync(n => n.ParentNoteId == id);
+        note.ChildCount = await db.Notes.CountAsync(n => n.ParentNoteId == id, ct);
 
         if (note.ParentNoteId.HasValue)
         {
             note.ParentTitle = await db.Notes
                 .Where(n => n.Id == note.ParentNoteId.Value)
                 .Select(n => n.Title)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(ct);
         }
 
         return note;
     }
 
-    public async Task<NoteItem> Create(NoteItem note)
+    public async Task<NoteItem> Create(NoteItem note, CancellationToken ct = default)
     {
         note.Id = Guid.NewGuid();
         note.UpdatedAt = UtcNowMicroseconds();
@@ -221,13 +222,13 @@ public class NoteService(
         note.ArchivedAt = null;
         note.IsArchiveRoot = false;
         db.Notes.Add(note);
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(ct);
         return note;
     }
 
-    public async Task<(NoteItem? Note, bool Conflict, bool Archived)> Update(Guid id, NoteItem note)
+    public async Task<(NoteItem? Note, bool Conflict, bool Archived)> Update(Guid id, NoteItem note, CancellationToken ct = default)
     {
-        var existing = await db.Notes.FirstOrDefaultAsync(n => n.Id == id);
+        var existing = await db.Notes.FirstOrDefaultAsync(n => n.Id == id, ct);
         if (existing is null) return (null, false, false);
 
         // Archived notes are read-only. Checked before the concurrency check so a
@@ -267,7 +268,7 @@ public class NoteService(
 
         try
         {
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsync(ct);
         }
         catch (DbUpdateConcurrencyException)
         {
@@ -278,12 +279,12 @@ public class NoteService(
         }
 
         if (titleChanged)
-            await UpdatePageLinkReferences(id, note.Title);
+            await UpdatePageLinkReferences(id, note.Title, ct);
 
         return (existing, false, false);
     }
 
-    private async Task UpdatePageLinkReferences(Guid noteId, string newTitle)
+    private async Task UpdatePageLinkReferences(Guid noteId, string newTitle, CancellationToken ct = default)
     {
         var idStr = noteId.ToString();
         // IgnoreQueryFilters so recycle-bin (soft-deleted) notes referencing this
@@ -291,7 +292,7 @@ public class NoteService(
         // keeps a stale title.
         var referencingNotes = await db.Notes.IgnoreQueryFilters()
             .Where(n => n.Content.Contains($"data-note-id=\"{idStr}\""))
-            .ToListAsync();
+            .ToListAsync(ct);
 
         if (referencingNotes.Count == 0) return;
 
@@ -304,7 +305,7 @@ public class NoteService(
             n.ContentText = StripHtml(updated);
         }
 
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(ct);
         logger.LogInformation(
             "Propagated title change to '{NewTitle}' across {Count} note(s) referencing {NoteId}.",
             newTitle, referencingNotes.Count, noteId);
@@ -361,7 +362,7 @@ public class NoteService(
     /// Returns true if making <paramref name="proposedParentId"/> the parent of
     /// <paramref name="noteId"/> would create a cycle in the ancestor chain.
     /// </summary>
-    public async Task<bool> HasCircularReference(Guid noteId, Guid proposedParentId)
+    public async Task<bool> HasCircularReference(Guid noteId, Guid proposedParentId, CancellationToken ct = default)
     {
         const int maxDepth = 100;
         var current = (Guid?)proposedParentId;
@@ -371,12 +372,12 @@ public class NoteService(
             current = await db.Notes
                 .Where(n => n.Id == current.Value)
                 .Select(n => n.ParentNoteId)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(ct);
         }
         return false;
     }
 
-    public async Task<List<MentionSuggestionDto>> SearchForMention(string query, int limit = 10)
+    public async Task<List<MentionSuggestionDto>> SearchForMention(string query, int limit = 10, CancellationToken ct = default)
     {
         // Mentions target active work — archived notes are excluded.
         var q = db.Notes.Where(n => n.ArchivedAt == null);
@@ -389,7 +390,7 @@ public class NoteService(
             .OrderByDescending(n => n.UpdatedAt)
             .Take(limit)
             .Select(n => new MentionSuggestionDto { Id = n.Id, Title = n.Title })
-            .ToListAsync();
+            .ToListAsync(ct);
     }
 
     /// <summary>
@@ -398,7 +399,7 @@ public class NoteService(
     /// Archived notes are INCLUDED (no <c>ArchivedAt == null</c> predicate); the default
     /// <c>DeletedAt == null</c> global filter excludes Recycle Bin notes — no opt-out needed.
     /// </summary>
-    public async Task<List<QuickNavResult>> QuickSearch(string query, int limit = 20)
+    public async Task<List<QuickNavResult>> QuickSearch(string query, int limit = 20, CancellationToken ct = default)
     {
         var terms = (query ?? string.Empty).Trim()
             .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -420,7 +421,7 @@ public class NoteService(
             .OrderByDescending(n => n.UpdatedAt)
             .Take(limit)
             .Select(n => new { n.Id, n.Title, n.ContentText, ArchivedAt = n.ArchivedAt })
-            .ToListAsync();
+            .ToListAsync(ct);
 
         return rows.Select(r => new QuickNavResult
         {
@@ -467,9 +468,9 @@ public class NoteService(
     /// References in other notes and uploaded files are left untouched so a
     /// restore is lossless; cleanup is deferred to permanent deletion.
     /// </summary>
-    public async Task<bool> Delete(Guid id)
+    public async Task<bool> Delete(Guid id, CancellationToken ct = default)
     {
-        var note = await db.Notes.FirstOrDefaultAsync(n => n.Id == id);
+        var note = await db.Notes.FirstOrDefaultAsync(n => n.Id == id, ct);
         if (note is null) return false;
 
         var deletedAt = UtcNowMicroseconds();
@@ -478,26 +479,26 @@ public class NoteService(
 
         // Active descendants are swept into the same recycle bin group (same timestamp).
         // Descendants soft-deleted earlier keep their own group and restore independently.
-        var descendants = await CollectActiveDescendantsAsync(id);
+        var descendants = await CollectActiveDescendantsAsync(id, ct);
         foreach (var descendant in descendants)
         {
             descendant.DeletedAt = deletedAt;
             descendant.IsDeletionRoot = false;
         }
 
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(ct);
         logger.LogInformation(
             "Note {NoteId} moved to recycle bin with {DescendantCount} descendant(s).",
             id, descendants.Count);
         return true;
     }
 
-    public async Task<PagedResult<RecycleBinNoteSummary>> GetRecycleBin(int page, int pageSize)
+    public async Task<PagedResult<RecycleBinNoteSummary>> GetRecycleBin(int page, int pageSize, CancellationToken ct = default)
     {
         var query = db.Notes.IgnoreQueryFilters()
             .Where(n => n.DeletedAt != null && n.IsDeletionRoot);
 
-        var totalCount = await query.CountAsync();
+        var totalCount = await query.CountAsync(ct);
 
         var items = await query
             .OrderByDescending(n => n.DeletedAt)
@@ -510,7 +511,7 @@ public class NoteService(
                 DeletedAt = n.DeletedAt!.Value,
                 IsArchived = n.ArchivedAt != null
             })
-            .ToListAsync();
+            .ToListAsync(ct);
 
         // Direct soft-deleted children per listed root (two-step, mirrors GetChildCountsAsync)
         var ids = items.Select(i => i.Id).ToList();
@@ -522,7 +523,7 @@ public class NoteService(
                     && ids.Contains(n.ParentNoteId.Value))
                 .GroupBy(n => n.ParentNoteId!.Value)
                 .Select(g => new { ParentId = g.Key, Count = g.Count() })
-                .ToDictionaryAsync(x => x.ParentId, x => x.Count);
+                .ToDictionaryAsync(x => x.ParentId, x => x.Count, ct);
             foreach (var item in items)
                 item.ChildCount = childCounts.GetValueOrDefault(item.Id);
         }
@@ -541,15 +542,15 @@ public class NoteService(
     /// with it (same DeletedAt). If the original parent is missing or itself
     /// soft-deleted, the note is reattached as a root note.
     /// </summary>
-    public async Task<bool> Restore(Guid id)
+    public async Task<bool> Restore(Guid id, CancellationToken ct = default)
     {
         var note = await db.Notes.IgnoreQueryFilters()
             .FirstOrDefaultAsync(n =>
-                n.Id == id && n.DeletedAt != null && n.IsDeletionRoot);
+                n.Id == id && n.DeletedAt != null && n.IsDeletionRoot, ct);
         if (note is null) return false;
 
         var groupDeletedAt = note.DeletedAt!.Value;
-        var groupMembers = await CollectDeletedGroupDescendantsAsync(id, groupDeletedAt);
+        var groupMembers = await CollectDeletedGroupDescendantsAsync(id, groupDeletedAt, ct);
 
         if (note.ParentNoteId.HasValue)
         {
@@ -557,8 +558,8 @@ public class NoteService(
             // parent also detaches, unless the restored root is itself archived —
             // then it returns to the archive where an archived parent is a legal home.
             var parentIsValid = note.ArchivedAt is not null
-                ? await db.Notes.AnyAsync(n => n.Id == note.ParentNoteId.Value)
-                : await db.Notes.AnyAsync(n => n.Id == note.ParentNoteId.Value && n.ArchivedAt == null);
+                ? await db.Notes.AnyAsync(n => n.Id == note.ParentNoteId.Value, ct)
+                : await db.Notes.AnyAsync(n => n.Id == note.ParentNoteId.Value && n.ArchivedAt == null, ct);
             if (!parentIsValid)
                 note.ParentNoteId = null;
         }
@@ -571,7 +572,7 @@ public class NoteService(
             member.IsDeletionRoot = false;
         }
 
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(ct);
         logger.LogInformation(
             "Note {NoteId} restored from recycle bin with {DescendantCount} descendant(s).",
             id, groupMembers.Count);
@@ -585,9 +586,9 @@ public class NoteService(
     /// note is a no-op. Returns false when the note is not found (or is in the
     /// recycle bin, which the global filter hides from this lookup).
     /// </summary>
-    public async Task<bool> Archive(Guid id)
+    public async Task<bool> Archive(Guid id, CancellationToken ct = default)
     {
-        var note = await db.Notes.FirstOrDefaultAsync(n => n.Id == id);
+        var note = await db.Notes.FirstOrDefaultAsync(n => n.Id == id, ct);
         if (note is null) return false;
         if (note.ArchivedAt is not null) return true; // idempotent no-op
 
@@ -598,7 +599,7 @@ public class NoteService(
         // Sweep active descendants into the same archive group. The BFS sees
         // archived descendants too (archive has no global filter), so skip them:
         // independently archived subtrees keep their own root and timestamp.
-        var descendants = (await CollectActiveDescendantsAsync(id))
+        var descendants = (await CollectActiveDescendantsAsync(id, ct))
             .Where(d => d.ArchivedAt == null)
             .ToList();
         foreach (var descendant in descendants)
@@ -607,7 +608,7 @@ public class NoteService(
             descendant.IsArchiveRoot = false;
         }
 
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(ct);
         logger.LogInformation(
             "Note {NoteId} archived with {DescendantCount} descendant(s).",
             id, descendants.Count);
@@ -621,14 +622,14 @@ public class NoteService(
     /// reattached as a root note. Returns false when the note is not found or
     /// not archived.
     /// </summary>
-    public async Task<bool> Unarchive(Guid id)
+    public async Task<bool> Unarchive(Guid id, CancellationToken ct = default)
     {
         var note = await db.Notes.FirstOrDefaultAsync(n =>
-            n.Id == id && n.ArchivedAt != null);
+            n.Id == id && n.ArchivedAt != null, ct);
         if (note is null) return false;
 
         var groupArchivedAt = note.ArchivedAt!.Value;
-        var groupMembers = await CollectArchivedGroupDescendantsAsync(id, groupArchivedAt);
+        var groupMembers = await CollectArchivedGroupDescendantsAsync(id, groupArchivedAt, ct);
 
         note.ArchivedAt = null;
         note.IsArchiveRoot = false;
@@ -643,12 +644,12 @@ public class NoteService(
         if (note.ParentNoteId.HasValue)
         {
             var parentIsActive = await db.Notes.AnyAsync(n =>
-                n.Id == note.ParentNoteId.Value && n.ArchivedAt == null);
+                n.Id == note.ParentNoteId.Value && n.ArchivedAt == null, ct);
             if (!parentIsActive)
                 note.ParentNoteId = null;
         }
 
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(ct);
         logger.LogInformation(
             "Note {NoteId} unarchived with {DescendantCount} descendant(s).",
             id, groupMembers.Count);
@@ -659,12 +660,12 @@ public class NoteService(
     /// Paged list of archive roots, newest first. The global filter automatically
     /// excludes archived notes that are currently in the recycle bin.
     /// </summary>
-    public async Task<PagedResult<ArchivedNoteSummary>> GetArchive(int page, int pageSize)
+    public async Task<PagedResult<ArchivedNoteSummary>> GetArchive(int page, int pageSize, CancellationToken ct = default)
     {
         var query = db.Notes
             .Where(n => n.ArchivedAt != null && n.IsArchiveRoot);
 
-        var totalCount = await query.CountAsync();
+        var totalCount = await query.CountAsync(ct);
 
         var items = await query
             .OrderByDescending(n => n.ArchivedAt)
@@ -676,7 +677,7 @@ public class NoteService(
                 Title = n.Title,
                 ArchivedAt = n.ArchivedAt!.Value
             })
-            .ToListAsync();
+            .ToListAsync(ct);
 
         // Direct children swept in the same archive operation (same timestamp),
         // mirroring the recycle bin's per-root child counts.
@@ -688,7 +689,7 @@ public class NoteService(
                     && n.ParentNoteId.HasValue
                     && ids.Contains(n.ParentNoteId.Value))
                 .Select(n => new { ParentId = n.ParentNoteId!.Value, n.ArchivedAt })
-                .ToListAsync();
+                .ToListAsync(ct);
             foreach (var item in items)
                 item.ChildCount = children.Count(c =>
                     c.ParentId == item.Id && c.ArchivedAt == item.ArchivedAt);
@@ -707,24 +708,24 @@ public class NoteService(
     /// Permanently deletes a soft-deleted note. Returns (Found, WasInRecycleBin):
     /// active notes are refused so the recycle bin cannot be bypassed.
     /// </summary>
-    public async Task<(bool Found, bool WasInRecycleBin)> DeletePermanent(Guid id)
+    public async Task<(bool Found, bool WasInRecycleBin)> DeletePermanent(Guid id, CancellationToken ct = default)
     {
         var note = await db.Notes.IgnoreQueryFilters()
-            .FirstOrDefaultAsync(n => n.Id == id);
+            .FirstOrDefaultAsync(n => n.Id == id, ct);
         if (note is null) return (false, false);
         if (note.DeletedAt is null) return (true, false);
 
-        await HardDeleteAsync(note);
+        await HardDeleteAsync(note, ct);
         return (true, true);
     }
 
     /// <summary>Permanently deletes every soft-deleted note of the user. Returns the root count.</summary>
-    public async Task<int> EmptyRecycleBin()
+    public async Task<int> EmptyRecycleBin(CancellationToken ct = default)
     {
         var rootIds = await db.Notes.IgnoreQueryFilters()
             .Where(n => n.DeletedAt != null && n.IsDeletionRoot)
             .Select(n => n.Id)
-            .ToListAsync();
+            .ToListAsync(ct);
 
         var purged = 0;
         foreach (var rootId in rootIds)
@@ -732,9 +733,9 @@ public class NoteService(
             // Re-fetch: an earlier iteration may have cascade-deleted this root
             // (a separately-soft-deleted sub-note of another soft-deleted parent).
             var note = await db.Notes.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(n => n.Id == rootId && n.DeletedAt != null);
+                .FirstOrDefaultAsync(n => n.Id == rootId && n.DeletedAt != null, ct);
             if (note is null) continue;
-            await HardDeleteAsync(note);
+            await HardDeleteAsync(note, ct);
             purged++;
         }
 
@@ -760,7 +761,7 @@ public class NoteService(
             var note = await db.Notes.IgnoreQueryFilters()
                 .FirstOrDefaultAsync(n => n.Id == rootId && n.DeletedAt != null, ct);
             if (note is null) continue;
-            await HardDeleteAsync(note);
+            await HardDeleteAsync(note, ct);
             purged++;
         }
 
@@ -772,9 +773,9 @@ public class NoteService(
     /// from remaining notes, deletes the row (DB cascades the subtree), then
     /// cleans up files orphaned by the whole subtree's content.
     /// </summary>
-    private async Task HardDeleteAsync(NoteItem note)
+    private async Task HardDeleteAsync(NoteItem note, CancellationToken ct = default)
     {
-        var subtree = await CollectDescendantsUnfilteredAsync(note.Id);
+        var subtree = await CollectDescendantsUnfilteredAsync(note.Id, ct);
 
         var combinedContent = string.Join(' ',
             subtree.Select(n => n.Content).Prepend(note.Content));
@@ -789,13 +790,13 @@ public class NoteService(
         var strategy = db.Database.CreateExecutionStrategy();
         await strategy.ExecuteAsync(async () =>
         {
-            await using var tx = await db.Database.BeginTransactionAsync();
+            await using var tx = await db.Database.BeginTransactionAsync(ct);
 
             // Remove any page-link blocks referencing this note from the parent's content
             if (note.ParentNoteId.HasValue)
             {
                 var parent = await db.Notes.IgnoreQueryFilters()
-                    .FirstOrDefaultAsync(n => n.Id == note.ParentNoteId.Value);
+                    .FirstOrDefaultAsync(n => n.Id == note.ParentNoteId.Value, ct);
                 if (parent is not null)
                 {
                     var cleaned = RemovePageLinkFromContent(parent.Content, note.Id);
@@ -808,47 +809,49 @@ public class NoteService(
             }
 
             // Strip mention links referencing any note in the subtree from active notes
-            await StripMentionReferencesAsync(note.Id);
+            await StripMentionReferencesAsync(note.Id, ct);
             foreach (var descendant in subtree)
-                await StripMentionReferencesAsync(descendant.Id);
+                await StripMentionReferencesAsync(descendant.Id, ct);
 
             db.Notes.Remove(note);
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsync(ct);
 
-            await tx.CommitAsync();
+            await tx.CommitAsync(ct);
         });
 
         // File cleanup runs AFTER the transaction commits: deleting files is an
         // irreversible filesystem side effect and must not sit inside the DB
         // transaction (a rollback cannot un-delete files).
-        await fileCleanup.DeleteOrphanedFromContentAsync(combinedContent);
+        await fileCleanup.DeleteOrphanedFromContentAsync(combinedContent, ct);
         logger.LogInformation(
             "Note {NoteId} permanently deleted with {DescendantCount} descendant(s).",
             note.Id, subtree.Count);
     }
 
     /// <summary>BFS over active descendants only (global filter applies).</summary>
-    private async Task<List<NoteItem>> CollectActiveDescendantsAsync(Guid rootId)
-        => await CollectDescendantsAsync(rootId, db.Notes);
+    private async Task<List<NoteItem>> CollectActiveDescendantsAsync(Guid rootId, CancellationToken ct = default)
+        => await CollectDescendantsAsync(rootId, db.Notes, ct);
 
     /// <summary>BFS over all descendants regardless of recycle bin state.</summary>
-    private async Task<List<NoteItem>> CollectDescendantsUnfilteredAsync(Guid rootId)
-        => await CollectDescendantsAsync(rootId, db.Notes.IgnoreQueryFilters());
+    private async Task<List<NoteItem>> CollectDescendantsUnfilteredAsync(Guid rootId, CancellationToken ct = default)
+        => await CollectDescendantsAsync(rootId, db.Notes.IgnoreQueryFilters(), ct);
 
     /// <summary>BFS over soft-deleted descendants sharing the given recycle-bin-group timestamp.</summary>
-    private async Task<List<NoteItem>> CollectDeletedGroupDescendantsAsync(Guid rootId, DateTime groupDeletedAt)
+    private async Task<List<NoteItem>> CollectDeletedGroupDescendantsAsync(Guid rootId, DateTime groupDeletedAt, CancellationToken ct = default)
         => await CollectDescendantsAsync(
             rootId,
-            db.Notes.IgnoreQueryFilters().Where(n => n.DeletedAt == groupDeletedAt));
+            db.Notes.IgnoreQueryFilters().Where(n => n.DeletedAt == groupDeletedAt),
+            ct);
 
     /// <summary>BFS over archived descendants sharing the given archive-group timestamp.
     /// Descends only through same-group notes, so independently archived subtrees stay put.</summary>
-    private async Task<List<NoteItem>> CollectArchivedGroupDescendantsAsync(Guid rootId, DateTime groupArchivedAt)
+    private async Task<List<NoteItem>> CollectArchivedGroupDescendantsAsync(Guid rootId, DateTime groupArchivedAt, CancellationToken ct = default)
         => await CollectDescendantsAsync(
             rootId,
-            db.Notes.Where(n => n.ArchivedAt == groupArchivedAt));
+            db.Notes.Where(n => n.ArchivedAt == groupArchivedAt),
+            ct);
 
-    private static async Task<List<NoteItem>> CollectDescendantsAsync(Guid rootId, IQueryable<NoteItem> source)
+    private static async Task<List<NoteItem>> CollectDescendantsAsync(Guid rootId, IQueryable<NoteItem> source, CancellationToken ct = default)
     {
         const int maxDepth = 100;
         var result = new List<NoteItem>();
@@ -857,7 +860,7 @@ public class NoteService(
         {
             var children = await source
                 .Where(n => n.ParentNoteId.HasValue && frontier.Contains(n.ParentNoteId.Value))
-                .ToListAsync();
+                .ToListAsync(ct);
             if (children.Count == 0) break;
             result.AddRange(children);
             frontier = children.Select(c => c.Id).ToList();
@@ -865,7 +868,7 @@ public class NoteService(
         return result;
     }
 
-    private async Task StripMentionReferencesAsync(Guid noteId)
+    private async Task StripMentionReferencesAsync(Guid noteId, CancellationToken ct = default)
     {
         var idStr = noteId.ToString();
         // IgnoreQueryFilters so recycle-bin (soft-deleted) notes referencing this
@@ -873,7 +876,7 @@ public class NoteService(
         // note keeps a dead mention pointing at a permanently-deleted note.
         var referencingNotes = await db.Notes.IgnoreQueryFilters()
             .Where(n => n.Content.Contains($"data-note-id=\"{idStr}\""))
-            .ToListAsync();
+            .ToListAsync(ct);
 
         foreach (var n in referencingNotes)
         {
@@ -884,7 +887,7 @@ public class NoteService(
         }
 
         if (referencingNotes.Count > 0)
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsync(ct);
     }
 
     private static string RemovePageLinkFromContent(string content, Guid noteId)
@@ -945,7 +948,7 @@ public class NoteService(
         return WhitespaceRegex.Replace(text, " ").Trim();
     }
 
-    private async Task<Dictionary<Guid, int>> GetChildCountsAsync(IEnumerable<Guid> noteIds)
+    private async Task<Dictionary<Guid, int>> GetChildCountsAsync(IEnumerable<Guid> noteIds, CancellationToken ct = default)
     {
         var ids = noteIds.ToList();
         if (ids.Count == 0) return [];
@@ -953,7 +956,7 @@ public class NoteService(
             .Where(n => n.ParentNoteId.HasValue && ids.Contains(n.ParentNoteId!.Value))
             .GroupBy(n => n.ParentNoteId!.Value)
             .Select(g => new { ParentId = g.Key, Count = g.Count() })
-            .ToDictionaryAsync(x => x.ParentId, x => x.Count);
+            .ToDictionaryAsync(x => x.ParentId, x => x.Count, ct);
     }
 
     private static void PopulateLabels(NoteItem note)


### PR DESCRIPTION
## 개요
`NotesController` 와 `NoteService` 전반에 `CancellationToken` 을 일관되게 배관하여, 클라이언트가 요청을 취소하거나 연결이 끊기면 진행 중인 EF Core 작업도 취소되도록 한다. 기존에 이미 배관된 경로(`ApiTokenService`, `FileCleanupService`, `AccountService`, 백그라운드 잡)의 스타일에 맞췄다.

Closes #140

## 변경 내용
- **`NoteService`**: 모든 async I/O 메서드 시그니처에 `CancellationToken ct = default` 추가, 내부 EF Core 호출(`ToListAsync`, `FirstOrDefaultAsync`, `CountAsync`, `SaveChangesAsync`, `ToDictionaryAsync`, `AnyAsync`, `BeginTransactionAsync`, `CommitAsync`)과 파일 클린업 호출에 `ct` 전파. 내부 BFS/헬퍼(`Collect*`, `StripMentionReferencesAsync`, `GetChildCountsAsync`, `HardDeleteAsync`, `UpdatePageLinkReferences`)까지 토큰을 이어붙여 EF 호출 지점까지 도달하도록 함.
- **`NotesController`**: 각 async 액션이 `CancellationToken` 을 받아 서비스로 전달. `[FromQuery]` 선택 파라미터가 있는 액션은 `CancellationToken ct = default`, 그 외에는 참조 구현(`ApiTokensController`)과 동일하게 `CancellationToken ct` 시그니처 사용. `IsActiveNote` 헬퍼에도 전파.
- **테스트**: 컨트롤러를 직접 호출하는 `ArchiveControllerTests` 호출부를 새 시그니처에 맞게 갱신. 취소 토큰이 실제로 EF Core 까지 도달함을 검증하는 회귀 테스트(`NoteServiceCancellationTests`, 4건) 추가 — 이미 취소된 토큰 전달 시 `OperationCanceledException` 발생 확인.

## 완료 조건 검증
- [x] `NotesController` 의 async 액션이 `CancellationToken` 을 받아 서비스로 전달 — 모든 async 액션 갱신 완료.
- [x] `NoteService` 의 async I/O 메서드가 `CancellationToken` 을 받아 EF Core 호출에 전파 — `NoteServiceCancellationTests` 4건이 GetPaged/Get/Create/Delete 경로에서 취소 전파를 검증.
- [x] 기존 배관 경로와 시그니처 스타일 일치 — 서비스는 `ct = default`, 컨트롤러는 `ApiTokensController` 와 동일 패턴.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0.

## 검증
- `dotnet build Vanadium.slnx` → 경고 0개, 오류 0개
- `dotnet test Vanadium.slnx` → 통과 89, 건너뜀 3(PostgreSQL 전용 트라이그램 테스트), 실패 0

## 범위
프런트엔드(`Vanadium.Note.Web`)와 취소 정책(부분 커밋/롤백·재시도) 변경은 이슈 명시대로 범위 밖으로 두었다.