### PR TITLE
#139 CLAUDE.md 문서 불일치 정정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ dotnet ef database update --project Vanadium.Note.REST
 docker compose up -d
 ```
 
-Required env vars for `docker-compose.yml`: `DB_PASSWORD`, `AUTH_JWT_SECRET`. Optional: `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `CORS_ALLOWED_ORIGINS`, `API_BASE_URL`.
+Required env vars for `docker-compose.yml`: `DB_PASSWORD`, `AUTH_JWT_SECRET`, `AUTH_PASSWORD_HASH`. Optional: `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `CORS_ALLOWED_ORIGINS`, `API_BASE_URL`.
 
 ### Verifying a change
 
@@ -96,7 +96,12 @@ Editor-layer-only feature (no backend/schema change): toggle blocks (`/toggle`),
 
 ### File uploads
 
-Files are uploaded to `Vanadium.Note.REST/uploads/` as `file_{guid}`. Metadata is stored in `FileAttachments`. An `OrphanFileCleanupJob` (background hosted service) periodically removes files whose GUIDs no longer appear in any note's HTML content. Soft-deleted notes' content still counts as a live reference (the scans use `IgnoreQueryFilters()`).
+Two upload kinds share the `Vanadium.Note.REST/uploads/` directory:
+
+- **File attachments** (`FilesController`) — stored on disk as `file_{guid}` (no extension), with a metadata row in `FileAttachments`. The upload response returns `url = /api/files/{guid}`, and that is the reference form embedded in note HTML.
+- **Images** (`ImagesController`) — stored on disk as `{guid}{ext}` (extension preserved), with **no** DB record. The upload response returns `url = /api/images/{guid}`.
+
+An `OrphanFileCleanupJob` (background hosted service) periodically removes files whose GUIDs no longer appear in any note's HTML content — `FileCleanupService` scans note HTML for `/api/files/{guid}` and `/api/images/{guid}` references. Soft-deleted notes' content still counts as a live reference (the scans use `IgnoreQueryFilters()`).
 
 ### Note recycle bin (soft delete)
 
@@ -146,10 +151,17 @@ The frontend's dev API base URL is set in `Vanadium.Note.Web/wwwroot/appsettings
 
 Order matters. Registered in `Program.cs`:
 
-1. `CorrelationIdMiddleware` — assigns/propagates `X-Correlation-Id`
-2. `UserContextMiddleware` — pushes username into Serilog `LogContext`
-3. `RequestLoggingMiddleware` — structured request log
-4. CORS, Authentication, Authorization, RateLimiter
+1. `UseForwardedHeaders` — restores client IP / request scheme from the reverse proxy
+2. `UseHsts` — non-Development only
+3. `SecurityHeadersMiddleware` — security response headers
+4. `CorrelationIdMiddleware` — assigns/propagates `X-Correlation-Id`
+5. `UseCors`
+6. `UseRateLimiter`
+7. `UseAuthentication`
+8. `UserContextMiddleware` — pushes username into Serilog `LogContext`
+9. `RequestLoggingMiddleware` — structured request log
+10. `UseAuthorization`
+11. `MapControllers`
 
 When adding new middleware, place it AFTER `CorrelationIdMiddleware` so logs carry the correlation ID.
 
@@ -192,5 +204,5 @@ A keyboard-first note switcher opened by `Ctrl+K` (Windows/Linux) / `Cmd+K` (mac
 - **Schema changes:** always create an EF Core migration (`dotnet ef migrations add <Name> --project Vanadium.Note.REST`). Never edit existing migration files.
 - **New API endpoint:** add (1) DTO in `Vanadium.Note.REST/Models`, (2) DTO mirror in `Vanadium.Note.Web/Models`, (3) HTTP client method in `NoteService`/`LabelService`/etc.
 - **Tiptap editor changes:** all JS interop must go through `tiptapInterop.*` in `wwwroot/js/tiptap-editor.js` and be invoked only from `NoteEditor.razor`. Do not call interop from other components.
-- **File uploads:** orphan cleanup expects file references to appear as `/uploads/file_{guid}` substrings in note HTML. Changing the URL format requires updating `OrphanFileCleanupJob`.
+- **File uploads:** orphan cleanup expects file references to appear as `/api/files/{guid}` (attachments) and `/api/images/{guid}` (images) substrings in note HTML. Changing either URL format requires updating `FileCleanupService`'s scan patterns.
 - **Label categories:** mutual exclusion within a category is enforced server-side in `NoteService`, not via DB constraint. Frontend should not assume DB will reject duplicates.


### PR DESCRIPTION
Closes #139

## 개요
`CLAUDE.md` 의 서술이 실제 코드/설정과 어긋난 세 항목을 실제 구현에 맞게 정정한다. 문서(`CLAUDE.md`)만 변경하며 코드/설정은 건드리지 않는다.

## 변경 내용
1. **미들웨어 순서** — "Middleware pipeline (REST)" 섹션을 `Program.cs` 실제 등록 순서(`UseForwardedHeaders` → `UseHsts` → `SecurityHeadersMiddleware` → `CorrelationIdMiddleware` → `UseCors` → `UseRateLimiter` → `UseAuthentication` → `UserContextMiddleware` → `RequestLoggingMiddleware` → `UseAuthorization` → `MapControllers`)로 갱신.
2. **필수 env** — "Docker (production)" 필수 env 목록에 `AUTH_PASSWORD_HASH` 추가. `docker-compose.yml:10` 이 기본값 없이 `Auth__PasswordHash: ${AUTH_PASSWORD_HASH}` 를 참조하므로 필수 값이다.
3. **저장/참조 포맷** — "File uploads" 섹션을 실제 구현에 맞게 정정: 첨부파일은 디스크 `file_{guid}`(확장자 없음)+DB 레코드, 참조 URL `/api/files/{guid}`; 이미지는 디스크 `{guid}{ext}`+DB 레코드 없음, 참조 URL `/api/images/{guid}`. "When making changes" 의 orphan cleanup 항목도 기존 `/uploads/file_{guid}` 오기를 `/api/files/{guid}` · `/api/images/{guid}` 로 정정.

## 완료 조건 검증
- [x] 미들웨어 순서가 `Program.cs:242-261` 와 일치
- [x] Docker 필수 env 에 `AUTH_PASSWORD_HASH` 포함 (`docker-compose.yml:10`)
- [x] 파일/이미지 저장·참조 포맷이 실제 코드(`FilesController.cs:80`, `ImagesController.cs:48`, `FileCleanupService.cs:23-30`)와 일치
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0

## 범위
문서만 변경(`CLAUDE.md` 1개 파일). 코드/설정 변경 없음.