### PR TITLE
#216 text/plain·markdown 업로드 검증 강화

### DIFF
--- a/Vanadium.Note.REST.Tests/TextUploadHeuristicTests.cs
+++ b/Vanadium.Note.REST.Tests/TextUploadHeuristicTests.cs
@@ -1,0 +1,75 @@
+using System.Text;
+using Vanadium.Note.REST.Controllers;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Guards the text/plain·text/markdown upload heuristic (issue #216). These types
+/// have no reliable magic bytes, so <see cref="FilesController.IsLikelyText"/>
+/// sniffs a sampled prefix and rejects obvious binary payloads (NUL bytes or a
+/// high ratio of non-whitespace control characters) while letting real text and
+/// markdown through unchanged.
+/// </summary>
+public class TextUploadHeuristicTests
+{
+    [Fact]
+    public void PlainText_IsAccepted()
+    {
+        var bytes = Encoding.UTF8.GetBytes("Hello, world!\r\nThis is a note.\tTabbed.\n");
+        Assert.True(FilesController.IsLikelyText(bytes));
+    }
+
+    [Fact]
+    public void Markdown_IsAccepted()
+    {
+        var bytes = Encoding.UTF8.GetBytes("# Title\n\n- item one\n- item two\n\n```csharp\nvar x = 1;\n```\n");
+        Assert.True(FilesController.IsLikelyText(bytes));
+    }
+
+    [Fact]
+    public void MultiByteUtf8Text_IsAccepted()
+    {
+        // High bytes (0x80-0xFF) from multi-byte UTF-8 must not be treated as binary.
+        var bytes = Encoding.UTF8.GetBytes("한국어 텍스트 émojis é ü ñ — dashes.");
+        Assert.True(FilesController.IsLikelyText(bytes));
+    }
+
+    [Fact]
+    public void Utf8Bom_IsAccepted()
+    {
+        var bytes = Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes("plain text")).ToArray();
+        Assert.True(FilesController.IsLikelyText(bytes));
+    }
+
+    [Fact]
+    public void BytesWithNul_AreRejected()
+    {
+        // A single NUL byte is a strong binary signal (e.g. a PNG mislabeled as text/plain).
+        var bytes = new byte[] { 0x48, 0x65, 0x00, 0x6C, 0x6C, 0x6F };
+        Assert.False(FilesController.IsLikelyText(bytes));
+    }
+
+    [Fact]
+    public void BinaryBlob_IsRejected()
+    {
+        // A run of control bytes exceeds the allowed control-character ratio.
+        var bytes = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x1B, 0x1C, 0x1D };
+        Assert.False(FilesController.IsLikelyText(bytes));
+    }
+
+    [Fact]
+    public void EmptySample_IsRejected()
+    {
+        Assert.False(FilesController.IsLikelyText(ReadOnlySpan<byte>.Empty));
+    }
+
+    [Fact]
+    public void MostlyTextWithFewControlChars_IsAccepted()
+    {
+        // A couple of stray control chars in otherwise-clean text stays under the threshold.
+        var text = new string('a', 200);
+        var bytes = Encoding.UTF8.GetBytes(text).Append((byte)0x01).ToArray();
+        Assert.True(FilesController.IsLikelyText(bytes));
+    }
+}

--- a/Vanadium.Note.REST/Controllers/FilesController.cs
+++ b/Vanadium.Note.REST/Controllers/FilesController.cs
@@ -48,9 +48,9 @@ public class FilesController(IWebHostEnvironment env, NoteDbContext db, ILogger<
             return Problem(detail: $"File type '{request.File.ContentType}' is not allowed.", statusCode: StatusCodes.Status400BadRequest);
         }
 
