### PR TITLE
#214 텍스트 입력 중 전역 단축키 스킵 (Ctrl+N 오발동 수정)

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/keyboard-shortcuts.js
+++ b/Vanadium.Note.Web/wwwroot/js/keyboard-shortcuts.js
@@ -2,6 +2,10 @@
     'use strict';
 
     const _active = new Set();
+    // Shortcuts that must keep working while a text field is focused (command
+    // palette, save). Every other shortcut — bare keys AND modifier combos such
+    // as Ctrl+N — is skipped while typing so it can't hijack the input (#214).
+    const _inputSafe = new Set(['ctrl+k', 'ctrl+s']);
     let _ref = null;
 
     function _buildKey(e) {
@@ -17,9 +21,10 @@
         const key = _buildKey(e);
         if (!_active.has(key)) return;
 
-        // For bare keys (no Ctrl/Alt/Meta), skip when a text field has focus
-        const hasModifier = e.ctrlKey || e.metaKey || e.altKey;
-        if (!hasModifier) {
+        // Skip when a text field has focus, unless the shortcut is explicitly
+        // input-safe. This covers modifier combos (e.g. Ctrl+N) too, not just
+        // bare keys, so typing in a title/search field is never hijacked (#214).
+        if (!_inputSafe.has(key)) {
             const el = document.activeElement;
             const isTextField =
                 (el?.tagName === 'INPUT' && el?.type !== 'checkbox') ||


### PR DESCRIPTION
Closes #214

## 문제

`keyboard-shortcuts.js`가 bare 키(수식어 없는 키)만 텍스트 필드 포커스 시 스킵했기 때문에, `Ctrl+N`(새 노트) 같은 modifier 조합 단축키가 제목/검색 입력 도중에도 발동해 사용자를 페이지에서 이탈시켰다.

## 변경

- `_onKeyDown`의 스킵 조건을 보정: 텍스트 필드 포커스 시 bare 키뿐 아니라 **모든 단축키(modifier 조합 포함)** 를 스킵.
- 입력 중에도 의도적으로 동작해야 하는 단축키는 `_inputSafe` 예외 목록(`ctrl+k` 팔레트, `ctrl+s` 저장)으로 유지.
- 예외 목록을 키 문자열 기준으로 두어 `SubNoteDialog`의 `Ctrl+S` override도 자동 커버 → `KeyboardShortcutService` 등록 구조는 전혀 건드리지 않음 (범위 밖 준수).

## 완료 조건 검증

- [x] **텍스트 필드 포커스 시 Ctrl+N 등 전역 단축키가 발동하지 않는다** — `ctrl+n`/`ctrl+/`는 `_inputSafe`에 없으므로 입력 필드(INPUT/TEXTAREA/contentEditable) 포커스 시 `return`으로 스킵.
- [x] **Ctrl+K 팔레트 등 의도된 입력 중 단축키는 계속 동작한다** — `ctrl+k`, `ctrl+s`가 `_inputSafe`에 포함되어 스킵 조건을 우회.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0. `dotnet test` 128 통과.

## 참고

버그는 `keyboard-shortcuts.js`(JS)에 있고 Web 프로젝트에는 테스트 프로젝트/JS 테스트 하네스가 없어 자동 회귀 테스트는 추가하지 못했다. 빌드·기존 테스트 통과와 코드 흐름 검증으로 확인했다.