### PR TITLE
#184 노트 에디터 라벨 영역 시각적 구분 개선

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor.css
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor.css
@@ -268,43 +268,61 @@
     z-index: 2;
 }
 
-/* ── Label bar ──────────────────────────────────────────────────────────── */
+/* ── Label bar ────────────────────────────────────────────────────────────
+   The bar and its chips/buttons are rendered by the shared <LabelPicker> child
+   component, so these rules must pierce component isolation with ::deep — a
+   plain `.label-bar { }` here would not reach the child's markup. */
 
-.label-bar {
+.editor-body ::deep .label-bar {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 0.35rem;
-    padding: 0.4rem 0 0.5rem;
-    margin-bottom: 0.5rem;
-    border-bottom: 1px solid var(--vn-editor-title-border);
+    padding: 0.4rem 0.6rem;
+    margin-bottom: 0.75rem;
+    background-color: var(--vn-label-bar-bg);
+    border: 1px solid var(--vn-label-bar-border);
+    border-radius: 6px;
     min-height: 2.2rem;
 }
 
-.label-chip {
+/* Leading caption so the strip reads as the "labels" zone even when empty. */
+.editor-body ::deep .label-bar::before {
+    content: "Labels";
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--vn-label-caption-color);
+    margin-right: 0.15rem;
+    user-select: none;
+}
+
+.editor-body ::deep .label-chip {
     display: inline-flex;
     align-items: center;
     gap: 0.2rem;
-    padding: 0.15rem 0.45rem;
+    padding: 0.15rem 0.5rem;
     border-radius: 999px;
     font-size: 0.78rem;
-    background-color: var(--mud-palette-action-default-hover);
-    border: 1px solid var(--mud-palette-divider);
+    font-weight: 500;
+    background-color: var(--vn-label-chip-bg);
+    border: 1px solid var(--vn-label-chip-border);
     color: inherit;
     white-space: nowrap;
 }
 
-.label-chip-cat {
+.editor-body ::deep .label-chip-cat {
     border-color: var(--mud-palette-primary);
 }
 
-.label-cat-prefix {
+.editor-body ::deep .label-cat-prefix {
     font-size: 0.7rem;
     opacity: 0.65;
     margin-right: 0.1rem;
 }
 
-.label-chip-remove {
+.editor-body ::deep .label-chip-remove {
     background: none;
     border: none;
     cursor: pointer;
@@ -315,21 +333,21 @@
     opacity: 0.55;
 }
 
-.label-chip-remove:hover {
+.editor-body ::deep .label-chip-remove:hover {
     opacity: 1;
 }
 
-.label-add-hint {
+.editor-body ::deep .label-add-hint {
     font-size: 0.75rem;
     opacity: 0.5;
     font-style: italic;
 }
 
-.label-add-wrapper {
+.editor-body ::deep .label-add-wrapper {
     position: relative;
 }
 
-.label-add-btn {
+.editor-body ::deep .label-add-btn {
     background: none;
     border: 1px dashed var(--mud-palette-divider);
     border-radius: 999px;
@@ -341,12 +359,12 @@
     transition: opacity 0.15s;
 }
 
-.label-add-btn:hover {
+.editor-body ::deep .label-add-btn:hover {
     opacity: 1;
     border-color: var(--mud-palette-primary);
 }
 
-.label-add-btn-active {
+.editor-body ::deep .label-add-btn-active {
     opacity: 1;
     border-color: var(--mud-palette-primary);
     color: var(--mud-palette-primary);
@@ -354,13 +372,13 @@
 
 /* ── Label picker dropdown ──────────────────────────────────────────────── */
 
-.label-picker-backdrop {
+.editor-body ::deep .label-picker-backdrop {
     position: fixed;
     inset: 0;
     z-index: 199;
 }
 
-.label-picker {
+.editor-body ::deep .label-picker {
     position: absolute;
     top: calc(100% + 0.25rem);
     left: 0;
@@ -373,15 +391,15 @@
     padding: 0.3rem 0;
 }
 
-.label-picker-section {
+.editor-body ::deep .label-picker-section {
     padding: 0.25rem 0;
 }
 
-.label-picker-section + .label-picker-section {
+.editor-body ::deep .label-picker-section + .label-picker-section {
     border-top: 1px solid var(--mud-palette-divider);
 }
 
-.label-picker-section-title {
+.editor-body ::deep .label-picker-section-title {
     font-size: 0.7rem;
     font-weight: 600;
     opacity: 0.55;
@@ -390,7 +408,7 @@
     padding: 0.2rem 0.75rem 0.1rem;
 }
 
-.label-picker-item {
+.editor-body ::deep .label-picker-item {
     display: flex;
     align-items: center;
     gap: 0.4rem;
@@ -399,22 +417,22 @@
     cursor: pointer;
 }
 
-.label-picker-item:hover {
+.editor-body ::deep .label-picker-item:hover {
     background-color: var(--mud-palette-action-default-hover);
 }
 
-.label-picker-item.is-added {
+.editor-body ::deep .label-picker-item.is-added {
     font-weight: 600;
 }
 
-.label-picker-check {
+.editor-body ::deep .label-picker-check {
     width: 1rem;
     text-align: center;
     font-size: 0.75rem;
     color: var(--mud-palette-primary);
 }
 
-.label-picker-empty {
+.editor-body ::deep .label-picker-empty {
     padding: 0.5rem 0.75rem;
     font-size: 0.82rem;
     opacity: 0.5;

--- a/Vanadium.Note.Web/wwwroot/css/app.css
+++ b/Vanadium.Note.Web/wwwroot/css/app.css
@@ -17,6 +17,12 @@
     --vn-editor-code-color: #c92a2a;
     --vn-editor-pre-bg: #f8f9fa;
     --vn-editor-hr-color: #dee2e6;
+    /* Label bar / chips */
+    --vn-label-bar-bg: #f6f6fb;
+    --vn-label-bar-border: #e3e2ef;
+    --vn-label-chip-bg: #ececf5;
+    --vn-label-chip-border: #cfced2;
+    --vn-label-caption-color: #8a8a9c;
     --vn-link-popover-bg: #ffffff;
     --vn-link-popover-border: #dee2e6;
     --vn-link-popover-color: #333;
@@ -74,6 +80,12 @@ body.dark-mode {
     --vn-editor-code-color: #ff8080;
     --vn-editor-pre-bg: #22222e;
     --vn-editor-hr-color: #3a3a4e;
+    /* Label bar / chips */
+    --vn-label-bar-bg: #232334;
+    --vn-label-bar-border: #3a3a4e;
+    --vn-label-chip-bg: #32324a;
+    --vn-label-chip-border: #4a4a63;
+    --vn-label-caption-color: #8a8aa2;
     --vn-link-popover-bg: #2a2a3e;
     --vn-link-popover-border: #4a4a5e;
     --vn-link-popover-color: #e0e0e0;


### PR DESCRIPTION
## 개요
Closes #184

노트 에디터에서 라벨 영역이 본문과 시각적으로 구분되지 않고, 라벨이 일반 텍스트처럼 보이던 문제를 개선한다. 순수 프론트엔드 CSS 변경이다.

## 변경 내용
- **라벨 바(`.label-bar`)**: 하단 border만 있던 약한 구분을 배경색·전체 테두리·둥근 모서리를 가진 별도 영역으로 변경하고, `::before`로 "LABELS" 캡션을 추가해 본문 입력 영역과 명확히 구분.
- **라벨 칩(`.label-chip`)**: 거의 보이지 않던 hover 색 배경 대신 전용 배경/테두리 색을 적용해 뱃지 형태로 인지되도록 강화.
- **CSS 변수**: 라이트/다크 테마용 `--vn-label-bar-bg`, `--vn-label-bar-border`, `--vn-label-chip-bg`, `--vn-label-chip-border`, `--vn-label-caption-color`를 `app.css`의 `:root` / `body.dark-mode`에 추가.
- **스코프 수정(핵심)**: 라벨 바/칩/추가 버튼/드롭다운은 공용 자식 컴포넌트 `<LabelPicker>`가 렌더링한다. 기존 `NoteEditor.razor.css`의 스코프 스타일은 자식 컴포넌트 마크업에 적용되지 않으므로(Blazor CSS isolation), 선택자를 `.editor-body ::deep ...` 형태로 수정해 실제로 적용되도록 함. (기존 파일의 `.tiptap-wrapper ::deep` 패턴과 동일한 관용구.)

## 완료 조건 검증
- [x] 라벨 영역이 본문과 시각적으로 구분됨 — 배경/테두리/캡션이 적용된 별도 패널로 표시 (스크린샷 확인).
- [x] 라벨이 칩/뱃지 형태로 일반 텍스트와 구분됨 — 배경·테두리 강화 (스크린샷 확인).
- [x] 라벨이 없을 때도 라벨 영역 힌트 유지 — "LABELS" 캡션 + 점선 "+ Label" 버튼 (스크린샷 확인).
- [x] 다크/라이트 테마 모두에서 구분 유지 — 양쪽 테마 스크린샷으로 확인.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0/오류 0.
- [x] `dotnet test Vanadium.slnx` — 89 통과 (3 PostgreSQL 전용 skip, 기존과 동일).

## 검증 방법 관련 참고
Web 프로젝트는 테스트 프로젝트가 없어(자동 테스트 대상 아님), 라벨 UI를 실제 마크업/CSS/CSS 변수로 재현한 독립 HTML 하네스를 Playwright로 라이트·다크 스크린샷 캡처하여 시각적으로 검증했다. 에디터 페이지는 비밀번호 인증 뒤에 있어 실제 앱 구동 검증은 로컬에서 수동 확인이 필요할 수 있다.