### PR TITLE
#141 백링크 패널 (what links here) 추가

### DIFF
--- a/Vanadium.Note.REST.Tests/BacklinkServiceTests.cs
+++ b/Vanadium.Note.REST.Tests/BacklinkServiceTests.cs
@@ -1,0 +1,120 @@
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Service-level tests for the backlink ("what links here") query (issue #141).
+/// The scan uses <c>Content.Contains</c> (SQL LIKE), which runs on the in-memory
+/// SQLite host — unlike the trigram <c>EF.Functions.ILike</c> search path — so the
+/// visibility rules (soft-delete exclusion, archive inclusion, self-exclusion) are
+/// verified directly here.
+/// </summary>
+public class BacklinkServiceTests
+{
+    /// <summary>Inserts a note with exact raw content, bypassing the service sanitizer so the
+    /// reference markup under test is preserved. Optionally soft-deleted or archived.</summary>
+    private static async Task<NoteItem> AddNoteAsync(
+        TestHost h, string title, string content, bool softDeleted = false, bool archived = false)
+    {
+        var note = new NoteItem
+        {
+            Title = title,
+            Content = content,
+            ContentText = content,
+            DeletedAt = softDeleted ? DateTime.UtcNow : null,
+            IsDeletionRoot = softDeleted,
+            ArchivedAt = archived ? DateTime.UtcNow : null,
+            IsArchiveRoot = archived,
+        };
+        h.Db.Notes.Add(note);
+        await h.Db.SaveChangesAsync();
+        return note;
+    }
+
+    private static string MentionMarkup(Guid targetId, string title = "Target") =>
+        $"<p><a data-type=\"noteMention\" data-note-id=\"{targetId}\" data-title=\"{title}\">@{title}</a></p>";
+
+    [Fact]
+    public async Task GetBacklinks_ReturnsNotesReferencingTarget()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Target");
+        var referencing = await AddNoteAsync(h, "Referencing", MentionMarkup(target.Id));
+        await AddNoteAsync(h, "Unrelated", "<p>no links here</p>");
+
+        var result = await h.Notes.GetBacklinks(target.Id);
+
+        var hit = Assert.Single(result);
+        Assert.Equal(referencing.Id, hit.Id);
+        Assert.Equal("Referencing", hit.Title);
+        Assert.False(hit.IsArchived);
+    }
+
+    [Fact]
+    public async Task GetBacklinks_ExcludesSoftDeletedReferencingNotes()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Target");
+        await AddNoteAsync(h, "In recycle bin", MentionMarkup(target.Id), softDeleted: true);
+
+        var result = await h.Notes.GetBacklinks(target.Id);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetBacklinks_IncludesArchivedReferencingNotes_Flagged()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Target");
+        var archived = await AddNoteAsync(h, "Archived note", MentionMarkup(target.Id), archived: true);
+
+        var result = await h.Notes.GetBacklinks(target.Id);
+
+        var hit = Assert.Single(result);
+        Assert.Equal(archived.Id, hit.Id);
+        Assert.True(hit.IsArchived);
+    }
+
+    [Fact]
+    public async Task GetBacklinks_ExcludesSelfReference()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Target");
+        // A note that references its own id must not appear in its own backlinks.
+        var self = await AddNoteAsync(h, "Self", MentionMarkup(target.Id));
+        var selfRef = await AddNoteAsync(h, "Self-referencing", MentionMarkup(default));
+        // Rewrite selfRef to reference its own id.
+        selfRef.Content = MentionMarkup(selfRef.Id);
+        selfRef.ContentText = selfRef.Content;
+        await h.Db.SaveChangesAsync();
+
+        var result = await h.Notes.GetBacklinks(selfRef.Id);
+
+        Assert.DoesNotContain(result, r => r.Id == selfRef.Id);
+    }
+
+    [Fact]
+    public async Task GetBacklinks_MatchesPageLinkMarkup()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Target");
+        var pageLink =
+            $"<div data-type=\"pageLink\" data-note-id=\"{target.Id}\" data-title=\"Target\">\U0001F4C4 Target</div>";
+        var referencing = await AddNoteAsync(h, "Has page link", pageLink);
+
+        var result = await h.Notes.GetBacklinks(target.Id);
+
+        Assert.Contains(result, r => r.Id == referencing.Id);
+    }
+
+    [Fact]
+    public async Task GetBacklinks_NoReferences_ReturnsEmpty()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Lonely");
+
+        Assert.Empty(await h.Notes.GetBacklinks(target.Id));
+    }
+}

