### PR TITLE
#125 페이지 레벨 반응형 미디어 쿼리 추가

### DIFF
--- a/Vanadium.Note.Web/Pages/Archive.razor.css
+++ b/Vanadium.Note.Web/Pages/Archive.razor.css
@@ -189,3 +189,33 @@
     opacity: 0.5;
     white-space: nowrap;
 }
+
+/* ── Responsive (narrow / mobile) ───────────────────────────────────────────
+   Complements the desktop breakpoint in MainLayout.razor.css (min-width: 641px).
+   The desktop row (1fr 10rem 13rem) is wider than a phone viewport, so on
+   narrow screens the row stacks vertically and the aligned header is hidden. */
+@media (max-width: 640px) {
+    .archive-header {
+        flex-wrap: wrap;
+    }
+
+    .note-header {
+        display: none;
+    }
+
+    .note-row {
+        grid-template-columns: 1fr;
+        row-gap: 0.4rem;
+        padding: 0.6rem 0.75rem;
+    }
+
+    .col-date {
+        text-align: left;
+        font-size: 0.72rem;
+    }
+
+    .col-actions {
+        justify-content: flex-start;
+        flex-wrap: wrap;
+    }
+}

--- a/Vanadium.Note.Web/Pages/Board.razor.css
+++ b/Vanadium.Note.Web/Pages/Board.razor.css
@@ -330,3 +330,16 @@
     justify-content: flex-end;
     gap: 0.5rem;
 }
+
+/* ── Responsive (narrow / mobile) ───────────────────────────────────────────
+   Complements the desktop breakpoint in MainLayout.razor.css (min-width: 641px).
+   The columns container already scrolls horizontally; on a phone viewport a
+   fixed 280px column leaves almost no margin, so columns become viewport-width
+   and the user swipes between them. */
+@media (max-width: 640px) {
+    .board-column {
+        width: 82vw;
+        min-width: 0;
+        max-width: 300px;
+    }
+}

--- a/Vanadium.Note.Web/Pages/Home.razor.css
+++ b/Vanadium.Note.Web/Pages/Home.razor.css
@@ -456,3 +456,29 @@ a.note-title-text:hover {
     opacity: 0.5;
     white-space: nowrap;
 }
+
+/* ── Responsive (narrow / mobile) ───────────────────────────────────────────
+   Complements the desktop breakpoint in MainLayout.razor.css (min-width: 641px).
+   Tightens the note table so it fits a phone-width viewport without clipping. */
+@media (max-width: 640px) {
+    .notes-header {
+        flex-wrap: wrap;
+    }
+
+    .notes-search {
+        max-width: none;
+    }
+
+    .note-row {
+        grid-template-columns: 2rem 1fr 8.5rem;
+        padding: 0.5rem 0.6rem;
+    }
+
+    .col-date {
+        font-size: 0.72rem;
+    }
+
+    .pagination-info {
+        display: none;
+    }
+}

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor.css
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor.css
@@ -632,3 +632,21 @@
     gap: 0.5rem;
     flex-shrink: 0;
 }
+
+/* ── Responsive (narrow / mobile) ───────────────────────────────────────────
+   Complements the desktop breakpoint in MainLayout.razor.css (min-width: 641px).
+   The header already wraps (flex-wrap); on a phone viewport, trim the editor
+   body padding and title size so content is not cramped against the edges. */
+@media (max-width: 640px) {
+    .editor-actions {
+        margin-left: 0;
+    }
+
+    .editor-body {
+        padding: 1rem 0.9rem;
+    }
+
+    .editor-title {
+        font-size: 1.25rem;
+    }
+}

--- a/Vanadium.Note.Web/Pages/RecycleBin.razor.css
+++ b/Vanadium.Note.Web/Pages/RecycleBin.razor.css
@@ -200,3 +200,33 @@
     opacity: 0.5;
     white-space: nowrap;
 }
+
+/* ── Responsive (narrow / mobile) ───────────────────────────────────────────
+   Complements the desktop breakpoint in MainLayout.razor.css (min-width: 641px).
+   The desktop row (1fr 10rem 13rem) is wider than a phone viewport, so on
+   narrow screens the row stacks vertically and the aligned header is hidden. */
+@media (max-width: 640px) {
+    .recycle-bin-header {
+        flex-wrap: wrap;
+    }
+
+    .note-header {
+        display: none;
+    }
+
+    .note-row {
+        grid-template-columns: 1fr;
+        row-gap: 0.4rem;
+        padding: 0.6rem 0.75rem;
+    }
+
+    .col-date {
+        text-align: left;
+        font-size: 0.72rem;
+    }
+
+    .col-actions {
+        justify-content: flex-start;
+        flex-wrap: wrap;
+    }
+}


### PR DESCRIPTION
Closes #125

## 목적
페이지 레벨 미디어 쿼리가 없어 좁은(모바일) 화면에서 노트 테이블/보드/에디터 헤더가 가로로 오버플로되던 문제를 해소한다. 이슈의 두 선택지 중 **반응형 추가**를 택했다(제목·라벨·마일스톤이 기능 추가를 의도). 데스크톱 전용 방침이 아니므로 CLAUDE.md 변경은 없다.

## 변경 내용
레이아웃 CSS(`MainLayout.razor.css`)가 이미 쓰는 데스크톱 브레이크포인트 `min-width: 641px`와 짝을 이루도록, 페이지 CSS에 `@media (max-width: 640px)` 블록을 추가했다. 백엔드/스키마 변경 없음.

- **Home.razor.css** — 노트 행 열 폭(`2.5rem 1fr 10rem` → `2rem 1fr 8.5rem`)·여백 축소, 검색창 전체 폭, 헤더 줄바꿈, 페이지네이션 정보 숨김
- **Archive.razor.css / RecycleBin.razor.css** — 행이 `1fr 10rem 13rem`(고정 폭 합계 ≈ 368px)이라 375px 뷰포트를 넘겨 잘리던 것을 세로 스택(`grid-template-columns: 1fr`)으로 전환하고, 정렬이 무의미해진 헤더 행은 숨김
- **Board.razor.css** — 이미 가로 스크롤되는 컬럼 컨테이너에서 고정 280px 컬럼을 뷰포트 폭(`82vw`, 최대 300px)으로 바꿔 한 화면에 한 컬럼씩 스와이프
- **NoteEditor.razor.css** — 헤더는 이미 `flex-wrap`으로 줄바꿈되므로, 본문 여백·제목 크기만 축소

## 완료 조건 검증
- **좁은 화면(375px)에서 오버플로 없이 표시** — 가장 심하게 넘치던 Archive/RecycleBin 행을 세로 스택으로 전환해 고정 폭 열 오버플로를 제거. Home은 `1fr`이 폭을 흡수하고, Board는 컬럼이 뷰포트 폭이라 스크롤로 접근, 에디터 헤더는 `flex-wrap`으로 줄바꿈. 실제 브라우저 렌더링은 이 환경에서 확인 불가하여 **수동 확인 필요**.
- **빌드 클린** — `dotnet build Vanadium.slnx` → 경고 0 / 오류 0. `dotnet test Vanadium.slnx` → 89 통과, 3 스킵(PostgreSQL 전용), 0 실패.

## 범위
`Pages/*.razor.css` 5개 파일만 수정. 백엔드/스키마 변경 없음, 터치 제스처 등 모바일 전용 UX 재설계는 범위 밖.
