### PR TITLE
#206 보드 컬럼별 카드 렌더 상한 및 더 보기 추가

### DIFF
--- a/Vanadium.Note.Web/Pages/Board.razor
+++ b/Vanadium.Note.Web/Pages/Board.razor
@@ -56,6 +56,9 @@
             {
                 var columnLabel = label;
                 var notesForLabel = GetNotesForLabel(columnLabel.Id);
+                var isExpanded = expandedColumns.Contains(columnLabel.Id);
+                var visibleNotes = isExpanded ? notesForLabel : notesForLabel.Take(CardsPerColumnLimit).ToList();
+                var hiddenCount = notesForLabel.Count - visibleNotes.Count;
 
                 <div class="board-column"
                      data-label-id="@columnLabel.Id">
@@ -64,7 +67,7 @@
                         <span class="board-column-count">@notesForLabel.Count</span>
                     </div>
                     <div class="board-column-cards">
-                        @foreach (var note in notesForLabel)
+                        @foreach (var note in visibleNotes)
                         {
                             var capturedNote = note;
                             <div class="board-card"
@@ -99,6 +102,14 @@
                             </div>
                         }
                     </div>
+                    @if (hiddenCount > 0)
+                    {
+                        <div class="board-column-showmore">
+                            <button class="board-showmore-btn" @onclick="() => ShowMore(columnLabel.Id)">
+                                Show @hiddenCount more
+                            </button>
+                        </div>
+                    }
                     <div class="board-column-footer">
                         <button class="board-add-btn" @onclick="() => OpenAddDialog(columnLabel)">
                             + Add a note
@@ -149,10 +160,17 @@
 }
 
 @code {
+    // Cap the cards initially rendered per column so a category with many notes
+    // does not grow the board's DOM/render cost without bound (#206). The rest
+    // stay reachable behind a per-column "Show more" toggle.
+    private const int CardsPerColumnLimit = 50;
+
     private IReadOnlyList<NoteSummary> notes = [];
     private List<LabelCategory> categories = [];
     private Guid? selectedCategoryId;
     private bool isLoading = false;
+    // Label ids whose column has been expanded past CardsPerColumnLimit.
+    private readonly HashSet<Guid> expandedColumns = [];
     private DotNetObjectReference<Board>? _dotNetRef;
 
     // ── Dialog state ──────────────────────────────────────────────────────────
@@ -185,6 +203,8 @@
 
     private async Task LoadNotesForCurrentCategory()
     {
+        // A fresh load collapses every column back to the cap.
+        expandedColumns.Clear();
         if (selectedCategory is null || !selectedCategory.Labels.Any())
         {
             notes = [];
@@ -289,6 +309,8 @@
         notes.Where(n => n.Labels.Any(l => l.Id == labelId))
              .OrderByDescending(n => n.UpdatedAt)
              .ToList();
+
+    private void ShowMore(Guid labelId) => expandedColumns.Add(labelId);
 
     private async Task SelectCategory(Guid catId)
     {

--- a/Vanadium.Note.Web/Pages/Board.razor.css
+++ b/Vanadium.Note.Web/Pages/Board.razor.css
@@ -139,6 +139,30 @@
     gap: 0.4rem;
 }
 
+.board-column-showmore {
+    padding: 0.35rem 0.5rem 0;
+    flex-shrink: 0;
+}
+
+.board-showmore-btn {
+    width: 100%;
+    background: none;
+    border: 1px solid var(--mud-palette-divider);
+    cursor: pointer;
+    font-size: 0.78rem;
+    color: inherit;
+    opacity: 0.6;
+    padding: 0.3rem 0.5rem;
+    border-radius: 4px;
+    text-align: center;
+    transition: opacity 0.15s, background-color 0.15s;
+}
+
+.board-showmore-btn:hover {
+    opacity: 1;
+    background-color: var(--vn-note-hover-bg);
+}
+
 .board-column-footer {
     padding: 0.35rem 0.5rem;
     border-top: 1px solid var(--mud-palette-divider);


### PR DESCRIPTION
## 목적

보드가 카테고리별 전체 요약을 페이지네이션 없이 로드·렌더해 노트가 쌓이면 컬럼 DOM이 무한정 커지는 문제(#206)를 프론트 상한으로 해결한다.

## 변경 내용

- `Board.razor`: 컬럼당 초기 렌더 카드 수를 `CardsPerColumnLimit`(50)로 제한. 초과분은 컬럼별 **Show N more** 버튼으로 펼쳐 볼 수 있다.
- 확장 상태는 `expandedColumns`(label id 집합)로 관리하며, 카테고리 전환·노트 재로드(`LoadNotesForCurrentCategory`) 시 초기화해 다시 상한으로 접힌다.
- `Board.razor.css`: 기존 `board-add-btn`/footer 스타일과 어울리는 `board-showmore-btn` 스타일 추가.

## 범위 결정

이슈의 `범위 밖 / 제약`("서버 검색/요약 API의 근본 페이징 재설계는 최소화, 프론트 상한 우선")에 따라 **서버 `GetAllSummaries`는 손대지 않았다.** 상한은 렌더 계층에만 적용되며, 이는 실제 클라이언트 비용의 지배 요인인 DOM/렌더 규모를 직접 제한한다.

## 완료 조건 검증

- [x] 카테고리당 렌더되는 카드 수가 상한으로 제한된다 — `notesForLabel.Take(CardsPerColumnLimit)`로 컬럼당 최대 50장만 렌더.
- [x] 노트가 많아도 보드 초기 로드가 선형으로 무한정 커지지 않는다 — 초기 렌더가 컬럼당 50장으로 고정, 나머지는 명시적 Show more로만 추가 렌더.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0.
- 테스트: `dotnet test Vanadium.slnx` 142개 통과(3개는 PostgreSQL 전용 skip). 본 변경은 Web 전용이며 Web 프로젝트에는 테스트 프로젝트가 없어(CLAUDE.md 명시) 추가 자동화 테스트 없음. 서버 요약 경로는 변경되지 않음.

Closes #206
