### PR TITLE
#194 공유 페이지 Mermaid 다이어그램 렌더링

### DIFF
--- a/Vanadium.Note.Web/Pages/Share.razor
+++ b/Vanadium.Note.Web/Pages/Share.razor
@@ -2,6 +2,7 @@
 @layout ShareLayout
 @attribute [AllowAnonymous]
 @inject NoteService NoteService
+@inject IJSRuntime JS
 
 <PageTitle>@(_note is not null ? DisplayTitle : "Shared note")</PageTitle>
 
@@ -26,7 +27,7 @@
             </header>
 
             @* Content is sanitized server-side before storage, so rendering it as markup is safe. *@
-            <div class="shared-note-content">@((MarkupString)_note.Content)</div>
+            <div class="shared-note-content" @ref="_contentRef">@((MarkupString)_note.Content)</div>
 
             <footer class="shared-note-footer">
                 Shared via Vanadium. Embedded images or attachments may not be visible in this view.
@@ -41,6 +42,8 @@
     private SharedNote? _note;
     private bool _loading = true;
     private string? _loadedToken;
+    private ElementReference _contentRef;
+    private bool _mermaidRendered;
 
     private string DisplayTitle =>
         string.IsNullOrWhiteSpace(_note?.Title) ? "(Untitled)" : _note!.Title;
@@ -51,9 +54,28 @@
         _loadedToken = Token;
         _loading = true;
         _note = null;
+        _mermaidRendered = false;
 
         var result = await NoteService.GetSharedNoteAsync(Token);
         _note = result.IsSuccess ? result.Value : null;
         _loading = false;
+    }
+
+    // Shared content is dumped as raw markup, so Tiptap's node views never run.
+    // Render any Mermaid code blocks in place once the content is in the DOM,
+    // mirroring the read-only render the editor performs via the same interop.
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_note is null || _mermaidRendered) return;
+        _mermaidRendered = true;
+        try
+        {
+            await JS.InvokeVoidAsync("tiptapInterop.renderMermaidIn", _contentRef);
+        }
+        catch (JSException ex)
+        {
+            // Read-only page: a diagram render failure must not break the note.
+            Console.Error.WriteLine($"Failed to render shared Mermaid diagrams: {ex.Message}");
+        }
     }
 }


### PR DESCRIPTION
Closes #194

## 문제
익명 `/share/{token}` 공유 페이지가 `(MarkupString)_note.Content`만 덤프하고 `renderMermaidIn` interop을 어디서도 호출하지 않아, Mermaid 다이어그램이 렌더되지 않고 원본 `<pre>` 코드 블록 그대로 노출됐다. '다이어그램 중심 기록'이 타깃인 제품에서 공유 경험을 해쳤다.

## 변경
`Share.razor`에서 콘텐츠가 DOM에 반영된 뒤 `OnAfterRenderAsync`에서 `tiptapInterop.renderMermaidIn`을 콘텐츠 요소(`ElementReference`)에 대해 한 번 호출한다. 이 interop은 편집기의 읽기 전용 렌더 경로와 동일하며, `pre[data-type="mermaid"]` 블록을 렌더된 SVG로 치환한다.

- `_mermaidRendered` 플래그로 중복 호출 방지, 토큰 변경 시 리셋.
- `window.tiptapInterop`은 `index.html`에서 전역 로드되므로 `ShareLayout`에서도 사용 가능.
- 서버 sanitizer가 `data-*` 및 `pre`/`code`를 보존하므로 공유 HTML에 `pre[data-type="mermaid"]`가 그대로 남는다.
- 읽기 전용 페이지이므로 `JSException`은 삼켜 다이어그램 렌더 실패가 노트 표시 자체를 깨뜨리지 않게 한다.

## 완료 조건 검증
- [x] 익명 공유 페이지 로드 후 Mermaid 노드가 렌더된 다이어그램으로 표시 — `OnAfterRenderAsync`가 `renderMermaidIn` 호출, 블록을 SVG로 치환
- [x] 원본 Mermaid 코드가 그대로 노출되지 않음 — `renderMermaidIn`이 `pre[data-type="mermaid"]`를 `div.mermaid-rendered`로 교체
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0/오류 0, `dotnet test` 112 통과

## 참고
- 범위 밖(공유 페이지 asset 프록시, #208)은 건드리지 않음.
- Web(Blazor WASM) 프로젝트는 테스트 프로젝트가 없고 JS interop/WASM 렌더는 단위 테스트 범위 밖이라 회귀 테스트는 추가하지 않음(수동 확인 필요).