### PR TITLE
#192 SubNoteDialog에 beforeunload 가드 + draft 백업 이식 (편집분 소실)

### DIFF
--- a/Vanadium.Note.Web/Pages/SubNoteDialog.razor
+++ b/Vanadium.Note.Web/Pages/SubNoteDialog.razor
@@ -9,6 +9,7 @@
 @inject ISnackbar Snackbar
 @inject ILogger<SubNoteDialog> Logger
 @inject KeyboardShortcutService ShortcutService
+@inject DraftStore DraftStore
 
 <MudDialog>
     <TitleContent>
@@ -63,9 +64,39 @@
     private IAsyncDisposable? _ctrlSOverride;
     private readonly AutoSaveDebouncer _autoSave = new();
     private bool _hasPendingChanges = false;
+    private bool _hasConflict = false;
     private bool _isSaving = false;
     private bool _editorMounted = false;
     private bool _contentJustLoaded = false;
+
+    /// <summary>
+    /// Whether the dialog holds edits not yet persisted to the server. Setting it
+    /// also arms/disarms a browser <c>beforeunload</c> guard so that closing or
+    /// reloading the tab during the auto-save debounce window warns the user
+    /// instead of silently dropping the change — parity with the full-page editor
+    /// (issue #192, mirrors <c>NoteEditor.HasPendingChanges</c>).
+    /// </summary>
+    private bool HasPendingChanges
+    {
+        get => _hasPendingChanges;
+        set
+        {
+            if (_hasPendingChanges == value) return;
+            _hasPendingChanges = value;
+            _ = SyncUnsavedChangesGuardAsync(value);
+        }
+    }
+
+    private async Task SyncUnsavedChangesGuardAsync(bool armed)
+    {
+        try
+        {
+            await JS.InvokeVoidAsync(
+                armed ? "unsavedChangesInterop.enable" : "unsavedChangesInterop.disable");
+        }
+        catch (JSException) { }
+        catch (InvalidOperationException) { }
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -85,6 +116,23 @@
             Snackbar.Add("Failed to load note.", Severity.Error);
             MudDialog.Close();
             return;
+        }
+
+        // Restore any unsaved draft stashed when a prior edit of this note failed to
+        // save (409 conflict, auth-expiry 401, network error). The draft is keyed by
+        // note id so it only fires for this note; archived notes are read-only and
+        // cannot hold pending edits (issue #192, mirrors NoteEditor).
+        if (!_isArchived)
+        {
+            var draft = await DraftStore.GetAsync(NoteId);
+            if (draft is not null)
+            {
+                title = draft.Title;
+                content = draft.Content;
+                _contentJustLoaded = true;
+                HasPendingChanges = true;
+                Snackbar.Add("Restored your unsaved changes.", Severity.Info);
+            }
         }
 
         var labelsResult = await LabelService.GetLabelsAsync();
@@ -180,7 +228,11 @@
     private void ScheduleAutoSave()
     {
         if (_isArchived) return; // archived notes are read-only
-        _hasPendingChanges = true;
+        // After a 409 the note is stale; further auto-saves would just re-409, so stop
+        // scheduling and let the draft backup carry the edits (issue #192). The latest
+        // content still lives in the `content`/`title` fields for the close/dispose stash.
+        if (_hasConflict) return;
+        HasPendingChanges = true;
         saveStatusText = "Unsaved changes";
         saveStatusCss = "status-pending";
         StateHasChanged();
@@ -206,7 +258,24 @@
         if (result.IsSuccess)
         {
             _serverUpdatedAt = result.Value!.UpdatedAt;
-            _hasPendingChanges = false;
+            HasPendingChanges = false;
+            await DraftStore.ClearAsync();
+        }
+        else if (result.IsConflict)
+        {
+            // Optimistic-concurrency clash: the save can never succeed against this stale
+            // snapshot, so record it (this stops ScheduleAutoSave from re-firing and the
+            // dispose flush from repeating the failing save) and back the edit up to a
+            // draft that a reopen / full-page restore recovers (issue #192).
+            _hasConflict = true;
+            await DraftStore.SaveAsync(NoteId, title, content);
+        }
+        else if (!result.IsForbidden)
+        {
+            // Transient/auth failure (e.g. 401 → login redirect). Stash the draft so the
+            // in-progress edit survives and is restored on return (issue #192). Archived
+            // (Forbidden) notes are read-only and never hold a pending edit to stash.
+            await DraftStore.SaveAsync(NoteId, title, content);
         }
         return result;
     }
@@ -272,8 +341,16 @@
         // Cancel the pending debounce, then flush any unsaved edit before the dialog goes away so
         // the last <1.5s of typing is not silently discarded.
         _autoSave.Cancel();
-        if (_hasPendingChanges && !_isArchived)
-            await DoAutoSave();
+        if (!_isArchived && HasPendingChanges)
+        {
+            if (_hasConflict)
+                // The snapshot is stale — a save can only 409 again — so back the edit up to a
+                // draft that a reopen / full-page restore recovers instead of losing it (#192).
+                await DraftStore.SaveAsync(NoteId, title, content);
+            else
+                // A normal flush; DoAutoSave → SaveCoreAsync itself stashes a draft if it fails.
+                await DoAutoSave();
+        }
         MudDialog.Close(DialogResult.Ok(title));
     }
 
