### PR TITLE
#199 CSP 헤더 추가 (저장 HTML XSS 2차 방어선)

### DIFF
--- a/Vanadium.Note.REST.Tests/SecurityHeadersMiddlewareTests.cs
+++ b/Vanadium.Note.REST.Tests/SecurityHeadersMiddlewareTests.cs
@@ -29,4 +29,37 @@ public class SecurityHeadersMiddlewareTests
         Assert.True(called);
         Assert.Equal("nosniff", context.Response.Headers["X-Content-Type-Options"]);
     }
+
+    [Fact]
+    public async Task InvokeAsync_SetsLockedDownCspOnApiPaths()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/notes";
+        var middleware = new SecurityHeadersMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        var csp = context.Response.Headers["Content-Security-Policy"].ToString();
+        Assert.Contains("default-src 'none'", csp);
+        Assert.Contains("frame-ancestors 'none'", csp);
+        Assert.Contains("base-uri 'none'", csp);
+        // The locked-down API policy must never permit script execution.
+        Assert.DoesNotContain("script-src", csp);
+        Assert.DoesNotContain("unsafe-inline", csp);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_SkipsCspForSwaggerUi()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/swagger/index.html";
+        var middleware = new SecurityHeadersMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        // Swagger UI serves an inline bundle; a 'none' CSP would break it.
+        Assert.False(context.Response.Headers.ContainsKey("Content-Security-Policy"));
+        // Baseline headers still apply everywhere.
+        Assert.Equal("nosniff", context.Response.Headers["X-Content-Type-Options"]);
+    }
 }

--- a/Vanadium.Note.REST/Middleware/SecurityHeadersMiddleware.cs
+++ b/Vanadium.Note.REST/Middleware/SecurityHeadersMiddleware.cs
@@ -1,16 +1,35 @@
 namespace Vanadium.Note.REST.Middleware;
 
 /// <summary>
-/// Adds baseline security response headers. Currently emits
-/// <c>X-Content-Type-Options: nosniff</c> to stop browsers from MIME-sniffing
-/// responses away from their declared Content-Type. Broader headers (CSP, etc.)
-/// are intentionally left for a separate change (see issue #113 scope).
+/// Adds baseline security response headers:
+/// <list type="bullet">
+///   <item><c>X-Content-Type-Options: nosniff</c> stops browsers from
+///   MIME-sniffing responses away from their declared Content-Type.</item>
+///   <item>A locked-down <c>Content-Security-Policy</c> (issue #199). This API
+///   only ever returns JSON / <c>application/problem+json</c>, never an HTML
+///   document meant to run scripts, so it advertises the tightest possible
+///   policy: any HTML that somehow leaves an API path cannot load a script,
+///   frame content, be framed, or set a base URI. This is a defense-in-depth
+///   second line behind the HTML sanitizer — the interactive render surface
+///   (the Blazor WASM app and anonymous share page) carries its own,
+///   necessarily looser, CSP at the nginx layer.</item>
+/// </list>
+/// Swagger UI is a legitimate HTML+script surface (Development only), so the CSP
+/// is skipped for its paths — a request that reaches this middleware under
+/// <c>/swagger</c> must keep loading its inline bundle.
 /// </summary>
 public class SecurityHeadersMiddleware(RequestDelegate next)
 {
     public async Task InvokeAsync(HttpContext context)
     {
         context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+
+        // frame-ancestors and base-uri do NOT fall back to default-src, so they
+        // are stated explicitly alongside the 'none' default.
+        if (!context.Request.Path.StartsWithSegments("/swagger"))
+            context.Response.Headers["Content-Security-Policy"] =
+                "default-src 'none'; frame-ancestors 'none'; base-uri 'none'";
+
         await next(context);
     }
 }

