### PR TITLE
#191 로그인 비밀번호 필드에 autocomplete/label/id 추가

### DIFF
--- a/Vanadium.Note.Web/Pages/Login.razor
+++ b/Vanadium.Note.Web/Pages/Login.razor
@@ -9,8 +9,23 @@
 
         <EditForm Model="@_model" OnValidSubmit="HandleLogin">
             <DataAnnotationsValidator />
+
+            @* Hidden username field so password managers can associate the saved credential. *@
+            <input type="text"
+                   name="username"
+                   autocomplete="username"
+                   value="owner"
+                   readonly
+                   aria-hidden="true"
+                   tabindex="-1"
+                   class="login-hidden-username" />
+
             <div class="login-field">
+                <label for="password" class="login-visually-hidden">Password</label>
                 <input type="password"
+                       id="password"
+                       name="password"
+                       autocomplete="current-password"
                        class="login-input"
                        placeholder="Password"
                        @bind="_model.Password"

--- a/Vanadium.Note.Web/Pages/Login.razor.css
+++ b/Vanadium.Note.Web/Pages/Login.razor.css
@@ -44,6 +44,22 @@
     border-color: var(--mud-palette-primary, #594ae2);
 }
 
+.login-hidden-username {
+    display: none;
+}
+
+.login-visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .login-error {
     font-size: 0.85rem;
     color: var(--mud-palette-error, #f44336);


### PR DESCRIPTION
Closes #191

## 목적
로그인 비밀번호 입력 필드에 `name`/`autocomplete`/`id`/`<label>`이 빠져 있어 브라우저·비밀번호 매니저 자동입력과 스크린리더 접근성이 동작하지 않던 문제를 해결한다.

## 변경 사항
- 비밀번호 `<input>`에 `name="password"`, `id="password"`, `autocomplete="current-password"` 부여
- 스크린리더용 시각적 숨김 `<label for="password">Password</label>` 추가 (`.login-visually-hidden` 클립 기법)
- 비밀번호 매니저 자격증명 연결을 위한 숨김 username 필드(`autocomplete="username"`, `value="owner"`, `aria-hidden`/`tabindex="-1"`) 추가

## 범위
- 마크업/접근성 속성 및 스코프 CSS만 수정. 인증 로직/JWT 발급 흐름은 건드리지 않음.

## 완료 조건 검증
- [x] 비밀번호 필드에 `name`/`autocomplete`/`id`/연결된 `<label>` 존재 — Login.razor 마크업으로 확인
- [ ] 브라우저 비밀번호 매니저 저장 프롬프트 — **수동 확인 필요** (실브라우저 로그인 후 확인)
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0