### PR TITLE
#237 keyboard-shortcuts _buildKey에서 e.key undefined 예외 수정

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/keyboard-shortcuts.js
+++ b/Vanadium.Note.Web/wwwroot/js/keyboard-shortcuts.js
@@ -9,6 +9,11 @@
     let _ref = null;
 
     function _buildKey(e) {
+        // Some synthetic keydown events (e.g. browser credential autofill on the
+        // login form) have no `key`, so guard against a falsy value instead of
+        // calling toLowerCase() on undefined (#237).
+        if (!e.key) return null;
+
         const mods = [];
         if (e.ctrlKey || e.metaKey) mods.push('ctrl');
         if (e.altKey) mods.push('alt');
@@ -19,7 +24,7 @@
 
     function _onKeyDown(e) {
         const key = _buildKey(e);
-        if (!_active.has(key)) return;
+        if (!key || !_active.has(key)) return;
 
         // Skip when a text field has focus, unless the shortcut is explicitly
         // input-safe. This covers modifier combos (e.g. Ctrl+N) too, not just


### PR DESCRIPTION
Closes #237

## 문제
로그인/로그아웃 시 `keyboard-shortcuts.js`의 `_buildKey`에서 `e.key`가 `undefined`인 keydown 이벤트가 들어오면 `e.key.toLowerCase()`에서 `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`가 발생했다. 브라우저 자격증명 자동완성(autofill)이 만들어내는 합성 keydown 이벤트에 `key`가 없는 경우가 원인이다.

## 변경 사항
- `_buildKey(e)`: `e.key`가 falsy이면 `null`을 반환하고 조기 종료 (`toLowerCase()` 미호출).
- `_onKeyDown(e)`: `key`가 falsy이면 조용히 무시하도록 가드 추가.

`Vanadium.Note.Web/wwwroot/js/keyboard-shortcuts.js` 한 파일만 변경. `KeyboardShortcutService`, `_inputSafe`/`_active` 등록 체계, Ctrl+K/Ctrl+S 키맵 로직(#214)은 건드리지 않음 (범위 밖 준수).

## 완료 조건 검증
- [x] `e.key`가 undefined/falsy인 keydown에서 `_buildKey`가 예외를 던지지 않음 — 코드상 `if (!e.key) return null;` 조기 반환으로 `toLowerCase()`에 도달하지 않음.
- [x] 로그인/로그아웃 시 `TypeError ... reading 'toLowerCase'` 미발생 — 위 가드로 예외 경로 제거.
- [x] 기존 단축키(Ctrl+K, Ctrl+S 등) 정상 동작 — falsy-key 경로만 추가, 정상 키의 조합 생성 로직은 그대로.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0/오류 0.

## 비고
변경 대상이 순수 JS 정적 자산이며, Web 프로젝트에는 JS 테스트 프레임워크가 없어 자동 회귀 테스트는 추가하지 못했다(기존 xUnit 테스트 145건은 전부 통과). 검증은 코드 인스펙션 및 빌드로 수행했다.