### PR TITLE
#202 새 노트 라벨 저장 실패 감지 및 롤백

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -585,8 +585,7 @@
 
         if (isNew && !_isDisposing)
         {
-            foreach (var label in noteLabels.ToList())
-                await LabelService.AddLabelToNoteAsync(saved.Id, label.Id);
+            await PersistNewNoteLabelsAsync(saved.Id);
             // Set _currentId/_currentParentId before navigating so OnParametersSetAsync
             // treats this as a same-note transition and skips the full state reset,
             // preserving any content the user typed during the network round-trip.
@@ -650,8 +649,7 @@
         // the new note's labels and navigated — don't repeat that work here.
         if (isNew && !joinedInFlight)
         {
-            foreach (var label in noteLabels.ToList())
-                await LabelService.AddLabelToNoteAsync(saved.Id, label.Id);
+            await PersistNewNoteLabelsAsync(saved.Id);
         }
         Nav.NavigateTo(BackUrl);
     }
@@ -958,6 +956,32 @@
             }
         }
         noteLabels.RemoveAll(l => l.Id == labelId);
+    }
+
+    // A new note's labels are chosen locally (while Id is null) and only POSTed once the
+    // note exists. Each POST can fail independently; ignoring the result left the label
+    // showing in the UI while it was never saved, so it "vanished" on refresh (#202).
+    // Roll every failed label back out of the local list and alert the user so the UI
+    // matches the real server state.
+    private async Task PersistNewNoteLabelsAsync(Guid noteId)
+    {
+        var failed = new List<Label>();
+        foreach (var label in noteLabels.ToList())
+        {
+            var result = await LabelService.AddLabelToNoteAsync(noteId, label.Id);
+            if (!result.IsSuccess)
+                failed.Add(label);
+        }
+        if (failed.Count == 0)
+            return;
+
+        var failedIds = failed.Select(l => l.Id).ToHashSet();
+        noteLabels.RemoveAll(l => failedIds.Contains(l.Id));
+        Snackbar.Add(
+            failed.Count == 1
+                ? $"Failed to save label \"{failed[0].Name}\"."
+                : $"Failed to save {failed.Count} labels.",
+            Severity.Warning);
     }
 
     private async Task CreateLabel()


### PR DESCRIPTION
Closes #202

## 문제

새 노트에 붙인 라벨을 저장할 때 `AddLabelToNoteAsync`의 결과를 확인하지 않고 무시했다. 라벨 POST가 실패해도 UI에는 라벨이 남아 있지만 서버에는 저장되지 않아, 새로고침 후 '라벨이 사라졌다'로 보였다.

## 변경 사항

- `NoteEditor.razor`의 새 노트 라벨 저장 경로 두 곳(자동저장 `DoAutoSave`, 수동저장 `SaveNote`)에서 `AddLabelToNoteAsync` 결과를 무시하던 `foreach` 루프를 `PersistNewNoteLabelsAsync` 헬퍼로 통합.
- POST가 실패한 라벨은 로컬 `noteLabels`에서 롤백(제거)하고, 스낵바(`Severity.Warning`)로 사용자에게 알린다. 단일/복수 실패에 따라 메시지 문구를 구분.
- 기존 `ToggleLabel`/`RemoveLabel` 핸들러와 동일한 실패 처리 패턴(결과 확인 → 스낵바 → 로컬 상태 미적용)을 따른다.

## 완료 조건 검증

- [x] 라벨 POST 실패가 감지되면 사용자에게 알림이 뜬다 — 실패 라벨 발생 시 `Snackbar.Add(..., Severity.Warning)` 호출.
- [x] 실패한 라벨은 UI에서 롤백되어 실제 저장 상태와 일치한다 — `noteLabels.RemoveAll(failedIds)`로 실패 라벨만 제거. 자동저장 경로는 이후 재렌더링(`StateHasChanged`)에서 반영, 수동저장 경로는 서버 상태(라벨 없음)로 재진입 시 일치.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0. `dotnet test Vanadium.slnx` 128 통과 / 3 스킵(PostgreSQL 전용) / 0 실패.

## 범위

- 프론트엔드 `NoteEditor.razor`만 변경. 라벨 카테고리 상호배제 서버 로직은 건드리지 않음(범위 밖).
- Web 프로젝트에는 테스트 프로젝트가 없어 `.razor` @code 블록에 대한 단위 회귀 테스트는 추가하지 못했다(알려진 제약).