### PR TITLE
#186 노트 라벨 표시 순서를 카테고리 우선 그룹 정렬로 개선

### DIFF
--- a/Vanadium.Note.REST.Tests/LabelOrderingTests.cs
+++ b/Vanadium.Note.REST.Tests/LabelOrderingTests.cs
@@ -1,0 +1,58 @@
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Issue #186: note-label chips must not interleave category and general labels.
+/// The service orders category labels first (grouped by category name), then
+/// general labels, alphabetically by name within each group.
+/// </summary>
+public class LabelOrderingTests
+{
+    [Fact]
+    public async Task Get_OrdersLabels_CategoryFirstThenGeneral_ByNameWithinGroup()
+    {
+        using var h = new TestHost();
+
+        var category = await h.Labels.CreateCategoryAsync("Priority");
+        // Names chosen so a pure name-sort would interleave the category label
+        // ("mmm") between the two general labels ("aaa", "zzz").
+        var catLabel = await h.Labels.CreateLabelAsync("mmm", category.Id);
+        var generalZ = await h.Labels.CreateLabelAsync("zzz", null);
+        var generalA = await h.Labels.CreateLabelAsync("aaa", null);
+
+        var note = await h.CreateNoteAsync();
+        // Add in an order that neither matches insertion nor pure name-sort output.
+        await h.Labels.AddLabelToNoteAsync(note.Id, generalZ.Id);
+        await h.Labels.AddLabelToNoteAsync(note.Id, catLabel.Id);
+        await h.Labels.AddLabelToNoteAsync(note.Id, generalA.Id);
+
+        var loaded = await h.Notes.Get(note.Id);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(new[] { "mmm", "aaa", "zzz" }, loaded!.Labels.Select(l => l.Name));
+    }
+
+    [Fact]
+    public async Task GetPaged_OrdersLabels_CategoryFirstThenGeneral()
+    {
+        using var h = new TestHost();
+
+        var category = await h.Labels.CreateCategoryAsync("Status");
+        var catLabel = await h.Labels.CreateLabelAsync("mmm", category.Id);
+        var generalZ = await h.Labels.CreateLabelAsync("zzz", null);
+        var generalA = await h.Labels.CreateLabelAsync("aaa", null);
+
+        var note = await h.CreateNoteAsync();
+        await h.Labels.AddLabelToNoteAsync(note.Id, generalZ.Id);
+        await h.Labels.AddLabelToNoteAsync(note.Id, catLabel.Id);
+        await h.Labels.AddLabelToNoteAsync(note.Id, generalA.Id);
+
+        var paged = await h.Notes.GetPaged(
+            page: 1, pageSize: 10, search: null, sortBy: "date", sortDir: "desc", labelIds: null);
+
+        var summary = Assert.Single(paged.Items);
+        Assert.Equal(new[] { "mmm", "aaa", "zzz" }, summary.Labels.Select(l => l.Name));
+    }
+}

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -97,7 +97,7 @@ public class NoteService(
                 ParentTitle = n.ParentNoteId.HasValue ? parentTitles.GetValueOrDefault(n.ParentNoteId.Value) : null,
                 ChildCount = childCounts.GetValueOrDefault(n.Id),
                 IsArchived = n.IsArchived,
-                Labels = n.Labels.OrderBy(l => l.Name).ToList()
+                Labels = OrderLabelsForDisplay(n.Labels).ToList()
             }).ToList(),
             TotalCount = totalCount,
             Page = page,
@@ -142,7 +142,7 @@ public class NoteService(
             UpdatedAt = n.UpdatedAt,
             ParentNoteId = n.ParentNoteId,
             ChildCount = childCounts.GetValueOrDefault(n.Id),
-            Labels = n.Labels.OrderBy(l => l.Name).ToList()
+            Labels = OrderLabelsForDisplay(n.Labels).ToList()
         }).ToList();
     }
 
@@ -177,7 +177,7 @@ public class NoteService(
             UpdatedAt = n.UpdatedAt,
             ParentNoteId = n.ParentNoteId,
             ChildCount = childCounts.GetValueOrDefault(n.Id),
-            Labels = n.Labels.OrderBy(l => l.Name).ToList()
+            Labels = OrderLabelsForDisplay(n.Labels).ToList()
         }).ToList();
     }
 
@@ -961,15 +961,25 @@ public class NoteService(
 
     private static void PopulateLabels(NoteItem note)
     {
-        note.Labels = note.NoteLabels
-            .Select(nl => new LabelSummary
+        note.Labels = OrderLabelsForDisplay(
+            note.NoteLabels.Select(nl => new LabelSummary
             {
                 Id = nl.Label.Id,
                 Name = nl.Label.Name,
                 CategoryId = nl.Label.CategoryId,
                 CategoryName = nl.Label.Category?.Name
-            })
-            .OrderBy(l => l.Name)
+            }))
             .ToList();
     }
+
+    /// <summary>
+    /// Orders labels for display so category and general labels do not interleave
+    /// (issue #186): category labels first, grouped by category name, then general
+    /// labels, sorted alphabetically by name within each group.
+    /// </summary>
+    private static IOrderedEnumerable<LabelSummary> OrderLabelsForDisplay(IEnumerable<LabelSummary> labels) =>
+        labels
+            .OrderBy(l => l.CategoryId.HasValue ? 0 : 1)
+            .ThenBy(l => l.CategoryName)
+            .ThenBy(l => l.Name);
 }

