### PR TITLE
#197 KnownProxies 설정으로 XFF 위조 rate-limit 우회 차단

### DIFF
--- a/Vanadium.Note.REST.Tests/ForwardedHeadersConfiguratorTests.cs
+++ b/Vanadium.Note.REST.Tests/ForwardedHeadersConfiguratorTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Vanadium.Note.REST.Security;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression coverage for the proxy trust configuration (issue #197). The security-critical
+/// invariant is that when NO trust list is configured, the framework's loopback-only defaults
+/// are preserved — never cleared — so ASP.NET Core does not fall back to trusting every
+/// <c>X-Forwarded-For</c> hop (which would let a direct client forge its IP and defeat the
+/// login rate limiter). The full middleware pipeline needs an integration host and is verified
+/// manually; this exercises the pure configuration seam.
+/// </summary>
+public class ForwardedHeadersConfiguratorTests
+{
+    private static IConfiguration BuildConfig(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    [Fact]
+    public void Configure_NoTrustListConfigured_PreservesFrameworkDefaults()
+    {
+        var options = new ForwardedHeadersOptions();
+        var proxiesBefore = options.KnownProxies.Count;
+        var networksBefore = options.KnownIPNetworks.Count;
+        // Guard the guard: the framework must ship non-empty defaults, otherwise "preserve" is meaningless.
+        Assert.True(proxiesBefore > 0 || networksBefore > 0,
+            "Framework defaults should be non-empty before configuration.");
+
+        ForwardedHeadersConfigurator.Configure(options, BuildConfig(new()));
+
+        // Untouched — an untrusted origin's XFF can never partition the rate limiter.
+        Assert.Equal(proxiesBefore, options.KnownProxies.Count);
+        Assert.Equal(networksBefore, options.KnownIPNetworks.Count);
+    }
+
+    [Fact]
+    public void Configure_KnownNetworksConfigured_ReplacesDefaults()
+    {
+        var options = new ForwardedHeadersOptions();
+        var config = BuildConfig(new() { ["ForwardedHeaders:KnownNetworks:0"] = "10.0.0.0/8" });
+
+        ForwardedHeadersConfigurator.Configure(options, config);
+
+        Assert.Empty(options.KnownProxies);
+        var net = Assert.Single(options.KnownIPNetworks);
+        Assert.Equal(System.Net.IPNetwork.Parse("10.0.0.0/8"), net);
+    }
+
+    [Fact]
+    public void Configure_KnownProxiesConfigured_ReplacesDefaults()
+    {
+        var options = new ForwardedHeadersOptions();
+        var config = BuildConfig(new() { ["ForwardedHeaders:KnownProxies:0"] = "203.0.113.5" });
+
+        ForwardedHeadersConfigurator.Configure(options, config);
+
+        Assert.Empty(options.KnownIPNetworks);
+        var proxy = Assert.Single(options.KnownProxies);
+        Assert.Equal(IPAddress.Parse("203.0.113.5"), proxy);
+    }
+
+    [Fact]
+    public void Configure_ProxiesAndNetworksConfigured_BothApplied()
+    {
+        var options = new ForwardedHeadersOptions();
+        var config = BuildConfig(new()
+        {
+            ["ForwardedHeaders:KnownProxies:0"] = "203.0.113.5",
+            ["ForwardedHeaders:KnownNetworks:0"] = "172.16.0.0/12",
+        });
+
+        ForwardedHeadersConfigurator.Configure(options, config);
+
+        Assert.Equal(IPAddress.Parse("203.0.113.5"), Assert.Single(options.KnownProxies));
+        Assert.Equal(System.Net.IPNetwork.Parse("172.16.0.0/12"), Assert.Single(options.KnownIPNetworks));
+    }
+
+    [Fact]
+    public void Configure_InvalidProxy_Throws()
+    {
+        var options = new ForwardedHeadersOptions();
+        var config = BuildConfig(new() { ["ForwardedHeaders:KnownProxies:0"] = "not-an-ip" });
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ForwardedHeadersConfigurator.Configure(options, config));
+        Assert.Contains("KnownProxies", ex.Message);
+    }
+
+    [Fact]
+    public void Configure_InvalidNetwork_Throws()
+    {
+        var options = new ForwardedHeadersOptions();
+        var config = BuildConfig(new() { ["ForwardedHeaders:KnownNetworks:0"] = "not-a-cidr" });
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ForwardedHeadersConfigurator.Configure(options, config));
+        Assert.Contains("KnownNetworks", ex.Message);
+    }
+}

