### PR TITLE
#193 홈 선택 삭제 액션바 추가

### DIFF
--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -65,6 +65,15 @@
     }
     else
     {
+        @if (selectedIds.Count > 0)
+        {
+            <div class="selection-actionbar">
+                <span class="selection-count">@selectedIds.Count selected</span>
+                <button class="selection-delete-btn" @onclick="DeleteSelectedAsync">
+                    Delete @selectedIds.Count
+                </button>
+            </div>
+        }
         <div class="note-table">
             <div class="note-row note-header">
                 <div class="col-check">
@@ -266,7 +275,7 @@
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
-            await ShortcutService.RegisterAsync("delete", "Delete selected notes", () => InvokeAsync(OnDeleteKeyPressed));
+            await ShortcutService.RegisterAsync("delete", "Delete selected notes", () => InvokeAsync(DeleteSelectedAsync));
     }
 
     private async Task LoadNotes(bool includeLabels = false)
@@ -421,7 +430,9 @@
         await LoadNotes();
     }
 
-    private async Task OnDeleteKeyPressed()
+    // Shared by the Delete-key shortcut and the selection action bar's Delete button
+    // so both paths produce the identical soft-delete + Undo result.
+    private async Task DeleteSelectedAsync()
     {
         if (selectedIds.Count == 0) return;
 

--- a/Vanadium.Note.Web/Pages/Home.razor.css
+++ b/Vanadium.Note.Web/Pages/Home.razor.css
@@ -252,6 +252,48 @@ button.col-title.sortable {
     color: var(--vn-note-header-color);
 }
 
+/* ── Selection action bar ───────────────────────────────────────────────────
+   Appears above the note table only while one or more rows are checked, giving
+   the row checkboxes a visible bulk-delete affordance (the Delete-key shortcut
+   alone was undiscoverable). */
+
+.selection-actionbar {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.6rem;
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--mud-palette-divider);
+    border-radius: 6px;
+    background-color: var(--mud-palette-surface);
+}
+
+.selection-count {
+    font-size: 0.8rem;
+    font-weight: 600;
+    opacity: 0.7;
+}
+
+.selection-delete-btn {
+    height: 28px;
+    padding: 0 0.75rem;
+    border: 1px solid var(--mud-palette-error);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--mud-palette-error);
+    cursor: pointer;
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1;
+    transition: background-color 0.12s, color 0.12s;
+}
+
+.selection-delete-btn:hover {
+    background-color: var(--mud-palette-error);
+    color: #fff;
+}
+
 /* ── Label filter bar ───────────────────────────────────────────────────── */
 
 .label-filter-bar {


### PR DESCRIPTION
Closes #193

## 목적
홈 노트 목록에서 행별 체크박스와 전체선택은 렌더되지만, 일괄 삭제 트리거가 물리 Delete 키뿐이라 발견하기 어려웠다. 체크된 항목이 있을 때 나타나는 '선택 삭제' 액션바를 추가해 명시적인 삭제 어포던스를 제공한다.

## 변경 내용
- `Home.razor`: 선택된 항목이 1개 이상일 때 노트 테이블 위에 나타나는 액션바 추가. 선택 개수(`N selected`)와 삭제 버튼(`Delete N`)을 노출한다. (UI 텍스트는 프로젝트 규칙에 따라 영어)
- 기존 `OnDeleteKeyPressed` 핸들러를 `DeleteSelectedAsync`로 이름을 바꿔 Delete 키 단축키와 액션바 버튼이 **동일한 메서드**(소프트 삭제 + Undo 스낵바)를 호출하도록 공유. 기존 Delete 키 단축키는 그대로 유지.
- `Home.razor.css`: 액션바 스코프 스타일 추가(MudBlazor 팔레트 변수 사용, `--mud-palette-error` 기반 삭제 버튼).

서버 API 변경 없음 — 기존 소프트 삭제(휴지통) 경로를 그대로 재사용한다.

## 완료 조건 검증
- **항목을 체크하면 액션바가 나타나고 선택 해제하면 사라진다**: 액션바는 `@if (selectedIds.Count > 0)`로 조건부 렌더 → 체크 시 표시, 전체 해제 시 자동으로 사라짐.
- **액션바 버튼으로 선택 항목 삭제(Delete 키와 동일 결과)**: 버튼 `@onclick`이 Delete 키가 등록하는 것과 동일한 `DeleteSelectedAsync`를 호출 → 확인 다이얼로그, 소프트 삭제, Undo 스낵바까지 동일 동작.
- **빌드 클린**: `dotnet build`(Web 프로젝트) 경고 0 / 오류 0. 기존 테스트 스위트 142 통과 / 0 실패(백엔드 무변경).

## 참고
로컬 `bin` 산출물이 실행 중인 REST 앱과 Visual Studio에 잠겨 있어, 검증 빌드는 별도 출력 디렉터리로 수행했다(경고 0/오류 0). 변경은 프론트엔드 2개 파일에 한정된다.
