### PR TITLE
#134 storage 이벤트로 탭 간 토큰 동기화

### DIFF
--- a/Vanadium.Note.Web/Auth/JwtAuthenticationStateProvider.cs
+++ b/Vanadium.Note.Web/Auth/JwtAuthenticationStateProvider.cs
@@ -4,12 +4,26 @@ using System.Text.Json;
 
 namespace Vanadium.Note.Web.Auth;
 
-public class JwtAuthenticationStateProvider(
-    TokenStore tokenStore,
-    ILogger<JwtAuthenticationStateProvider> logger) : AuthenticationStateProvider
+public class JwtAuthenticationStateProvider : AuthenticationStateProvider
 {
     private static readonly AuthenticationState Anonymous =
         new(new ClaimsPrincipal(new ClaimsIdentity()));
+
+    private readonly TokenStore tokenStore;
+    private readonly ILogger<JwtAuthenticationStateProvider> logger;
+
+    public JwtAuthenticationStateProvider(
+        TokenStore tokenStore,
+        ILogger<JwtAuthenticationStateProvider> logger)
+    {
+        this.tokenStore = tokenStore;
+        this.logger = logger;
+        // Cross-tab logout/login: when another tab changes the token, TokenStore
+        // invalidates its cache and raises this event so we re-publish auth state
+        // (issue #134). Both services live for the app's lifetime, so the
+        // subscription needs no explicit teardown.
+        this.tokenStore.TokenChangedExternally += NotifyAuthStateChanged;
+    }
 
     public override async Task<AuthenticationState> GetAuthenticationStateAsync()
     {

--- a/Vanadium.Note.Web/Auth/TokenStore.cs
+++ b/Vanadium.Note.Web/Auth/TokenStore.cs
@@ -2,9 +2,34 @@ using Microsoft.JSInterop;
 
 namespace Vanadium.Note.Web.Auth;
 
-public class TokenStore(IJSRuntime js, ILogger<TokenStore> logger)
+public class TokenStore(IJSRuntime js, ILogger<TokenStore> logger) : IAsyncDisposable
 {
     private string? _cachedToken;
+    private DotNetObjectReference<TokenStore>? _objRef;
+
+    /// <summary>
+    /// Raised when another browser tab changes the stored auth token (cross-tab
+    /// login/logout sync, issue #134). The local <see cref="_cachedToken"/> cache
+    /// is already updated to the new value when this fires.
+    /// </summary>
+    public event Action? TokenChangedExternally;
+
+    /// <summary>
+    /// Registers the cross-tab <c>storage</c> listener. Idempotent — safe to call
+    /// again if the hosting layout is re-created.
+    /// </summary>
+    public async Task InitAsync()
+    {
+        try
+        {
+            _objRef ??= DotNetObjectReference.Create(this);
+            await js.InvokeVoidAsync("tokenSync.init", _objRef);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to initialize cross-tab token sync.");
+        }
+    }
 
     public async Task<string?> GetAsync()
     {
@@ -44,5 +69,30 @@ public class TokenStore(IJSRuntime js, ILogger<TokenStore> logger)
         {
             logger.LogError(ex, "Failed to clear auth token from localStorage.");
         }
+    }
+
+    /// <summary>
+    /// Invoked from JS when another tab changes the <c>authToken</c> localStorage key.
+    /// Invalidates the cached token so subsequent reads reflect the external change,
+    /// then notifies subscribers so auth state can refresh.
+    /// </summary>
+    [JSInvokable]
+    public void OnExternalTokenChange(string? newToken)
+    {
+        _cachedToken = string.IsNullOrWhiteSpace(newToken) ? null : newToken;
+        TokenChangedExternally?.Invoke();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await js.InvokeVoidAsync("tokenSync.dispose");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to dispose cross-tab token sync.");
+        }
+        _objRef?.Dispose();
     }
 }

--- a/Vanadium.Note.Web/Layout/MainLayout.razor
+++ b/Vanadium.Note.Web/Layout/MainLayout.razor
@@ -4,6 +4,7 @@
 @inject ThemeService ThemeService
 @inject AuthenticationStateProvider AuthStateProvider
 @inject KeyboardShortcutService ShortcutService
+@inject TokenStore TokenStore
 @inject NavigationManager Nav
 @inject ILogger<MainLayout> Logger
 @implements IAsyncDisposable
@@ -87,6 +88,7 @@
         if (firstRender)
         {
             await LoadThemeAsync();
+            await TokenStore.InitAsync();
             await ShortcutService.InitAsync();
             await ShortcutService.RegisterAsync("ctrl+n", "New note", () => InvokeAsync(() =>
             {

--- a/Vanadium.Note.Web/wwwroot/index.html
+++ b/Vanadium.Note.Web/wwwroot/index.html
@@ -32,6 +32,7 @@
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script src="js/keyboard-shortcuts.js"></script>
+    <script src="js/token-sync.js"></script>
     <script src="js/focus-trap.js"></script>
     <script src="js/quick-nav.js"></script>
     <script src="js/unsaved-changes.js"></script>

--- a/Vanadium.Note.Web/wwwroot/js/token-sync.js
+++ b/Vanadium.Note.Web/wwwroot/js/token-sync.js
@@ -1,0 +1,32 @@
+(function () {
+    'use strict';
+
+    let _ref = null;
+
+    // The `storage` event fires only in OTHER tabs/windows of the same origin,
+    // never in the tab that made the change. So this exclusively carries
+    // cross-tab auth token changes (login/logout), which is what we want to
+    // sync back into TokenStore's cache (issue #134).
+    function _onStorage(e) {
+        // e.key is null when localStorage.clear() is called; treat that as an
+        // authToken change too. Otherwise only react to the authToken key.
+        if (e.key !== null && e.key !== 'authToken') return;
+        const newValue = e.key === null ? null : e.newValue;
+        _ref?.invokeMethodAsync('OnExternalTokenChange', newValue)
+            .catch(err => console.error('[token-sync] OnExternalTokenChange failed:', err));
+    }
+
+    window.tokenSync = {
+        init(dotnetRef) {
+            _ref = dotnetRef;
+            // Idempotent: removing first keeps a re-init (e.g. after logout then
+            // login re-creates the layout) from stacking duplicate listeners.
+            window.removeEventListener('storage', _onStorage);
+            window.addEventListener('storage', _onStorage);
+        },
+        dispose() {
+            window.removeEventListener('storage', _onStorage);
+            _ref = null;
+        }
+    };
+}());


### PR DESCRIPTION
Closes #134

## 목적
`TokenStore`가 최초 조회 시 `_cachedToken`에 JWT를 캐시한 뒤 `localStorage`를 다시 읽지 않아, 한 탭에서 로그아웃해도 다른 탭이 캐시된 토큰으로 로그인 상태를 유지하는 문제를 해결한다.

## 변경 내용
- **`wwwroot/js/token-sync.js` (신규)** — `window`의 `storage` 이벤트를 구독해 다른 탭에서 `authToken`이 변경/제거되면 .NET 콜백(`OnExternalTokenChange`)을 호출한다. `storage` 이벤트는 변경을 일으킨 탭이 아닌 다른 탭에서만 발생하므로 탭 간 동기화에 정확히 부합한다. `localStorage.clear()`로 `e.key`가 null인 경우도 처리하며, init은 멱등하게 구현해 레이아웃 재생성 시 리스너가 중복 등록되지 않는다.
- **`Auth/TokenStore.cs`** — `IAsyncDisposable` 구현, `DotNetObjectReference` 보유, `InitAsync()`/`[JSInvokable] OnExternalTokenChange` 추가. 외부 변경 시 `_cachedToken`을 새 값(또는 null)으로 갱신하고 `TokenChangedExternally` 이벤트를 발생시킨다.
- **`Auth/JwtAuthenticationStateProvider.cs`** — 생성자에서 `TokenChangedExternally`를 구독해 `NotifyAuthStateChanged()`를 호출한다(DI 순환 없음 — 이미 `TokenStore` 의존).
- **`Layout/MainLayout.razor`** — 최초 렌더 시 `TokenStore.InitAsync()` 호출(기존 `ShortcutService.InitAsync` 위치와 동일).
- **`wwwroot/index.html`** — `token-sync.js` 스크립트 포함.

## 완료 조건 검증
- [x] **한 탭에서 로그아웃하면 다른 탭에도 반영** — 다른 탭의 `storage` 이벤트 → `OnExternalTokenChange(null)` → 캐시 무효화 + `NotifyAuthStateChanged` → `AuthorizeRouteView`가 익명으로 재평가 → `RedirectToLogin`. (코드 경로로 검증; Web 프로젝트는 테스트 프로젝트 없음)
- [x] **외부 `authToken` 변경 시 캐시 무효화** — `OnExternalTokenChange`가 `_cachedToken`을 새 값으로 덮어씀.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0개. `dotnet test` 89 통과/3 스킵(PostgreSQL 전용, 기존)/0 실패.

## 범위
리프레시 토큰 미도입, 토큰 저장 위치(`localStorage`) 유지 — 범위 밖 항목 미변경.