### PR TITLE
#198 로그인 전역 실패 백오프(지수 잠금) 추가

### DIFF
--- a/Vanadium.Note.REST.Tests/LoginThrottleTests.cs
+++ b/Vanadium.Note.REST.Tests/LoginThrottleTests.cs
@@ -1,0 +1,174 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Vanadium.Note.REST.Security;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression tests for the global login backoff (issue #198): consecutive failed logins
+/// past a threshold must trigger an exponentially growing lockout that is shared across all
+/// sources (so IP distribution / XFF forgery cannot bypass it), resets on success, and does
+/// not let attempts during a lockout extend it indefinitely.
+/// </summary>
+public class LoginThrottleTests
+{
+    private const int Threshold = 5;
+    private const double BaseDelay = 30;
+    private const int MaxDelay = 900;
+
+    /// <summary>Minimal manual <see cref="TimeProvider"/> so tests control the clock without a new dependency.</summary>
+    private sealed class MutableTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+
+    private static (LoginThrottle Throttle, MutableTimeProvider Clock) CreateThrottle()
+    {
+        var clock = new MutableTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = Options.Create(new LoginLockoutOptions
+        {
+            FailureThreshold = Threshold,
+            BaseDelaySeconds = BaseDelay,
+            MaxDelaySeconds = MaxDelay,
+        });
+        var throttle = new LoginThrottle(options, clock, NullLogger<LoginThrottle>.Instance);
+        return (throttle, clock);
+    }
+
+    [Fact]
+    public void FailuresBelowThreshold_DoNotLock()
+    {
+        var (throttle, _) = CreateThrottle();
+
+        for (var i = 0; i < Threshold - 1; i++)
+            throttle.RegisterFailure();
+
+        Assert.False(throttle.IsLocked(out var retryAfter));
+        Assert.Equal(TimeSpan.Zero, retryAfter);
+    }
+
+    [Fact]
+    public void FailuresAtThreshold_LockForBaseDelay()
+    {
+        var (throttle, _) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+
+        Assert.True(throttle.IsLocked(out var retryAfter));
+        Assert.Equal(TimeSpan.FromSeconds(BaseDelay), retryAfter);
+    }
+
+    [Fact]
+    public void EachWindow_DoublesTheLockout_Exponentially()
+    {
+        var (throttle, clock) = CreateThrottle();
+
+        // Cross the threshold: first lockout is the base delay.
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out var first));
+        Assert.Equal(TimeSpan.FromSeconds(30), first);
+
+        // Wait out the window, then one more failure doubles the next window.
+        clock.Advance(TimeSpan.FromSeconds(30));
+        throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out var second));
+        Assert.Equal(TimeSpan.FromSeconds(60), second);
+
+        clock.Advance(TimeSpan.FromSeconds(60));
+        throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out var third));
+        Assert.Equal(TimeSpan.FromSeconds(120), third);
+    }
+
+    [Fact]
+    public void Lockout_IsCappedAtMaxDelay()
+    {
+        var (throttle, clock) = CreateThrottle();
+
+        // Drive far past the threshold, waiting out each window so every failure counts.
+        // 2^6 * 30 = 1920s would exceed the 900s cap; verify it clamps.
+        for (var i = 0; i < Threshold + 20; i++)
+        {
+            throttle.RegisterFailure();
+            throttle.IsLocked(out var retryAfter);
+            clock.Advance(retryAfter);
+        }
+
+        throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out var capped));
+        Assert.Equal(TimeSpan.FromSeconds(MaxDelay), capped);
+    }
+
+    [Fact]
+    public void IsLocked_BecomesFalse_AfterWindowExpires()
+    {
+        var (throttle, clock) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out _));
+
+        clock.Advance(TimeSpan.FromSeconds(BaseDelay));
+        Assert.False(throttle.IsLocked(out _));
+    }
+
+    [Fact]
+    public void RegisterSuccess_ClearsFailuresAndLockout()
+    {
+        var (throttle, _) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out _));
+
+        throttle.RegisterSuccess();
+
+        Assert.False(throttle.IsLocked(out _));
+        // The counter reset too: a fresh run of sub-threshold failures must not re-lock.
+        for (var i = 0; i < Threshold - 1; i++)
+            throttle.RegisterFailure();
+        Assert.False(throttle.IsLocked(out _));
+    }
+
+    [Fact]
+    public void FailuresDuringActiveLockout_DoNotExtendIt()
+    {
+        var (throttle, clock) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out var initial));
+        Assert.Equal(TimeSpan.FromSeconds(BaseDelay), initial);
+
+        // Hammer the locked login. These must be ignored — the window must neither
+        // grow nor its remaining time reset (lock-extension DoS protection).
+        clock.Advance(TimeSpan.FromSeconds(10));
+        for (var i = 0; i < 50; i++)
+            throttle.RegisterFailure();
+
+        Assert.True(throttle.IsLocked(out var remaining));
+        Assert.Equal(TimeSpan.FromSeconds(BaseDelay - 10), remaining);
+
+        // And the window still expires on the original schedule.
+        clock.Advance(TimeSpan.FromSeconds(BaseDelay - 10));
+        Assert.False(throttle.IsLocked(out _));
+    }
+
+    [Fact]
+    public void CounterIsSharedGlobally_RegardlessOfSource()
+    {
+        // The throttle holds no notion of client IP: every RegisterFailure feeds one counter,
+        // which is exactly why spreading attempts across IPs / forged XFF cannot bypass it.
+        var (throttle, _) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+
+        Assert.True(throttle.IsLocked(out _));
+    }
+}

