### PR TITLE
#133 멘션 검색 호출에 150ms 디바운스 추가

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/mention.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/mention.js
@@ -4,7 +4,34 @@ import Suggestion from 'https://esm.sh/@tiptap/suggestion@2'
 
 // ── Mention extension (@) ────────────────────────────────────────────────────
 
+const MENTION_SEARCH_DEBOUNCE_MS = 150;
+
+// Wraps the mention search so it only fires ~150ms after the last keystroke,
+// instead of once per keystroke. Each call supersedes any pending call; a late
+// API response whose query was already superseded is ignored so the menu never
+// renders stale results and the newest query alone drives the list.
+function createDebouncedSearch(dotnetRef, delayMs) {
+    let timer = null;
+    let latestToken = 0;
+    return query => {
+        if (timer) clearTimeout(timer);
+        const token = ++latestToken;
+        return new Promise(resolve => {
+            timer = setTimeout(async () => {
+                timer = null;
+                try {
+                    const results = await dotnetRef.invokeMethodAsync('SearchNotes', query);
+                    if (token === latestToken) resolve(results);
+                } catch {
+                    if (token === latestToken) resolve([]);
+                }
+            }, delayMs);
+        });
+    };
+}
+
 export function createMentionExtension(dotnetRef) {
+    const searchNotes = createDebouncedSearch(dotnetRef, MENTION_SEARCH_DEBOUNCE_MS);
     return Extension.create({
         name: 'mention',
         addProseMirrorPlugins() {
@@ -14,13 +41,7 @@ export function createMentionExtension(dotnetRef) {
                     pluginKey: new PluginKey('mention'),
                     char: '@',
                     allowSpaces: true,
-                    items: async ({ query }) => {
-                        try {
-                            return await dotnetRef.invokeMethodAsync('SearchNotes', query);
-                        } catch {
-                            return [];
-                        }
-                    },
+                    items: ({ query }) => searchNotes(query),
                     render() {
                         let menu = null;
                         let selectedIndex = 0;


### PR DESCRIPTION
Closes #133

## 목적
멘션 제안(`@`) 메뉴가 키스트로크마다 백엔드 검색 API(`SearchNotes` → `SearchForMentionAsync`)를 호출하던 것을 디바운스로 줄인다.

## 변경 내용
- `wwwroot/js/tiptap/extensions/mention.js`
  - `createDebouncedSearch(dotnetRef, 150)` 헬퍼 추가 — 마지막 입력 후 150ms가 지나야 `SearchNotes`를 호출.
  - Suggestion `items({ query })`가 이 디바운스 함수를 통해 검색하도록 변경.
  - 새 입력이 오면 대기 중이던 `setTimeout`을 취소(supersede)하고, 이미 무효화된 쿼리의 지연 API 응답은 토큰 비교로 무시 → 목록이 항상 최신 쿼리 기준으로만 갱신되어 stale/빈 목록 깜빡임이 없음.
  - 렌더링·키보드(화살표/Enter)·클릭 선택·멘션 삽입 로직은 변경 없음.

## 완료 조건 검증
- [x] **디바운스로 API 호출 감소** — 150ms trailing 디바운스. 150ms 이내 연속 키 입력은 `clearTimeout`으로 이전 대기 호출을 취소하여 마지막 입력 1건만 API 호출.
- [x] **제안 목록 정확성 및 선택 동작 유지** — `items()` 반환 형태(`[{id, title}]`) 동일, `render()`/`onKeyDown()`/`command()` 미변경. 토큰 가드로 현재 쿼리 결과만 표시.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0. `dotnet test` 89 통과 / 3 스킵(PostgreSQL 전용) / 0 실패.

## 범위
`SearchForMention`(백엔드)·트라이그램 인덱스·멘션 노드 직렬화는 건드리지 않음. 변경 파일은 `mention.js` 1개.

## 참고
JS 테스트 하네스(package.json/테스트 러너)가 없어 이 변경에 대한 자동 테스트는 추가하지 못함 — 수동 확인 필요.