--- a/Vanadium.Note.REST.Tests/Vanadium.Note.REST.Tests.csproj
+++ b/Vanadium.Note.REST.Tests/Vanadium.Note.REST.Tests.csproj
@@ -24,6 +24,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Needed to reference ASP.NET Core config types (e.g. ForwardedHeadersOptions) in unit tests;
+       does not flow transitively from the web project's ProjectReference. -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Vanadium.Note.REST\Vanadium.Note.REST.csproj" />
   </ItemGroup>

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
-using System.Net;
 using System.Text;
 using Microsoft.AspNetCore.RateLimiting;
 using System.Threading.RateLimiting;
@@ -34,51 +33,14 @@ builder.Host.UseSerilog((context, services, config) =>
 // TLS terminates at an upstream reverse proxy (nginx etc.); the app itself
 // serves HTTP inside the container. Trust the proxy's X-Forwarded-For /
 // X-Forwarded-Proto so the real client IP and request scheme are restored
-// (also fixes the login rate limiter's per-IP partitioning).
-//
-// Only proxies/networks listed in ForwardedHeaders:KnownProxies (individual IPs)
-// and ForwardedHeaders:KnownNetworks (CIDR) are trusted. This is defense-in-depth:
-// when BOTH lists are empty ASP.NET Core trusts EVERY forwarded hop, so a client
-// that reaches the app port directly could forge X-Forwarded-For and mint a fresh
-// login rate-limit bucket per spoofed IP, defeating brute-force protection. When
-// nothing is configured we therefore KEEP the framework's loopback-only defaults
-// rather than clearing them, so an untrusted origin's XFF is never honored and can
-// never partition the rate limiter. Configure the real proxy's IP/subnet in
-// production (e.g. ForwardedHeaders:KnownNetworks:0 = "10.0.0.0/8") to restore the
-// client IP through it.
+// (also fixes the login rate limiter's per-IP partitioning). Which proxies are
+// trusted is controlled by ForwardedHeaders:KnownProxies / KnownNetworks — see
+// ForwardedHeadersConfigurator for why unconfigured means "keep loopback defaults"
+// rather than "trust every hop" (issue #197).
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-
-    var knownProxies = builder.Configuration
-        .GetSection("ForwardedHeaders:KnownProxies").Get<string[]>() ?? [];
-    var knownNetworks = builder.Configuration
-        .GetSection("ForwardedHeaders:KnownNetworks").Get<string[]>() ?? [];
-
-    if (knownProxies.Length > 0 || knownNetworks.Length > 0)
-    {
-        // Explicit trust list configured — replace the loopback defaults with it.
-        options.KnownProxies.Clear();
-        options.KnownIPNetworks.Clear();
-
-        foreach (var proxy in knownProxies)
-        {
-            if (IPAddress.TryParse(proxy, out var ip))
-                options.KnownProxies.Add(ip);
-            else
-                throw new InvalidOperationException(
-                    $"ForwardedHeaders:KnownProxies contains an invalid IP address: '{proxy}'.");
-        }
-
-        foreach (var network in knownNetworks)
-        {
-            if (System.Net.IPNetwork.TryParse(network, out var net))
-                options.KnownIPNetworks.Add(net);
-            else
-                throw new InvalidOperationException(
-                    $"ForwardedHeaders:KnownNetworks contains an invalid CIDR network: '{network}'.");
-        }
-    }
+    ForwardedHeadersConfigurator.Configure(options, builder.Configuration);
 });
 
 var allowedOrigins = builder.Configuration["Cors:AllowedOrigins"]

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
+using System.Net;
 using System.Text;
 using Microsoft.AspNetCore.RateLimiting;
 using System.Threading.RateLimiting;
