### PR TITLE
#205 보드 추가 노트 라벨 저장 결과 확인

### DIFF
--- a/Vanadium.Note.Web/Pages/Board.razor
+++ b/Vanadium.Note.Web/Pages/Board.razor
@@ -335,7 +335,20 @@
             var saveResult = await NoteService.SaveAsync(note);
             if (saveResult.IsSuccess)
             {
-                await LabelService.AddLabelToNoteAsync(saveResult.Value!.Id, dialogLabel.Id);
+                // The board places a new note into a column purely via its label. Ignoring the
+                // label POST result left a saved-but-labelless note showing in no column, so it
+                // looked like it vanished (#205). Detect the failure and tell the user the note
+                // exists but was not added to the column.
+                var labelResult = await LabelService.AddLabelToNoteAsync(saveResult.Value!.Id, dialogLabel.Id);
+                if (!labelResult.IsSuccess)
+                {
+                    Logger.LogError(
+                        "Note {NoteId} created but failed to add label '{LabelName}' from board dialog.",
+                        saveResult.Value!.Id, dialogLabel.Name);
+                    Snackbar.Add(
+                        $"Note saved, but couldn't be added to \"{dialogLabel.Name}\". It won't appear on the board.",
+                        Severity.Warning);
+                }
                 await LoadNotesForCurrentCategory();
                 showDialog = false;
                 dialogLabel = null;


### PR DESCRIPTION
Closes #205

## 문제

보드의 새 노트 추가 다이얼로그(`Board.razor` `ConfirmAddNote`)가 라벨 POST(`AddLabelToNoteAsync`) 결과를 무시했다(#202와 동일 패턴). 보드는 노트를 라벨로만 컬럼에 배치하므로, 라벨 저장이 실패하면 노트는 생성되지만 어느 컬럼에도 나타나지 않아 사라진 것처럼 보였다.

## 변경

- `AddLabelToNoteAsync` 결과를 확인한다.
- 실패 시 `Logger.LogError`로 기록하고, 스낵바(`Severity.Warning`)로 "노트는 저장됐지만 컬럼에 추가되지 못했다"고 사용자에게 알린다.
- 성공/실패 관계없이 `LoadNotesForCurrentCategory()`로 목록을 다시 불러와 UI가 실제 서버 저장 상태와 일치하도록 한다.

## 완료 조건 검증

- [x] **라벨 POST 실패가 감지되면 사용자에게 알림이 뜬다** — `labelResult.IsSuccess` 검사 후 실패 시 `Snackbar.Add(..., Severity.Warning)`.
- [x] **실패 시 노트/컬럼 UI 상태가 실제 저장 상태와 일치한다** — `LoadNotesForCurrentCategory()`가 서버에서 다시 로드하므로, 라벨 없는 노트는 컬럼에 표시되지 않고(실제 상태) 스낵바가 이유를 설명한다.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0. `dotnet test Vanadium.slnx` 128 통과.

## 범위

- `Board.razor` 한 파일만 변경.
- 라벨 카테고리 상호배제 서버 로직은 건드리지 않았다(범위 밖 준수).

## 테스트 참고

Web 프로젝트에는 테스트가 없고(이 UI 흐름 버그는 기존 REST 테스트 범위 밖), #202 수정과 동일하게 회귀 테스트는 추가하지 않았다. 기존 REST 테스트 전체 통과로 회귀 없음을 확인했다.