### PR TITLE
#201 자동저장 실패를 스낵바로 승격

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -290,6 +290,9 @@
     private Task<NoteItem?>? _saveInFlight;
     private bool _isDisposing = false;
     private bool _hasConflict = false;
+    // Tracks whether the current auto-save failure episode already raised a snackbar,
+    // so repeated failing auto-saves don't spam the user with duplicate alerts (#201).
+    private bool _autoSaveErrorNotified = false;
     private bool _loadFailed = false;
     private bool _editorInitFailed = false;
     private DateTime _serverUpdatedAt;
@@ -566,9 +569,19 @@
         if (saved is null)
         {
             SetStatus(_hasConflict ? "Conflict" : IsArchived ? "Archived" : "Save failed", "status-error");
+            // Promote a genuine auto-save failure to a snackbar so it is as visible as a
+            // manual-save failure (#201). Conflict/archived have their own dedicated UI.
+            // Raise it only once per failure episode to avoid spamming on every retry.
+            if (!_hasConflict && !IsArchived && !_autoSaveErrorNotified)
+            {
+                Snackbar.Add("Failed to auto-save note.", Severity.Error);
+                _autoSaveErrorNotified = true;
+            }
             StateHasChanged();
             return;
         }
+        // A save succeeded — reset the failure-notified guard so a later failure alerts again.
+        _autoSaveErrorNotified = false;
 
         if (isNew && !_isDisposing)
         {


### PR DESCRIPTION
Closes #201

## 변경 내용

자동저장 실패가 작은 'Save failed' 라벨로만 표시되어, 일시적 5xx나 만료 토큰(401) 상황에서 사용자가 저장 실패를 인지하기 어려웠다. 수동저장과 동일하게 스낵바 알림으로 승격했다.

- `DoAutoSave`의 실패 분기에서, 충돌/보관(archived)이 아닌 **실제 저장 실패**일 때만 `Snackbar.Add("Failed to auto-save note.", Severity.Error)` 호출.
- 반복 실패로 인한 스낵바 남발을 막기 위해 `_autoSaveErrorNotified` 가드를 두어 **실패 에피소드당 1회만** 알림. 저장이 성공하면 가드를 초기화해 이후 실패를 다시 알린다.

## 완료 조건 검증

- [x] 자동저장 실패 시 스낵바 알림 표시 (수동저장 `SaveNote`와 동일 UX) — `DoAutoSave` 실패 분기에 스낵바 추가로 확인.
- [x] 성공 시 불필요한 스낵바 남발 없음 — 성공 경로에 스낵바를 추가하지 않았고, 실패 알림은 에피소드당 1회로 제한.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0/오류 0. `dotnet test` 128 통과.

## 범위

- `Vanadium.Note.Web/Pages/NoteEditor.razor`만 변경. draft 백업/복구 로직은 미변경.
- Web 프로젝트에는 테스트 프로젝트가 없어(프론트엔드) 자동 회귀 테스트는 추가하지 못함.