@@ -33,14 +34,51 @@ builder.Host.UseSerilog((context, services, config) =>
 // TLS terminates at an upstream reverse proxy (nginx etc.); the app itself
 // serves HTTP inside the container. Trust the proxy's X-Forwarded-For /
 // X-Forwarded-Proto so the real client IP and request scheme are restored
-// (also fixes the login rate limiter's per-IP partitioning). KnownNetworks /
-// KnownProxies are cleared because the proxy's container IP is not stable or
-// known ahead of time — the app port must only be reachable by the proxy.
+// (also fixes the login rate limiter's per-IP partitioning).
+//
+// Only proxies/networks listed in ForwardedHeaders:KnownProxies (individual IPs)
+// and ForwardedHeaders:KnownNetworks (CIDR) are trusted. This is defense-in-depth:
+// when BOTH lists are empty ASP.NET Core trusts EVERY forwarded hop, so a client
+// that reaches the app port directly could forge X-Forwarded-For and mint a fresh
+// login rate-limit bucket per spoofed IP, defeating brute-force protection. When
+// nothing is configured we therefore KEEP the framework's loopback-only defaults
+// rather than clearing them, so an untrusted origin's XFF is never honored and can
+// never partition the rate limiter. Configure the real proxy's IP/subnet in
+// production (e.g. ForwardedHeaders:KnownNetworks:0 = "10.0.0.0/8") to restore the
+// client IP through it.
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-    options.KnownIPNetworks.Clear();
-    options.KnownProxies.Clear();
+
+    var knownProxies = builder.Configuration
+        .GetSection("ForwardedHeaders:KnownProxies").Get<string[]>() ?? [];
+    var knownNetworks = builder.Configuration
+        .GetSection("ForwardedHeaders:KnownNetworks").Get<string[]>() ?? [];
+
+    if (knownProxies.Length > 0 || knownNetworks.Length > 0)
+    {
+        // Explicit trust list configured — replace the loopback defaults with it.
+        options.KnownProxies.Clear();
+        options.KnownIPNetworks.Clear();
+
+        foreach (var proxy in knownProxies)
+        {
+            if (IPAddress.TryParse(proxy, out var ip))
+                options.KnownProxies.Add(ip);
+            else
+                throw new InvalidOperationException(
+                    $"ForwardedHeaders:KnownProxies contains an invalid IP address: '{proxy}'.");
+        }
+
+        foreach (var network in knownNetworks)
+        {
+            if (System.Net.IPNetwork.TryParse(network, out var net))
+                options.KnownIPNetworks.Add(net);
+            else
+                throw new InvalidOperationException(
+                    $"ForwardedHeaders:KnownNetworks contains an invalid CIDR network: '{network}'.");
+        }
+    }
 });
 
 var allowedOrigins = builder.Configuration["Cors:AllowedOrigins"]

