### PR TITLE
#217 WebP 매직바이트 검증을 두 컨트롤러에서 통일

### DIFF
--- a/Vanadium.Note.REST.Tests/WebpMagicByteTests.cs
+++ b/Vanadium.Note.REST.Tests/WebpMagicByteTests.cs
@@ -1,0 +1,66 @@
+using Vanadium.Note.REST.Controllers;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Guards the WebP magic-byte validation in <see cref="FilesController"/> (issue #217).
+/// A WebP file is a RIFF container whose bytes at offset 8 spell <c>WEBP</c>. Checking
+/// only the <c>RIFF</c> prefix also accepts AVI/WAV (same container), so the offset-8
+/// signature must be verified — matching ImagesController.DetectImageTypeAsync.
+/// </summary>
+public class WebpMagicByteTests
+{
+    // "RIFF" (offset 0) + 4 size bytes + "WEBP" (offset 8).
+    private static byte[] Riff(params byte[] signatureAt8)
+    {
+        var buffer = new byte[12];
+        buffer[0] = 0x52; buffer[1] = 0x49; buffer[2] = 0x46; buffer[3] = 0x46; // RIFF
+        buffer[4] = 0x24; buffer[5] = 0x00; buffer[6] = 0x00; buffer[7] = 0x00; // size (arbitrary)
+        signatureAt8.CopyTo(buffer, 8);
+        return buffer;
+    }
+
+    [Fact]
+    public void RealWebp_IsAccepted()
+    {
+        var buffer = Riff(0x57, 0x45, 0x42, 0x50); // "WEBP"
+        Assert.True(FilesController.HasValidMagicBytes(buffer, buffer.Length, "image/webp"));
+    }
+
+    [Fact]
+    public void RiffAvi_IsRejectedAsWebp()
+    {
+        // AVI is a RIFF container ("AVI " at offset 8) — must NOT pass as WebP.
+        var buffer = Riff(0x41, 0x56, 0x49, 0x20); // "AVI "
+        Assert.False(FilesController.HasValidMagicBytes(buffer, buffer.Length, "image/webp"));
+    }
+
+    [Fact]
+    public void RiffWav_IsRejectedAsWebp()
+    {
+        // WAV is a RIFF container ("WAVE" at offset 8) — must NOT pass as WebP.
+        var buffer = Riff(0x57, 0x41, 0x56, 0x45); // "WAVE"
+        Assert.False(FilesController.HasValidMagicBytes(buffer, buffer.Length, "image/webp"));
+    }
+
+    [Fact]
+    public void RiffOnly_TooShortForOffset8_IsRejected()
+    {
+        // Only the RIFF prefix present (8 bytes read): offset-8 signature can't be
+        // verified, so it must be rejected rather than trusted.
+        var buffer = Riff(0x00, 0x00, 0x00, 0x00);
+        Assert.False(FilesController.HasValidMagicBytes(buffer, 8, "image/webp"));
+    }
+
+    [Fact]
+    public void OtherMimeTypes_AreUnaffected()
+    {
+        // The fix must not change validation for other MIME types (issue #217 범위 밖).
+        var png = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x00 };
+        Assert.True(FilesController.HasValidMagicBytes(png, png.Length, "image/png"));
+
+        var pdf = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x37 };
+        Assert.True(FilesController.HasValidMagicBytes(pdf, pdf.Length, "application/pdf"));
+    }
+}

--- a/Vanadium.Note.REST/Controllers/FilesController.cs
+++ b/Vanadium.Note.REST/Controllers/FilesController.cs
@@ -131,9 +131,15 @@ public class FilesController(IWebHostEnvironment env, NoteDbContext db, ILogger<
 
     private static async Task<bool> HasValidMagicBytesAsync(IFormFile file, string contentType)
     {
-        var buffer = new byte[8];
+        var buffer = new byte[12];
         await using var stream = file.OpenReadStream();
         var read = await stream.ReadAsync(buffer);
+
+        return HasValidMagicBytes(buffer, read, contentType);
+    }
+
+    internal static bool HasValidMagicBytes(ReadOnlySpan<byte> buffer, int read, string contentType)
+    {
         if (read < 4) return false;
 
         return contentType switch
@@ -157,8 +163,13 @@ public class FilesController(IWebHostEnvironment env, NoteDbContext db, ILogger<
             "image/jpeg" => buffer[0] == 0xFF && buffer[1] == 0xD8 && buffer[2] == 0xFF,
             "image/png"  => buffer[0] == 0x89 && buffer[1] == 0x50 && buffer[2] == 0x4E && buffer[3] == 0x47,
             "image/gif"  => buffer[0] == 0x47 && buffer[1] == 0x49 && buffer[2] == 0x46 && buffer[3] == 0x38,
-            "image/webp" => read >= 8 && buffer[0] == 0x52 && buffer[1] == 0x49 &&
-                            buffer[2] == 0x46 && buffer[3] == 0x46,
+
+            // RIFF container (offset 0) + WEBP signature (offset 8). Matching only the
+            // RIFF prefix would also accept AVI/WAV, so the offset-8 check is required —
+            // this mirrors ImagesController.DetectImageTypeAsync.
+            "image/webp" => read >= 12 &&
+                            buffer[0] == 0x52 && buffer[1] == 0x49 && buffer[2] == 0x46 && buffer[3] == 0x46 &&
+                            buffer[8] == 0x57 && buffer[9] == 0x45 && buffer[10] == 0x42 && buffer[11] == 0x50,
 
             // text/plain and text/markdown are validated separately by IsLikelyTextAsync.
             _ => false


### PR DESCRIPTION
Closes #217

## 변경 사항

`FilesController`의 WebP 매직바이트 검증이 `RIFF` 접두만 검사해 AVI/WAV(같은 RIFF 컨테이너)도 WebP로 통과하던 문제를 수정한다. offset 8의 `WEBP` 시그니처까지 확인해 `ImagesController.DetectImageTypeAsync`와 검증 로직을 통일했다.

- 읽는 버퍼를 8→12바이트로 늘리고, `image/webp` 케이스에 offset 8~11 `WEBP`(0x57 0x45 0x42 0x50) 검사를 추가.
- 검증 스위치를 순수 메서드 `HasValidMagicBytes(ReadOnlySpan<byte>, int, string)`로 분리(파일 내 기존 `IsLikelyText` 패턴과 동일)해 회귀 테스트가 가능하도록 함.
- 다른 MIME 타입 검증 로직은 바이트 단위로 동일(범위 밖 준수).

## 완료 조건 검증

- **FilesController가 RIFF + offset 8 `WEBP`를 함께 검사** — `FilesController.cs`의 `image/webp` 케이스에서 확인. `RealWebp_IsAccepted` 통과.
- **AVI/WAV 등 비-WebP RIFF가 통과하지 않음** — `RiffAvi_IsRejectedAsWebp`, `RiffWav_IsRejectedAsWebp` 통과.
- **두 컨트롤러 검증 로직 일치** — 두 컨트롤러 모두 RIFF(offset 0) + WEBP(offset 8)를 12바이트에서 검사.
- **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0, 오류 0. `dotnet test` 141 통과(신규 5 포함).