--- a/Vanadium.Note.REST/Controllers/NotesController.cs
+++ b/Vanadium.Note.REST/Controllers/NotesController.cs
@@ -74,6 +74,15 @@ public class NotesController(NoteService noteService, LabelService labelService,
         return Ok(await noteService.GetChildren(id, ct));
     }
 
+    [HttpGet("{id:guid}/backlinks")]
+    public async Task<ActionResult<List<BacklinkResult>>> GetBacklinks(
+        Guid id,
+        [FromQuery] int limit = 50,
+        CancellationToken ct = default)
+    {
+        return Ok(await noteService.GetBacklinks(id, limit, ct));
+    }
+
     [HttpGet("{id:guid}")]
     public async Task<ActionResult<NoteItem>> Get(Guid id, CancellationToken ct)
     {

--- a/Vanadium.Note.REST/Models/BacklinkResult.cs
+++ b/Vanadium.Note.REST/Models/BacklinkResult.cs
@@ -1,0 +1,18 @@
+namespace Vanadium.Note.REST.Models;
+
+/// <summary>
+/// Lean "what links here" backlink hit: a note whose HTML content references the
+/// current note via a <c>data-note-id="{id}"</c> attribute (mention or page link).
+/// Intentionally smaller than <see cref="NoteSummary"/>: no labels, child counts, or parent title.
+/// </summary>
+public class BacklinkResult
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Plain-text preview of the referencing note, tag-free (derived from ContentText). May be empty.</summary>
+    public string Snippet { get; set; } = string.Empty;
+
+    /// <summary>True if the referencing note is archived — drives the "Archived" badge.</summary>
+    public bool IsArchived { get; set; }
+}

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -464,6 +464,38 @@ public class NoteService(
     }
 
     /// <summary>
+    /// "What links here": returns notes whose HTML content references the given note via a
+    /// <c>data-note-id="{id}"</c> attribute (mentions and page links). Reuses the same
+    /// <c>Content.Contains</c> scan as title propagation (<see cref="UpdatePageLinkReferences"/>);
+    /// a normalized reference table is intentionally out of scope (issue #141).
+    /// Soft-deleted notes are excluded by the default global query filter (no
+    /// <c>IgnoreQueryFilters()</c>); archived notes are INCLUDED and flagged via
+    /// <see cref="BacklinkResult.IsArchived"/>, mirroring full-text/Quick Navigation search so
+    /// the full reference graph is visible. The note itself is excluded from its own backlinks.
+    /// </summary>
+    public async Task<List<BacklinkResult>> GetBacklinks(Guid id, int limit = 50, CancellationToken ct = default)
+    {
+        limit = Math.Clamp(limit, 1, 200);
+        var needle = $"data-note-id=\"{id}\"";
+
+        var rows = await db.Notes
+            .Where(n => n.Id != id && n.Content.Contains(needle))
+            .OrderByDescending(n => n.UpdatedAt)
+            .Take(limit)
+            .Select(n => new { n.Id, n.Title, n.ContentText, n.ArchivedAt })
+            .ToListAsync(ct);
+
+        return rows.Select(r => new BacklinkResult
+        {
+            Id = r.Id,
+            Title = r.Title,
+            // No search term for backlinks — BuildSnippet falls back to the leading slice.
+            Snippet = BuildSnippet(r.ContentText, []),
+            IsArchived = r.ArchivedAt != null
+        }).ToList();
+    }
+
+    /// <summary>
     /// Soft delete: moves the note and all its active descendants to the recycle bin.
     /// References in other notes and uploaded files are left untouched so a
     /// restore is lossless; cleanup is deferred to permanent deletion.

--- a/Vanadium.Note.Web/Models/BacklinkResult.cs
+++ b/Vanadium.Note.Web/Models/BacklinkResult.cs
@@ -1,0 +1,12 @@
+namespace Vanadium.Note.Web.Models;
+
+/// <summary>
+/// Lean "what links here" backlink hit. Mirror of the REST DTO.
+/// </summary>
+public class BacklinkResult
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Snippet { get; set; } = string.Empty;
+    public bool IsArchived { get; set; }
+}

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -186,6 +186,44 @@
     }
 
     <div id="@_editorId" class="tiptap-wrapper"></div>