--- a/Vanadium.Note.REST/Controllers/AuthController.cs
+++ b/Vanadium.Note.REST/Controllers/AuthController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.IdentityModel.Tokens;
+using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
@@ -21,6 +22,7 @@ public class AuthController(
     IConfiguration config,
     IWebHostEnvironment env,
     IPasswordValidator passwordValidator,
+    ILoginThrottle loginThrottle,
     ILogger<AuthController> logger) : ControllerBase
 {
     /// <summary>Fixed principal name for the single owner (used for logs/UI only).</summary>
@@ -31,6 +33,19 @@ public class AuthController(
     public IActionResult Login([FromBody] LoginRequest request)
     {
         logger.LogInformation("Login attempt.");
+
+        // Global backoff gate: unlike the per-IP fixed-window limiter, this counter is shared
+        // across every source, so distributed IPs or forged X-Forwarded-For cannot slip past it.
+        // Attempts arriving during an active lockout are rejected without touching the password.
+        if (loginThrottle.IsLocked(out var retryAfter))
+        {
+            var seconds = (int)Math.Ceiling(retryAfter.TotalSeconds);
+            Response.Headers.RetryAfter = seconds.ToString(CultureInfo.InvariantCulture);
+            logger.LogWarning("Login rejected by global lockout; {Seconds}s remaining.", seconds);
+            return Problem(
+                detail: "Too many failed login attempts. Try again later.",
+                statusCode: StatusCodes.Status429TooManyRequests);
+        }
 
         var storedHash = config["Auth:PasswordHash"];
         if (string.IsNullOrEmpty(storedHash))
@@ -43,10 +58,12 @@ public class AuthController(
 
         if (!PasswordHasher.Verify(request.Password, storedHash))
         {
+            loginThrottle.RegisterFailure();
             logger.LogWarning("Failed login attempt.");
             return Problem(detail: "Invalid password.", statusCode: StatusCodes.Status401Unauthorized);
         }
 
+        loginThrottle.RegisterSuccess();
         var token = GenerateJwtToken();
         logger.LogInformation("Owner authenticated successfully.");
         return Ok(new { token });

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -169,6 +169,15 @@ builder.Services.AddHttpClient<IPwnedPasswordsClient, PwnedPasswordsClient>(clie
 });
 builder.Services.AddScoped<IPasswordValidator, PasswordValidator>();
 
+// Global (IP-independent) login backoff. Complements the per-IP "login" rate limiter:
+// the singleton throttle shares one failure counter across all sources so distributed
+// IPs / forged X-Forwarded-For (issue #197) cannot dodge the cap. TimeProvider.System is
+// injected so the throttle's clock is fake-able in unit tests.
+builder.Services.Configure<LoginLockoutOptions>(
+    builder.Configuration.GetSection(LoginLockoutOptions.SectionName));
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<ILoginThrottle, LoginThrottle>();
+
 builder.Services.AddHostedService<OrphanFileCleanupJob>();
 builder.Services.AddHostedService<RecycleBinPurgeJob>();
 builder.Services.AddEndpointsApiExplorer();

--- a/Vanadium.Note.REST/Security/ILoginThrottle.cs
+++ b/Vanadium.Note.REST/Security/ILoginThrottle.cs
@@ -1,0 +1,23 @@
+namespace Vanadium.Note.REST.Security;
+
+/// <summary>
+/// A process-global, IP-independent throttle on login attempts. Tracks consecutive
+/// failed logins across every source and, past a threshold, imposes an exponentially
+/// growing lockout window. Because the counter is global (not partitioned by client IP),
+/// it cannot be bypassed by spreading attempts across many IPs or forging
+/// <c>X-Forwarded-For</c> headers — unlike the per-IP fixed-window rate limiter.
+/// </summary>
+public interface ILoginThrottle
+{
+    /// <summary>
+    /// Returns <c>true</c> if login is currently locked out. When locked,
+    /// <paramref name="retryAfter"/> is the remaining time until attempts are accepted again.
+    /// </summary>
+    bool IsLocked(out TimeSpan retryAfter);
+
+    /// <summary>Records a failed login attempt, extending the lockout once the threshold is crossed.</summary>
+    void RegisterFailure();
+
+    /// <summary>Records a successful login, clearing the failure count and any active lockout.</summary>
+    void RegisterSuccess();
+}

--- a/Vanadium.Note.REST/Security/LoginLockoutOptions.cs
+++ b/Vanadium.Note.REST/Security/LoginLockoutOptions.cs
@@ -1,0 +1,31 @@
+namespace Vanadium.Note.REST.Security;
+
+/// <summary>
+/// Configuration for <see cref="LoginThrottle"/>, the global (IP-independent) login
+/// failure backoff. Bound from the <c>Auth:Lockout</c> configuration section.
+/// </summary>
+/// <remarks>
+/// This complements the per-IP fixed-window rate limiter on <c>/api/auth/login</c>
+/// (see <c>Program.cs</c>): the per-IP limiter caps one source, this global throttle
+/// caps the total attempt rate so distributed sources or forged <c>X-Forwarded-For</c>
+/// headers (issue #197) cannot dodge the cap by spreading attempts across IPs.
+/// </remarks>
+public sealed class LoginLockoutOptions
+{
+    public const string SectionName = "Auth:Lockout";
+
+    /// <summary>
+    /// Number of consecutive global failures tolerated before any lockout applies.
+    /// Keeps an occasional typo by the legitimate owner from triggering a delay.
+    /// </summary>
+    public int FailureThreshold { get; set; } = 5;
+
+    /// <summary>
+    /// Lockout duration applied at the threshold. Each additional failure beyond the
+    /// threshold doubles this (exponential backoff), capped at <see cref="MaxDelaySeconds"/>.
+    /// </summary>
+    public double BaseDelaySeconds { get; set; } = 30;
+
+    /// <summary>Upper bound on a single lockout window, so the backoff never grows without limit.</summary>
+    public int MaxDelaySeconds { get; set; } = 900;
+}

--- a/Vanadium.Note.REST/Security/LoginThrottle.cs
+++ b/Vanadium.Note.REST/Security/LoginThrottle.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Options;
+
+namespace Vanadium.Note.REST.Security;
+
+/// <summary>
+/// In-memory, process-global implementation of <see cref="ILoginThrottle"/>. A single
+/// shared counter of consecutive failures drives an exponential backoff: the first
+/// <see cref="LoginLockoutOptions.FailureThreshold"/> failures are free, after which each
+/// failure locks logins for <c>BaseDelaySeconds * 2^n</c> (capped at <c>MaxDelaySeconds</c>).
+/// A successful login resets everything.
+/// </summary>
+/// <remarks>
+/// Registered as a singleton so the counter is shared across all requests. State is held
+/// in memory only, so it resets on restart — acceptable for a single-owner app whose goal
+/// is to blunt online guessing, not to provide durable lock records. The lock is a cheap
+/// short critical section; the expensive PBKDF2 verification happens outside it.
+/// </remarks>
+public sealed class LoginThrottle : ILoginThrottle
+{
+    private readonly LoginLockoutOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<LoginThrottle> _logger;
+    private readonly object _gate = new();
+
+    private int _consecutiveFailures;
+    private DateTimeOffset _lockedUntil = DateTimeOffset.MinValue;
+
+    public LoginThrottle(
+        IOptions<LoginLockoutOptions> options,
+        TimeProvider timeProvider,
+        ILogger<LoginThrottle> logger)
+    {
+        _options = options.Value;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public bool IsLocked(out TimeSpan retryAfter)
+    {
+        lock (_gate)
+        {
+            var now = _timeProvider.GetUtcNow();
+            if (now < _lockedUntil)
+            {
+                retryAfter = _lockedUntil - now;
+                return true;
+            }
+
+            retryAfter = TimeSpan.Zero;
+            return false;
+        }
+    }
+
+    public void RegisterFailure()
+    {
+        lock (_gate)
+        {
+            var now = _timeProvider.GetUtcNow();
+
+            // Ignore failures that arrive during an active lockout window. Counting them
+            // would let an attacker who keeps hammering a locked login extend the window
+            // forever, locking the legitimate owner out indefinitely (a self-inflicted DoS).
+            if (now < _lockedUntil)
+                return;
+
+            _consecutiveFailures++;
+            if (_consecutiveFailures < _options.FailureThreshold)
+                return;
+
+            var exponent = _consecutiveFailures - _options.FailureThreshold;
+            var seconds = Math.Min(
+                _options.BaseDelaySeconds * Math.Pow(2, exponent),
+                _options.MaxDelaySeconds);
+            _lockedUntil = now.AddSeconds(seconds);
+
+            _logger.LogWarning(
+                "Global login lockout engaged after {Failures} consecutive failures; locked for {Seconds}s.",
+                _consecutiveFailures, seconds);
+        }
+    }
+
+    public void RegisterSuccess()
+    {
+        lock (_gate)
+        {
+            _consecutiveFailures = 0;
+            _lockedUntil = DateTimeOffset.MinValue;
+        }
+    }
+}


### PR DESCRIPTION
Closes #198

## 문제

로그인은 IP당 10/min 고정 윈도우 제한만 있어, 분산 소스 또는 XFF 위조(#197)로 IP를 분산하면 전역 상한도 잠금도 없이 계속 시도할 수 있었다. 최종 방어가 PBKDF2 600k뿐이었다.

## 변경

소스와 무관하게 공유되는 **전역(IP 비종속) 로그인 실패 백오프**를 도입했다.

- `ILoginThrottle` / `LoginThrottle` (싱글턴): 하나의 전역 연속 실패 카운터를 유지. 임계치(`FailureThreshold`, 기본 5)까지는 자유, 이후 각 실패마다 `BaseDelaySeconds * 2^n` (기본 30초부터 두 배씩, `MaxDelaySeconds` 900초로 상한)로 잠금.
- `AuthController.Login`: 비밀번호 검증 전에 잠금 여부를 먼저 확인해 잠금 중이면 `429` + `Retry-After` 반환(비밀번호를 건드리지 않음). 실패 시 `RegisterFailure`, 성공 시 `RegisterSuccess`로 카운터 초기화.
- `LoginLockoutOptions` (`Auth:Lockout` 섹션 바인딩)로 임계치/지연/상한 조정 가능.
- 잠금 중 도착한 시도는 카운트하지 않아 공격자가 잠금을 무한 연장하는 self-DoS를 방지.
- `TimeProvider.System`을 주입해 단위 테스트에서 시계를 가짜로 제어.

기존 IP당 10/min 고정 윈도우 제한은 그대로 유지(범위 밖 준수), 리프레시 토큰 미도입.

## 완료 조건 검증

- [x] 실패 임계치 초과 시 지수 백오프/잠금 적용 — `FailuresAtThreshold_LockForBaseDelay`, `EachWindow_DoublesTheLockout_Exponentially`, `Lockout_IsCappedAtMaxDelay`
- [x] IP 분산/XFF 위조로 우회 불가(전역 카운터) — 싱글턴 공유 카운터, `CounterIsSharedGlobally_RegardlessOfSource`
- [x] 정상 재로그인 과도 차단 없음 — 임계치 이하 무시 + 성공 시 초기화, `FailuresBelowThreshold_DoNotLock`, `RegisterSuccess_ClearsFailuresAndLockout`
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0/오류 0
- 추가: 잠금 연장 DoS 방지 — `FailuresDuringActiveLockout_DoNotExtendIt`

테스트: `dotnet test` 전체 통과(신규 8건 포함, 126 통과 / 3 스킵).