@@ -327,8 +404,21 @@
         // Esc/backdrop closes bypass Close() and only reach here, so flush pending edits on this
         // path too. Use SaveCoreAsync (no StateHasChanged) since the component is being disposed.
         _autoSave.Dispose();
-        if (_hasPendingChanges && !_isArchived)
-            await SaveCoreAsync();
+        if (!_isArchived && HasPendingChanges)
+        {
+            if (_hasConflict)
+                // On a 409 the save can never win against this stale snapshot; re-issuing it here
+                // is exactly the loop that used to silently drop the edit. Back it up instead (#192).
+                await DraftStore.SaveAsync(NoteId, title, content);
+            else
+                await SaveCoreAsync();
+        }
+
+        // Release the beforeunload guard if this dialog still holds it (an unresolved conflict, or
+        // a flush that couldn't persist, leaves HasPendingChanges armed). Disarm exactly once so the
+        // reference-counted guard stays balanced with a concurrently-open full-page editor (#192).
+        if (_hasPendingChanges)
+            await SyncUnsavedChangesGuardAsync(false);
 
         _objRef?.Dispose();
         if (_editorMounted)

--- a/Vanadium.Note.Web/wwwroot/js/unsaved-changes.js
+++ b/Vanadium.Note.Web/wwwroot/js/unsaved-changes.js
@@ -13,18 +13,25 @@
         return '';
     }
 
-    let _armed = false;
+    // Reference-counted: NoteEditor and SubNoteDialog can be armed at the same
+    // time (a page-link/mention click opens the dialog on top of an editor that
+    // still holds unsaved changes). A single boolean would let the dialog's
+    // disable() strip the listener the editor still needs, so track how many
+    // callers want the guard and only remove the listener when the last one
+    // disarms (issue #192).
+    let _armedCount = 0;
 
     window.unsavedChangesInterop = {
         enable() {
-            if (_armed) return;
-            _armed = true;
-            window.addEventListener('beforeunload', _handler);
+            _armedCount++;
+            if (_armedCount === 1)
+                window.addEventListener('beforeunload', _handler);
         },
         disable() {
-            if (!_armed) return;
-            _armed = false;
-            window.removeEventListener('beforeunload', _handler);
+            if (_armedCount === 0) return;
+            _armedCount--;
+            if (_armedCount === 0)
+                window.removeEventListener('beforeunload', _handler);
         }
     };
 })();


### PR DESCRIPTION
Closes #192

## 문제

하위 노트 인라인 편집(`SubNoteDialog`)에는 풀페이지 에디터에 있는 `beforeunload` 가드도 `DraftStore` 백업도 없어 편집분이 소실된다.

- 409(낙관적 동시성) 충돌 시 `DisposeAsync`가 `SaveCoreAsync`를 반복 호출해 또 409가 나면서 편집 내용이 손실된다.
- 1.5초 자동저장 디바운스 창 안에서 다이얼로그를 닫을 때 저장 flush가 실패하면 편집분이 소실된다.

## 변경 내용

- **`beforeunload` 가드 이식**: `HasPendingChanges` 프로퍼티가 미저장 상태에서 브라우저 `beforeunload` 가드를 켜고 저장 완료 시 끈다 (탭 종료/새로고침 시 경고). 풀페이지 에디터의 `NoteEditor.HasPendingChanges` 패턴을 그대로 따른다.
- **draft 백업/복원**: 저장 실패(409 충돌 / 401 만료 / 네트워크)마다 편집분을 `DraftStore`(sessionStorage, 노트 id 키)로 백업하고, 같은 노트를 다이얼로그로 재오픈하거나 풀페이지로 열 때 복원한다.
- **409 소실 루프 제거**: 충돌 시 `_hasConflict` 플래그로 자동저장 재시도를 멈추고, `Close`/`DisposeAsync`가 실패하는 PUT을 반복하는 대신 draft로 백업한다.
- **가드 참조 카운트화**: 풀페이지 에디터와 다이얼로그가 동시에 가드를 켤 수 있으므로(에디터에 미저장 변경이 있는 상태에서 페이지 링크/멘션으로 다이얼로그를 여는 경우) `unsavedChangesInterop`을 단일 boolean에서 활성 카운트 방식으로 바꿔, 다이얼로그의 해제가 에디터가 여전히 필요로 하는 리스너를 떼어내지 않도록 한다.

## 완료 조건 검증

- [x] 다이얼로그에 `beforeunload` 가드 + draft 백업 적용 — `HasPendingChanges` 프로퍼티 + `SyncUnsavedChangesGuardAsync`, `SaveCoreAsync`의 실패 시 `DraftStore.SaveAsync`, `OnInitializedAsync`의 복원.
- [x] 409 충돌 시 `DisposeAsync`가 재저장을 반복해 편집분을 잃지 않음 — `_hasConflict` 시 `DisposeAsync`/`Close`가 `SaveCoreAsync` 대신 `DraftStore.SaveAsync`로 백업.
- [x] 디바운스 창 안에서 닫아도 편집분 보존 — 기존 강제 flush(`Close`/`DisposeAsync`)에 더해, flush 실패 시에도 draft로 백업.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0, `dotnet test` 112 통과.

## 범위

서버측 낙관적 동시성(clientVersion) 로직(#221)은 건드리지 않았다. 프론트 2개 파일만 변경. Web 프로젝트에는 테스트 프로젝트가 없어(문서화된 제약) 단위 회귀 테스트는 추가하지 못했다.