+
+    @if (!isNew && !_loadFailed)
+    {
+        <div class="backlinks-panel">
+            <div class="backlinks-header">🔗 Linked from@(backlinks.Count > 0 ? $" ({backlinks.Count})" : "")</div>
+            @if (_backlinksLoading)
+            {
+                <div class="backlinks-hint">Loading…</div>
+            }
+            else if (backlinks.Count == 0)
+            {
+                <div class="backlinks-hint">No other notes link here yet.</div>
+            }
+            else
+            {
+                <ul class="backlinks-list">
+                    @foreach (var bl in backlinks)
+                    {
+                        <li class="backlinks-item">
+                            <a href="/editor/@bl.Id" class="backlinks-link">
+                                <span class="backlinks-title">
+                                    @(string.IsNullOrWhiteSpace(bl.Title) ? "(Untitled)" : bl.Title)
+                                    @if (bl.IsArchived)
+                                    {
+                                        <span class="backlinks-badge">Archived</span>
+                                    }
+                                </span>
+                                @if (!string.IsNullOrEmpty(bl.Snippet))
+                                {
+                                    <span class="backlinks-snippet">@bl.Snippet</span>
+                                }
+                            </a>
+                        </li>
+                    }
+                </ul>
+            }
+        </div>
+    }
 </div>
 
 @code {
@@ -257,6 +295,10 @@
     private string saveStatusText = string.Empty;
     private string saveStatusCss = string.Empty;
 
+    // Backlinks ("what links here") state
+    private List<BacklinkResult> backlinks = [];
+    private bool _backlinksLoading = false;
+
     // Label state
     private List<Label> noteLabels = [];
     private List<Label> availableLabels = [];
@@ -285,6 +327,7 @@
         parentTitle = null;
         childCount = 0;
         noteLabels = [];
+        backlinks = [];
         _hasConflict = false;
         _loadFailed = false;
         _saveInFlight = null;
@@ -363,6 +406,20 @@
         _contentJustLoaded = true;
 
         await LoadLabelsAsync();
+
+        if (Id is not null)
+            await LoadBacklinksAsync(Id.Value);
+    }
+
+    private async Task LoadBacklinksAsync(Guid noteId)
+    {
+        _backlinksLoading = true;
+        var result = await NoteService.GetBacklinksAsync(noteId);
+        // Ignore a stale response if the user navigated to another note while loading.
+        if (_currentId != noteId) return;
+        backlinks = result.IsSuccess ? result.Value! : [];
+        _backlinksLoading = false;
+        StateHasChanged();
     }
 
     private async Task LoadLabelsAsync()

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor.css
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor.css
@@ -651,6 +651,81 @@
     flex-shrink: 0;
 }
 
