### PR TITLE
#221 강제저장을 명시적 force 파라미터로 분리 (동시성 우회 차단)

### DIFF
--- a/Vanadium.Note.REST.Tests/ArchiveControllerTests.cs
+++ b/Vanadium.Note.REST.Tests/ArchiveControllerTests.cs
@@ -55,7 +55,7 @@ public class ArchiveControllerTests
         var controller = CreateNotesController(h);
 
         var result = await controller.Update(note.Id,
-            new NoteItem { Title = "Changed", Content = "", UpdatedAt = default }, CancellationToken.None);
+            new NoteItem { Title = "Changed", Content = "", UpdatedAt = default }, force: false, CancellationToken.None);
 
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(StatusCodes.Status403Forbidden, objectResult.StatusCode);
@@ -111,7 +111,7 @@ public class ArchiveControllerTests
             Content = "",
             ParentNoteId = archivedParent.Id,
             UpdatedAt = default
-        }, CancellationToken.None);
+        }, force: false, CancellationToken.None);
 
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);

--- a/Vanadium.Note.REST.Tests/NoteConcurrencyTests.cs
+++ b/Vanadium.Note.REST.Tests/NoteConcurrencyTests.cs
@@ -96,15 +96,40 @@ public class NoteConcurrencyTests
         Assert.True(updated.UpdatedAt >= note.UpdatedAt);
     }
 
+    // ── #221: a default/zero version no longer bypasses the check on its own ──
+
     [Fact]
-    public async Task Update_DefaultVersion_ForceSaves_BypassingTheConflictCheck()
+    public async Task Update_DefaultVersion_WithoutForce_ReturnsConflict_AndLeavesNoteUnchanged()
     {
         using var h = new TestHost();
         var note = await h.CreateNoteAsync("Original", content: "<p>original</p>");
 
-        // A default UpdatedAt is the intentional force-save bypass.
+        // A default (zero) UpdatedAt used to silently force-save; it must now be
+        // pinned as the concurrency token like any other value. Zero matches no
+        // real row, so the save conflicts instead of overwriting (#221).
         var (updated, conflict, archived) = await h.Notes.Update(note.Id,
-            new NoteItem { Title = "Force", Content = "<p>f</p>", UpdatedAt = default });
+            new NoteItem { Title = "Sneaky force", Content = "<p>f</p>", UpdatedAt = default });
+
+        Assert.Null(updated);
+        Assert.True(conflict);
+        Assert.False(archived);
+
+        var fresh = await h.FindAsync(note.Id);
+        Assert.Equal("Original", fresh!.Title);
+    }
+
+    [Fact]
+    public async Task Update_ExplicitForce_BypassesConflictCheck_EvenWithStaleVersion()
+    {
+        using var h = new TestHost();
+        var note = await h.CreateNoteAsync("Original", content: "<p>original</p>");
+
+        // Even a stale version force-saves when the explicit force flag is set —
+        // the deliberate, server-authorized overwrite path.
+        var stale = note.UpdatedAt.AddSeconds(-5);
+        var (updated, conflict, archived) = await h.Notes.Update(note.Id,
+            new NoteItem { Title = "Force", Content = "<p>f</p>", UpdatedAt = stale },
+            forceSave: true);
 
         Assert.False(conflict);
         Assert.False(archived);

--- a/Vanadium.Note.REST.Tests/ReferenceCleanupRecycleBinTests.cs
+++ b/Vanadium.Note.REST.Tests/ReferenceCleanupRecycleBinTests.cs
@@ -68,10 +68,13 @@ public class ReferenceCleanupRecycleBinTests
             $"data-title=\"Old Title\">\U0001F4C4 Old Title</div>";
         var referencing = await AddSoftDeletedNoteAsync(h, pageLink);
 
-        // Rename the target (UpdatedAt=default → force-save, bypasses concurrency check).
+        // Rename the target via an explicit force-save so this reference-cleanup
+        // test does not depend on version bookkeeping (#221: a default version no
+        // longer bypasses the concurrency check on its own).
         var (updated, conflict, archived) = await h.Notes.Update(
             target.Id,
-            new NoteItem { Title = "New Title", Content = target.Content, UpdatedAt = default });
+            new NoteItem { Title = "New Title", Content = target.Content, UpdatedAt = default },
+            forceSave: true);
         Assert.NotNull(updated);
         Assert.False(conflict);
         Assert.False(archived);