-        if (!await HasValidMagicBytesAsync(request.File, request.File.ContentType))
+        if (!await IsContentValidAsync(request.File))
         {
-            logger.LogWarning("File upload rejected: magic bytes mismatch for '{ContentType}' ('{FileName}')",
+            logger.LogWarning("File upload rejected: content validation failed for '{ContentType}' ('{FileName}')",
                 request.File.ContentType, request.File.FileName);
             return Problem(detail: "File content does not match the declared file type.", statusCode: StatusCodes.Status400BadRequest);
         }
@@ -78,6 +78,55 @@ public class FilesController(IWebHostEnvironment env, NoteDbContext db, ILogger<
 
         logger.LogInformation("File saved: {FileId} ('{FileName}')", id, originalName);
         return Ok(new { url = $"/api/files/{id}", filename = originalName });
+    }
+
+    private static readonly HashSet<string> TextContentTypes = ["text/plain", "text/markdown"];
+
+    // Number of leading bytes sampled for the text/binary heuristic. A prefix is
+    // enough to catch obvious binary payloads without buffering the whole upload.
+    private const int TextSampleSize = 8192;
+
+    // Reject if more than this fraction of sampled bytes are suspicious control
+    // characters. Real text/markdown stays well under this; binary blobs blow past it.
+    private const double MaxControlCharRatio = 0.10;
+
+    private static Task<bool> IsContentValidAsync(IFormFile file) =>
+        TextContentTypes.Contains(file.ContentType)
+            ? IsLikelyTextAsync(file)
+            : HasValidMagicBytesAsync(file, file.ContentType);
+
+    // text/plain and text/markdown have no reliable magic bytes, so instead of
+    // trusting the client Content-Type we sniff a prefix and reject obvious binary
+    // (NUL bytes or a high ratio of non-whitespace control characters).
+    private static async Task<bool> IsLikelyTextAsync(IFormFile file)
+    {
+        var buffer = new byte[TextSampleSize];
+        await using var stream = file.OpenReadStream();
+        var read = await stream.ReadAsync(buffer);
+        if (read == 0) return false;
+
+        return IsLikelyText(buffer.AsSpan(0, read));
+    }
+
+    internal static bool IsLikelyText(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.IsEmpty) return false;
+
+        var suspicious = 0;
+        foreach (var b in bytes)
+        {
+            // A NUL byte is a strong binary signal (UTF-8/ASCII text never contains one).
+            if (b == 0x00) return false;
+
+            // Allow common text whitespace/control chars: tab, LF, VT, FF, CR.
+            var isAllowedWhitespace = b is 0x09 or 0x0A or 0x0B or 0x0C or 0x0D;
+            if ((b < 0x20 && !isAllowedWhitespace) || b == 0x7F)
+                suspicious++;
+        }
+
+        // High bytes (0x80–0xFF) are left uncounted so legitimate UTF-8 / Latin-1
+        // text passes; only control-character density drives the decision.
+        return suspicious <= bytes.Length * MaxControlCharRatio;
     }
 
     private static async Task<bool> HasValidMagicBytesAsync(IFormFile file, string contentType)
@@ -111,9 +160,7 @@ public class FilesController(IWebHostEnvironment env, NoteDbContext db, ILogger<
             "image/webp" => read >= 8 && buffer[0] == 0x52 && buffer[1] == 0x49 &&
                             buffer[2] == 0x46 && buffer[3] == 0x46,
 
-            // TXT / MD: no reliable magic bytes — trust Content-Type header
-            "text/plain" or "text/markdown" => true,
-
+            // text/plain and text/markdown are validated separately by IsLikelyTextAsync.
             _ => false
         };
     }


### PR DESCRIPTION
Closes #216

## 배경
`text/plain`·`text/markdown` 업로드는 매직바이트가 없어 클라이언트가 보낸 Content-Type만 신뢰했다. 임의 바이너리 바이트를 `text/plain`으로 위장해 저장할 수 있었다(`HasValidMagicBytesAsync`가 텍스트 타입에 대해 무조건 `true` 반환).

## 변경 내용
- 텍스트 타입 업로드를 `IsLikelyTextAsync`로 라우팅해, 앞부분 최대 8KB를 샘플링하는 최소 휴리스틱 검증을 적용.
- `IsLikelyText`: NUL 바이트가 있으면 즉시 바이너리로 거부, 비공백 제어문자(탭·LF·VT·FF·CR·고바이트 제외) 비율이 10%를 넘으면 거부.
- 고바이트(0x80–0xFF)는 세지 않으므로 다국어 UTF-8/Latin-1 텍스트는 정상 통과.
- 매직바이트 스위치의 죽은 `text/* => true` 분기 제거.
- 화이트리스트/100MB 상한은 그대로 유지(범위 밖).

## 완료 조건 검증
- [x] text/plain·markdown에 휴리스틱 검증 적용 — `IsContentValidAsync` 라우팅 + `IsLikelyText`
- [x] 명백한 바이너리 거부 — `BytesWithNul_AreRejected`, `BinaryBlob_IsRejected` 테스트 통과
- [x] 정상 텍스트/마크다운 통과 — `PlainText_IsAccepted`, `Markdown_IsAccepted`, `MultiByteUtf8Text_IsAccepted`, `Utf8Bom_IsAccepted` 통과
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0
- 전체 테스트 `dotnet test Vanadium.slnx`: 통과 136 / 실패 0 / 건너뜀 3(기존 PostgreSQL 전용)