--- a/Vanadium.Note.Web/nginx.conf
+++ b/Vanadium.Note.Web/nginx.conf
@@ -1,5 +1,28 @@
 server {
     listen 80;
+
+    # Content-Security-Policy: second line of defense behind the server-side HTML
+    # sanitizer for stored-note XSS (issue #199). The critical property is that
+    # script-src does NOT contain 'unsafe-inline': an injected inline <script> or
+    # inline event handler (onerror=, onclick=, ...) in stored note HTML cannot
+    # execute even if it survives the sanitizer, and javascript: URIs are blocked.
+    #
+    # Everything the Blazor WASM front-end legitimately needs is allowlisted:
+    #   - 'wasm-unsafe-eval' — the .NET WASM runtime compiles WebAssembly.
+    #   - 'unsafe-eval' — Mermaid (cdn.jsdelivr.net) and some CDN libs use eval;
+    #     kept so the editor/share diagrams work. It does NOT re-enable inline
+    #     <script> (that needs 'unsafe-inline'), so the XSS protection stands. It
+    #     can be dropped if diagram rendering is confirmed to work without it.
+    #   - esm.sh / cdn.jsdelivr.net — Tiptap, ProseMirror, lowlight and Mermaid
+    #     are loaded as ES modules from these CDNs (see wwwroot/js/tiptap/*).
+    # style-src allows 'unsafe-inline' because MudBlazor and Blazor inject inline
+    # styles (not a script-execution vector). img-/font-/connect-src are kept
+    # permissive because embedded images/attachments and the API live on a
+    # separate, deployment-configurable origin (API_BASE_URL) not known at build
+    # time; these are not inline-script vectors, so breadth here does not weaken
+    # the anti-XSS guarantee above.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' https://esm.sh https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: http:; font-src 'self' data:; connect-src 'self' https: http:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;
+
     location / {
         root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;

--- a/Vanadium.Note.Web/wwwroot/index.html
+++ b/Vanadium.Note.Web/wwwroot/index.html
@@ -38,28 +38,7 @@
     <script src="js/unsaved-changes.js"></script>
     <script type="module" src="js/tiptap-editor.js"></script>
     <script src="js/board-drag-drop.js"></script>
-    <script>
-        function setDarkMode(isDark) {
-            document.documentElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
-            document.body.classList.toggle('dark-mode', isDark);
-        }
-        function getSystemDarkMode() {
-            return window.matchMedia('(prefers-color-scheme: dark)').matches;
-        }
-        function applyTheme(theme) {
-            if (theme === 'dark') setDarkMode(true);
-            else if (theme === 'light') setDarkMode(false);
-            else setDarkMode(getSystemDarkMode());
-        }
-        function getStoredTheme() {
-            return localStorage.getItem('vn-theme') || 'system';
-        }
-        function storeTheme(theme) {
-            localStorage.setItem('vn-theme', theme);
-        }
-        // Apply immediately to prevent flash before Blazor loads
-        applyTheme(getStoredTheme());
-    </script>
+    <script src="js/theme-init.js"></script>
 </body>
 
 </html>

--- a/Vanadium.Note.Web/wwwroot/js/theme-init.js
+++ b/Vanadium.Note.Web/wwwroot/js/theme-init.js
@@ -1,0 +1,25 @@
+// Theme bootstrap. Kept as an external (non-module) script so the functions stay
+// on the global scope for Blazor JS interop (MainLayout/Settings call applyTheme,
+// storeTheme, setDarkMode, getSystemDarkMode). Extracted out of index.html so the
+// page can ship a Content-Security-Policy whose script-src omits 'unsafe-inline'
+// (issue #199) — an inline <script> block would otherwise be blocked.
+function setDarkMode(isDark) {
+    document.documentElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
+    document.body.classList.toggle('dark-mode', isDark);
+}
+function getSystemDarkMode() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+function applyTheme(theme) {
+    if (theme === 'dark') setDarkMode(true);
+    else if (theme === 'light') setDarkMode(false);
+    else setDarkMode(getSystemDarkMode());
+}
+function getStoredTheme() {
+    return localStorage.getItem('vn-theme') || 'system';
+}
+function storeTheme(theme) {
+    localStorage.setItem('vn-theme', theme);
+}
+// Apply immediately to prevent flash before Blazor loads
+applyTheme(getStoredTheme());


### PR DESCRIPTION
Closes #199

## 개요
저장 HTML XSS에 대한 2차 방어선으로 Content-Security-Policy 헤더를 추가한다. sanitizer(Ganss.Xss) 단일 계층만 있던 상태에서, sanitizer를 우회하거나 직접 DB write로 들어온 노트 HTML의 인라인 스크립트 실행을 CSP로 차단한다.

## 변경 내용

### 1. API (백엔드) — `SecurityHeadersMiddleware`
- API 경로 응답에 `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; base-uri 'none'` 설정.
- API는 JSON/ProblemDetails만 반환하므로 최대 강도 정책을 적용해, 혹시라도 HTML이 API 경로로 새어 나가도 스크립트 로드/프레이밍/base URI 설정을 전부 차단.
- Swagger UI(개발 전용, 인라인 번들 필요)는 `/swagger` 경로에서 제외.

### 2. 프론트엔드 (렌더 표면) — `nginx.conf`
저장 노트 HTML이 실제로 렌더되는 표면은 nginx가 서빙하는 Blazor WASM 앱(공유 페이지 포함)이므로, 여기에 CSP를 추가한다.
- **핵심 방어**: `script-src`에 `'unsafe-inline'`을 넣지 **않는다** → 노트 HTML에 주입된 인라인 `<script>` / `onerror=` 등 이벤트 핸들러 / `javascript:` URI가 sanitizer를 우회해도 실행 불가.
- 정상 동작에 필요한 출처만 허용: Blazor WASM 런타임(`'wasm-unsafe-eval'`), Tiptap/ProseMirror/Mermaid CDN(`https://esm.sh`, `https://cdn.jsdelivr.net`), MudBlazor/Blazor 인라인 스타일(`style-src 'unsafe-inline'`).
- `img-`/`connect-src`는 API·이미지 출처(`API_BASE_URL`, 빌드 시점에 미지정 + 배포별 상이)를 고려해 넓게 두되, 이들은 인라인 스크립트 실행 벡터가 아니므로 위 방어에는 영향 없음.
- `object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'none'`.

### 3. `index.html` 인라인 테마 스크립트 분리
- 엄격한 `script-src`(no `unsafe-inline`)와 호환되도록 인라인 `<script>` 테마 초기화 블록을 `js/theme-init.js`(classic 스크립트, 전역 함수 유지 — `applyTheme`/`storeTheme`/`setDarkMode`/`getSystemDarkMode`는 Blazor interop에서 호출)로 분리.

## 완료 조건 검증
- [x] **CSP 헤더 추가·인라인 스크립트 차단** — REST는 앱 실행 후 `curl`로 API 경로 CSP(`default-src 'none' …`)와 Swagger 제외를 확인. 프론트는 `script-src`에서 `'unsafe-inline'` 제거로 인라인 스크립트 차단.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0/오류 0, `dotnet test` 128 통과(3 skip은 기존 Postgres 전용).
- [ ] **Blazor 프론트/공유 페이지가 CSP 하 정상 로드·동작** — nginx+브라우저 실deploy에서 에디터(esm.sh 모듈)·Mermaid(공유 페이지 포함)·이미지 로드가 CSP 위반 없이 동작하는지 **수동 확인 필요**(dev는 Kestrel 서빙이라 nginx CSP 미적용). Mermaid가 `'unsafe-eval'` 없이도 렌더되면 해당 토큰 제거 가능.

## 범위 준수
- 미들웨어 파이프라인 순서(`Program.cs`) 변경 없음.
- HTML sanitizer 허용 태그/속성 정책(`HtmlSanitizerService`) 변경 없음.

## 테스트
`SecurityHeadersMiddlewareTests`에 API 경로 CSP 적용 / Swagger 제외 검증 추가.