--- a/Vanadium.Note.REST/Controllers/NotesController.cs
+++ b/Vanadium.Note.REST/Controllers/NotesController.cs
@@ -109,7 +109,7 @@ public class NotesController(NoteService noteService, LabelService labelService,
     }
 
     [HttpPut("{id:guid}")]
-    public async Task<ActionResult<NoteItem>> Update(Guid id, [FromBody] NoteItem note, CancellationToken ct)
+    public async Task<ActionResult<NoteItem>> Update(Guid id, [FromBody] NoteItem note, [FromQuery] bool force, CancellationToken ct)
     {
         if (note.ParentNoteId.HasValue)
         {
@@ -130,7 +130,10 @@ public class NotesController(NoteService noteService, LabelService labelService,
             }
         }
 
-        var (updated, conflict, archived) = await noteService.Update(id, note, ct);
+        // force=true is an explicit, opt-in force-save that bypasses the optimistic
+        // concurrency check. Without it, a client can no longer force-overwrite a
+        // concurrent edit merely by sending a default/zero version (#221).
+        var (updated, conflict, archived) = await noteService.Update(id, note, force, ct);
         if (archived)
             return Problem(
                 detail: "Note is archived and read-only.",

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -327,7 +327,7 @@ public class NoteService(
         return note;
     }
 
-    public async Task<(NoteItem? Note, bool Conflict, bool Archived)> Update(Guid id, NoteItem note, CancellationToken ct = default)
+    public async Task<(NoteItem? Note, bool Conflict, bool Archived)> Update(Guid id, NoteItem note, bool forceSave = false, CancellationToken ct = default)
     {
         var existing = await db.Notes.FirstOrDefaultAsync(n => n.Id == id, ct);
         if (existing is null) return (null, false, false);
@@ -357,14 +357,20 @@ public class NoteService(
         existing.ParentNoteId = note.ParentNoteId;
         existing.UpdatedAt = UtcNowMicroseconds();
 
-        // Optimistic concurrency: when the client sent the version it last saw,
-        // pin it as the concurrency token's original value so EF enforces the
-        // check in the UPDATE's WHERE clause at the DB level — the DB, not an
-        // in-memory compare, decides the conflict, so a write racing between our
-        // read and save can no longer be lost. A default version is the
-        // force-save bypass: leave the token at the freshly-read DB value so the
-        // save proceeds (only a genuine mid-flight race can still conflict it).
-        if (clientVersion != default)
+        // Optimistic concurrency: pin the client's claimed version as the
+        // concurrency token's original value so EF enforces the check in the
+        // UPDATE's WHERE clause at the DB level — the DB, not an in-memory
+        // compare, decides the conflict, so a write racing between our read and
+        // save can no longer be lost. This runs for EVERY non-force save,
+        // including a default/zero version: a zero can never match a real row, so
+        // it conflicts instead of silently overwriting (#221) — a client can no
+        // longer bypass the check merely by omitting the version.
+        //
+        // Force-save is the only bypass and must be an explicit, server-authorized
+        // action (the `force` flag, wired from a dedicated endpoint parameter):
+        // leave the token at the freshly-read DB value so the save proceeds (only
+        // a genuine mid-flight race can still conflict it).
+        if (!forceSave)
             db.Entry(existing).Property(e => e.UpdatedAt).OriginalValue = clientVersion;
 
         try

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -296,6 +296,10 @@
     private bool _loadFailed = false;
     private bool _editorInitFailed = false;
     private DateTime _serverUpdatedAt;
+    // One-shot flag: the user pressed "Force Save" in the conflict banner, so the
+    // next save must send the explicit force opt-in (#221). Consumed and reset by
+    // the save entry point — a default/zero version alone no longer force-saves.
+    private bool _forceNextSave;
     private string saveStatusText = string.Empty;
     private string saveStatusCss = string.Empty;
 
@@ -537,7 +541,10 @@
             ParentNoteId = parentNoteId,
             UpdatedAt = _serverUpdatedAt
         };
-        var result = await NoteService.SaveAsync(note);
+        // Consume the one-shot force flag so only this save bypasses the check.
+        var force = _forceNextSave;
+        _forceNextSave = false;
+        var result = await NoteService.SaveAsync(note, force);
         if (result.IsConflict)
         {
             _hasConflict = true;
@@ -663,7 +670,11 @@
 
     private async Task ForceSave()
     {
-        _serverUpdatedAt = default;
+        // Signal an explicit force-save rather than zeroing the version: the server
+        // now bypasses the concurrency check only for an explicit force opt-in, not
+        // for a default/zero version (#221). The last-known version still rides
+        // along in the payload; the server ignores it when forcing.
+        _forceNextSave = true;
         _hasConflict = false;
         HasPendingChanges = true;
         await DoAutoSave();

--- a/Vanadium.Note.Web/Services/NoteService.cs
+++ b/Vanadium.Note.Web/Services/NoteService.cs
@@ -98,13 +98,16 @@ public class NoteService(HttpClient http, ILogger<NoteService> logger)
         }
     }
 
-    public async Task<ServiceResult<NoteItem>> SaveAsync(NoteItem note)
+    public async Task<ServiceResult<NoteItem>> SaveAsync(NoteItem note, bool force = false)
     {
         try
         {
+            // force=true is the explicit force-save opt-in (#221): the server only
+            // bypasses the optimistic concurrency check when this flag is present,
+            // never merely because the version is default/zero.
             var response = note.Id == Guid.Empty
                 ? await http.PostAsJsonAsync("api/notes", note)
-                : await http.PutAsJsonAsync($"api/notes/{note.Id}", note);
+                : await http.PutAsJsonAsync($"api/notes/{note.Id}{(force ? "?force=true" : string.Empty)}", note);
 
             if (response.StatusCode == HttpStatusCode.Conflict)
                 return ServiceResult<NoteItem>.Conflict();


### PR DESCRIPTION
Closes #221

## 문제

`NoteService.Update`가 `clientVersion == default`(0)이면 낙관적 동시성 검사를 완전히 건너뛰었다. 클라이언트/PAT가 버전 0만 보내면 동시 편집을 조용히 last-write-wins로 덮어쓸 수 있어, 'force save'가 서버가 인가하는 명시적 액션이 아니라 버전 0 전송만으로 트리거되는 암묵적 우회였다.

## 변경

- **백엔드 정책 변경** (`NoteService.Update`): force가 아닌 모든 저장은 클라이언트가 보낸 버전을 동시성 토큰 `OriginalValue`로 고정한다. 버전 0은 실제 행과 절대 일치하지 않으므로 조용한 덮어쓰기 대신 409 충돌이 발생한다. 버전을 생략하는 것만으로는 검사를 우회할 수 없다.
- **명시적 강제저장 엔드포인트 파라미터**: `PUT /api/notes/{id}?force=true`. 컨트롤러가 `[FromQuery] bool force`를 받아 `Update`의 `forceSave` 인자로 전달한다. force=true일 때만 검사를 우회한다(정상적인 mid-flight race는 여전히 충돌).
- **프론트엔드**: `ForceSave`가 버전을 0으로 초기화하던 방식을 버리고 명시적 `force` 플래그를 세워 `?force=true`로 전송한다. `NoteService.SaveAsync(note, force)` 추가.
- 스키마/동시성 토큰 컬럼 변경 없음 (정책만 조정).

## 완료 조건 검증

- [x] `clientVersion == 0`만으로는 동시성 검사가 우회되지 않는다 — 회귀 테스트 `Update_DefaultVersion_WithoutForce_ReturnsConflict_AndLeavesNoteUnchanged` (버전 0 → 충돌, 노트 원본 유지)
- [x] 강제저장은 명시적 파라미터를 통해서만 수행된다 — `?force=true` / `forceSave` 인자, 테스트 `Update_ExplicitForce_BypassesConflictCheck_EvenWithStaleVersion`
- [x] 정상 편집 저장 흐름(정상 버전 전달)은 그대로 동작한다 — 기존 테스트 `Update_MatchingClientVersion_Succeeds_AndAdvancesVersion` 통과 유지
- [x] 빌드 클린 (`dotnet build Vanadium.slnx` — 경고 0, 오류 0)

전체 테스트: 142 통과 / 3 스킵(PostgreSQL 전용) / 0 실패.