--- a/Vanadium.Note.Web/Models/LabelOrdering.cs
+++ b/Vanadium.Note.Web/Models/LabelOrdering.cs
@@ -1,0 +1,15 @@
+namespace Vanadium.Note.Web.Models;
+
+/// <summary>
+/// Shared display ordering for note-label chips (issue #186): category labels
+/// first, grouped by category name, then general labels, sorted alphabetically
+/// by name within each group — so category and general labels do not interleave.
+/// </summary>
+public static class LabelOrdering
+{
+    public static IOrderedEnumerable<Label> OrderForDisplay(this IEnumerable<Label> labels) =>
+        labels
+            .OrderBy(l => l.CategoryId.HasValue ? 0 : 1)
+            .ThenBy(l => l.CategoryName)
+            .ThenBy(l => l.Name);
+}

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -863,7 +863,7 @@
                 noteLabels.RemoveAll(l => l.CategoryId == label.CategoryId);
 
             noteLabels.Add(label);
-            noteLabels = [.. noteLabels.OrderBy(l => l.Name)];
+            noteLabels = [.. noteLabels.OrderForDisplay()];
         }
     }
 

--- a/Vanadium.Note.Web/Pages/SubNoteDialog.razor
+++ b/Vanadium.Note.Web/Pages/SubNoteDialog.razor
@@ -302,7 +302,7 @@
             if (label.CategoryId.HasValue)
                 noteLabels.RemoveAll(l => l.CategoryId == label.CategoryId);
             noteLabels.Add(label);
-            noteLabels = [.. noteLabels.OrderBy(l => l.Name)];
+            noteLabels = [.. noteLabels.OrderForDisplay()];
         }
     }
 


### PR DESCRIPTION
## 개요
Closes #186

노트에 붙은 라벨을 이름(텍스트) 순으로만 정렬해 카테고리 라벨과 일반 라벨이 한 줄에 섞여 표시되던 문제를 개선한다. 카테고리 라벨과 일반 라벨을 그룹으로 분리해 표시한다. 순수 표시 순서 변경으로 스키마 변경은 없다.

## 정렬 규칙
- **카테고리 라벨 먼저** (카테고리명 순 → 라벨명 순), **그다음 일반 라벨** (라벨명 순).
- 각 그룹 내부는 기존과 동일하게 이름 순.

> 이슈에 `(추론 — 확인 필요)`로 표시했던 그룹 순서는 "카테고리 먼저 → 일반"으로 구현했다. 반대 순서(일반 먼저)를 원하면 `OrderLabelsForDisplay` / `OrderForDisplay`의 1차 키만 뒤집으면 된다.

## 변경 내용
### 백엔드
- `Vanadium.Note.REST/Services/NoteService.cs` — `OrderLabelsForDisplay(IEnumerable<LabelSummary>)` 헬퍼 추가. 라벨을 표시하는 모든 경로에 적용:
  - `GetPaged` / `GetAllSummaries` / `GetChildren`(노트 목록 요약, 3곳)의 `Labels` 정렬
  - `PopulateLabels`(단일 노트 조회 → 에디터) 정렬
- 기존 `OrderBy(l => l.Name)` → 그룹 정렬(`CategoryId 유무 → CategoryName → Name`)로 교체.

### 프론트엔드
- `Vanadium.Note.Web/Models/LabelOrdering.cs` (신규) — `OrderForDisplay()` 확장 메서드(백엔드와 동일 규칙).
- `Pages/NoteEditor.razor`, `Pages/SubNoteDialog.razor` — 라벨 추가 후 재정렬 로직을 `OrderBy(l => l.Name)` → `OrderForDisplay()`로 교체(초기 로드 순서는 백엔드가 이미 그룹 정렬로 제공).

## 완료 조건 검증
- [x] 카테고리 라벨과 일반 라벨이 그룹별로 분리되어 표시됨(이름 순 혼합 아님) — 회귀 테스트 `LabelOrderingTests`(Get + GetPaged) 및 시각 하네스 스크린샷으로 확인.
- [x] 라벨 표시 주요 위치(에디터 라벨 바, 홈 노트 라벨 칩)에서 동일한 그룹 정렬 적용 — 에디터 경로(`Get`/`PopulateLabels`)와 목록 경로(`GetPaged` 외)에 동일 헬퍼 적용, 프론트 재정렬도 동일 규칙.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0/오류 0.
- [x] `dotnet test Vanadium.slnx` — 91 통과(신규 2 포함), 3 skip(PostgreSQL 전용, 기존과 동일).

## 검증 방법
- 신규 유닛 테스트 2건: 이름 순이면 뒤섞일 라벨 집합(일반 `aaa`/`zzz`, 카테고리 `mmm`)을 넣고 `Get`·`GetPaged` 결과가 `[mmm, aaa, zzz]`(카테고리 우선) 순임을 검증.
- Web 프로젝트는 테스트 프로젝트가 없어, 실제 칩 마크업/스타일을 재현한 HTML 하네스로 "이름 순(기존, 섞임) vs 그룹 정렬(개선)"을 Playwright 스크린샷으로 대조 확인. 실제 앱 육안 확인은 로컬에서 수동 확인 권장.