+/* ── Backlinks panel ("what links here") ────────────────────────────────────
+   Sits below the editor body, listing notes that reference this one. */
+.backlinks-panel {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--mud-palette-lines-default, rgba(0, 0, 0, 0.12));
+}
+
+.backlinks-header {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    opacity: 0.6;
+    margin-bottom: 0.6rem;
+}
+
+.backlinks-hint {
+    font-size: 0.85rem;
+    opacity: 0.5;
+}
+
+.backlinks-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.backlinks-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.5rem 0.7rem;
+    border-radius: 6px;
+    text-decoration: none;
+    color: inherit;
+    border: 1px solid var(--mud-palette-lines-default, rgba(0, 0, 0, 0.1));
+    transition: background-color 0.12s ease;
+}
+
+.backlinks-link:hover {
+    background-color: var(--mud-palette-action-default-hover, rgba(0, 0, 0, 0.05));
+}
+
+.backlinks-title {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-weight: 500;
+    font-size: 0.92rem;
+}
+
+.backlinks-badge {
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 0.05rem 0.35rem;
+    border-radius: 4px;
+    background-color: var(--mud-palette-warning, #ff9800);
+    color: #fff;
+    opacity: 0.85;
+}
+
+.backlinks-snippet {
+    font-size: 0.8rem;
+    opacity: 0.6;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 /* ── Responsive (narrow / mobile) ───────────────────────────────────────────
    Complements the desktop breakpoint in MainLayout.razor.css (min-width: 641px).
    The header already wraps (flex-wrap); on a phone viewport, trim the editor

--- a/Vanadium.Note.Web/Services/NoteService.cs
+++ b/Vanadium.Note.Web/Services/NoteService.cs
@@ -296,6 +296,23 @@ public class NoteService(HttpClient http, ILogger<NoteService> logger)
         }
     }
 
+    public async Task<ServiceResult<List<BacklinkResult>>> GetBacklinksAsync(
+        Guid noteId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var url = $"api/notes/{noteId}/backlinks";
+            var result = await http.GetFromJsonAsync<List<BacklinkResult>>(url, cancellationToken);
+            return ServiceResult<List<BacklinkResult>>.Ok(result ?? []);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to load backlinks for note {NoteId}.", noteId);
+            return ServiceResult<List<BacklinkResult>>.Fail("Failed to load backlinks.");
+        }
+    }
+
     public async Task<ServiceResult<List<NoteSummary>>> GetChildrenAsync(Guid parentId)
     {
         try


### PR DESCRIPTION
Closes #141

## 목적
노트 본문에 이미 `data-note-id="{guid}"` 형태로 저장된 참조 데이터를 활용해, "이 노트를 어디에서 링크하고 있는가(what links here)"를 보여주는 백링크 패널을 추가한다.

## 변경 내용

### 백엔드
- `GET /api/notes/{id}/backlinks` 엔드포인트 추가 (`NotesController`).
- `NoteService.GetBacklinks(id, limit)` — 기존 제목 전파 로직(`UpdatePageLinkReferences`)과 동일한 `Content.Contains($"data-note-id=\"{id}\"")` 스캔을 사용해 참조 노트를 조회. lean projection(`BacklinkResult`: Id, Title, Snippet, IsArchived) 반환, `UpdatedAt` desc 정렬, limit `[1,200]` 클램프.
- `BacklinkResult` DTO 추가 (REST/Web 미러).

### 가시성 규칙 (명시적 결정)
- **soft-delete 노트: 제외** — 기본 전역 쿼리 필터(`DeletedAt == null`)에 의존, `IgnoreQueryFilters()` 미사용.
- **아카이브 노트: 포함** + `IsArchived` 플래그로 배지 표시 — 전문검색/Quick Navigation 검색과 동일한 정책으로 전체 참조 그래프를 노출.
- **자기 참조 제외** (`n.Id != id`).

### 프런트엔드
- `NoteEditor.razor` 하단에 백링크 패널 추가. 항목 클릭 시 `/editor/{id}`로 이동(기존 브레드크럼과 동일한 `<a href>` 방식). 아카이브 노트는 "Archived" 배지로 구분. 로딩/빈 상태 처리 포함.
- `NoteService.GetBacklinksAsync` 클라이언트 메서드 추가.

## 범위 밖 (미구현)
- 정규화 참조 테이블(`NoteReference`) — 이슈 명시대로 Content 스캔 방식 유지.
- 실시간 백링크 갱신.

## 완료 조건 검증
- ✅ 참조 노트 반환 엔드포인트: `GetBacklinks_ReturnsNotesReferencingTarget`, `GetBacklinks_MatchesPageLinkMarkup` 테스트 통과.
- ✅ soft-delete 제외 / 아카이브 포함 정책: `GetBacklinks_ExcludesSoftDeletedReferencingNotes`, `GetBacklinks_IncludesArchivedReferencingNotes_Flagged`, `GetBacklinks_ExcludesSelfReference` 테스트 통과.
- ✅ REST/Web DTO 미러 및 클라이언트 메서드 추가.
- ✅ 에디터 백링크 패널 노출 및 클릭 이동 — 빌드 클린으로 확인(런타임 UI는 수동 확인 필요).
- ✅ 빌드 클린: `dotnet build Vanadium.slnx` 경고 0.
- ✅ 전체 테스트: 97 통과 / 3 스킵(PostgreSQL 전용).

**참고:** 백링크 스캔은 `Content` 컬럼(트라이그램 인덱스 없음)에 대한 LIKE로, 기존 제목 전파 로직과 동일한 패턴이다. 성능 이슈 시 정규화 테이블 도입은 별도 논의.