### PR TITLE
#203 저장 전 제목 trim + 빈 제목 Untitled fallback

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -522,10 +522,17 @@
 
     private async Task<NoteItem?> SaveOnceAsync()
     {
+        // Normalize the title before saving so a whitespace-only or empty title
+        // never lands in the list. Mirrors the Board create path (which trims) and
+        // falls back to "Untitled" for an empty result (#203).
+        var normalizedTitle = title.Trim();
+        if (normalizedTitle.Length == 0)
+            normalizedTitle = "Untitled";
+
         var note = new NoteItem
         {
             Id = Id ?? Guid.Empty,
-            Title = title,
+            Title = normalizedTitle,
             Content = content,
             ParentNoteId = parentNoteId,
             UpdatedAt = _serverUpdatedAt


### PR DESCRIPTION
Closes #203

## 변경 내용

에디터 저장 경로(`NoteEditor.SaveOnceAsync`)가 제목을 정규화하지 않아, 공백만 있거나 빈 제목의 노트가 목록에 그대로 남던 일관성 결함을 수정했다. Board 생성 경로(`Board.razor:334`)는 `Trim()`을 적용하는데 에디터는 하지 않아 동작이 달랐다.

저장 전 `title.Trim()`을 적용하고, 그 결과가 비어 있으면 `"Untitled"`로 대체한 뒤 `NoteItem.Title`에 담아 저장한다.

## 완료 조건 검증

- [x] **저장 시 제목이 trim된다** — `SaveOnceAsync`에서 `title.Trim()` 후 저장.
- [x] **빈 제목은 'Untitled' fallback으로 저장된다** — trim 결과가 빈 문자열이면 `"Untitled"`로 대체.
- [x] **Board와 에디터의 제목 정규화 동작이 일치한다** — 두 경로 모두 저장 전 trim 적용(에디터는 추가로 빈 제목 fallback).
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0. `dotnet test` 128 통과.

## 범위

- `Vanadium.Note.Web/Pages/NoteEditor.razor` 1개 파일만 변경(8줄 추가, 1줄 삭제).
- 범위 밖(서버측 제목 검증/스키마)은 건드리지 않음.

## 테스트 참고

Web(Blazor) 프로젝트에는 테스트 프로젝트가 없어 이 컴포넌트 로직에 대한 자동 회귀 테스트를 추가할 수 없다. 정규화 동작은 코드 리뷰 및 수동 확인으로 검증한다.