--- a/Vanadium.Note.REST/Security/ForwardedHeadersConfigurator.cs
+++ b/Vanadium.Note.REST/Security/ForwardedHeadersConfigurator.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using Microsoft.AspNetCore.HttpOverrides;
+
+namespace Vanadium.Note.REST.Security;
+
+/// <summary>
+/// Configures which upstream proxies/networks are trusted to set <c>X-Forwarded-For</c>, so the
+/// login rate limiter partitions on a client IP that cannot be forged by a client reaching the
+/// app port directly (issue #197).
+///
+/// ASP.NET Core trusts EVERY forwarded hop when both
+/// <see cref="ForwardedHeadersOptions.KnownProxies"/> and
+/// <see cref="ForwardedHeadersOptions.KnownIPNetworks"/> are empty. This helper therefore KEEPS the
+/// framework's loopback-only defaults when nothing is configured, and only replaces them when an
+/// explicit trust list is supplied via <c>ForwardedHeaders:KnownProxies</c> (individual IPs) and
+/// <c>ForwardedHeaders:KnownNetworks</c> (CIDR). Clearing the defaults unconditionally — the previous
+/// behavior — is exactly what let a direct client forge its IP and mint a fresh rate-limit bucket.
+/// </summary>
+public static class ForwardedHeadersConfigurator
+{
+    /// <summary>Configuration section holding the trusted proxy/network lists.</summary>
+    public const string SectionName = "ForwardedHeaders";
+
+    /// <summary>
+    /// Applies the trusted-proxy configuration to <paramref name="options"/>. When no proxies or
+    /// networks are configured the framework defaults are left intact (so untrusted origins are never
+    /// honored); when a trust list is configured it replaces those defaults.
+    /// </summary>
+    /// <param name="options">The options instance to populate (already carrying framework defaults).</param>
+    /// <param name="configuration">Application configuration to read the trust list from.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a configured proxy is not a valid IP address, or a configured network is not valid CIDR.
+    /// </exception>
+    public static void Configure(ForwardedHeadersOptions options, IConfiguration configuration)
+    {
+        var knownProxies = configuration
+            .GetSection($"{SectionName}:KnownProxies").Get<string[]>() ?? [];
+        var knownNetworks = configuration
+            .GetSection($"{SectionName}:KnownNetworks").Get<string[]>() ?? [];
+
+        // No explicit trust list — keep the framework's loopback-only defaults so untrusted
+        // origins can never partition the rate limiter. Clearing here would re-open the hole.
+        if (knownProxies.Length == 0 && knownNetworks.Length == 0)
+            return;
+
+        // Explicit trust list configured — replace the loopback defaults with it.
+        options.KnownProxies.Clear();
+        options.KnownIPNetworks.Clear();
+
+        foreach (var proxy in knownProxies)
+        {
+            if (IPAddress.TryParse(proxy, out var ip))
+                options.KnownProxies.Add(ip);
+            else
+                throw new InvalidOperationException(
+                    $"{SectionName}:KnownProxies contains an invalid IP address: '{proxy}'.");
+        }
+
+        foreach (var network in knownNetworks)
+        {
+            if (System.Net.IPNetwork.TryParse(network, out var net))
+                options.KnownIPNetworks.Add(net);
+            else
+                throw new InvalidOperationException(
+                    $"{SectionName}:KnownNetworks contains an invalid CIDR network: '{network}'.");
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       Seq__ServerUrl: ${SEQ_URL:-}
       Seq__ApiKey: ${SEQ_API_KEY:-}
       RecycleBin__RetentionDays: ${RECYCLE_BIN_RETENTION_DAYS:-30}
+      # Trust X-Forwarded-For ONLY from the reverse proxy that fronts this service,
+      # so a client reaching the app port directly cannot forge its IP and bypass the
+      # login rate limiter. Set the proxy's IP/subnet (leave unset to trust none):
+      #   ForwardedHeaders__KnownProxies__0: "172.20.0.5"      # a specific proxy IP
+      #   ForwardedHeaders__KnownNetworks__0: "172.16.0.0/12"  # or the proxy's subnet (CIDR)
     volumes:
       # Persist uploaded files across container recreation/redeploys.
       - vanadium_uploads:/app/uploads


### PR DESCRIPTION
Closes #197

## 문제

`ForwardedHeaders`의 `KnownIPNetworks`/`KnownProxies`를 무조건 `Clear()` 하고 있었다. ASP.NET Core는 **두 신뢰 목록이 모두 비어 있으면 모든 `X-Forwarded-For` 홉을 무조건 신뢰**한다. 따라서 앱 포트(예: docker `5000:8080`)에 프록시를 우회해 직접 도달 가능하면, 공격자가 매 요청마다 `X-Forwarded-For`를 바꿔 IP당 새 로그인 rate-limit 버킷(10/min)을 무한 확보해 브루트포스 제한을 무력화할 수 있었다.

## 변경

- `Vanadium.Note.REST/Program.cs`
  - `ForwardedHeaders:KnownProxies`(개별 IP)와 `ForwardedHeaders:KnownNetworks`(CIDR) 설정을 읽어, **명시적으로 지정한 프록시/서브넷만** 신뢰하도록 변경.
  - 설정이 없으면 프레임워크의 **loopback 전용 기본값을 유지**(무조건 Clear 제거) — 미신뢰 출처의 XFF는 클라이언트 IP로 인정되지 않아 rate-limit 파티션 키로 쓰이지 않는다.
  - 잘못된 IP/CIDR 문자열은 시작 시 `InvalidOperationException`으로 즉시 실패(오설정을 조용히 무시하지 않음).
- `docker-compose.yml`
  - 프록시 신뢰 설정(`ForwardedHeaders__KnownProxies__0` / `ForwardedHeaders__KnownNetworks__0`) 예시를 주석으로 추가.

미들웨어 파이프라인 순서(`UseForwardedHeaders` 위치 포함)는 변경하지 않았다(범위 밖 제약 준수).

## 완료 조건 검증

- [x] **KnownProxies/KnownIPNetworks에 실제 프록시 설정 → 미신뢰 XFF가 파티션 키로 안 쓰임**: 설정한 프록시/서브넷만 신뢰하고, 미설정 시 loopback 기본값만 유지하므로 임의 XFF는 무시된다(`RemoteIpAddress`가 위조 IP로 바뀌지 않음).
- [x] **정상 프록시 경유 클라이언트 IP 복원 동작**: `ForwardedHeaders:KnownNetworks`에 프록시 서브넷(예: `172.16.0.0/12`)을 설정하면 해당 프록시가 전달한 XFF를 그대로 복원한다.
- [x] **빌드 클린**: `dotnet build Vanadium.slnx` → 경고 0, 오류 0. `dotnet test Vanadium.slnx` → 112 통과 / 3 스킵(PostgreSQL 전용, 기존).

## 참고 — 테스트 범위

ForwardedHeaders는 앱 시작 시 미들웨어 구성 코드라, `NoteService` 단위 로직을 다루는 기존 xUnit(EF SQLite in-memory) 하네스로는 커버되지 않는다(통합 테스트 하네스 부재). 빌드·기존 테스트 통과 + 코드 리뷰로 검증했다.

## 운영자 주의 (배포 시 조치 필요)

이 변경 이후 프록시 경유 클라이언트 IP 복원이 동작하려면 **실제 리버스 프록시의 IP/서브넷을 반드시 설정**해야 한다. 미설정 시 XFF가 신뢰되지 않아, 프록시 뒤 요청의 `RemoteIpAddress`가 실제 클라이언트가 아닌 프록시 IP로 남는다(보안상 안전한 기본값이나, 의도적으로 설정을 요구함).