### PR TITLE
#208 공유 뷰 깨진 이미지/첨부 placeholder 처리

### DIFF
--- a/Vanadium.Note.Web/Pages/Share.razor
+++ b/Vanadium.Note.Web/Pages/Share.razor
@@ -77,5 +77,18 @@
             // Read-only page: a diagram render failure must not break the note.
             Console.Error.WriteLine($"Failed to render shared Mermaid diagrams: {ex.Message}");
         }
+
+        try
+        {
+            // Images/attachments reference authenticated endpoints an anonymous
+            // viewer cannot load, so replace broken images with a placeholder and
+            // mark attachment links as unavailable instead of leaving dead icons.
+            await JS.InvokeVoidAsync("tiptapInterop.applySharedPlaceholders", _contentRef);
+        }
+        catch (JSException ex)
+        {
+            // Cosmetic fallback only — never break the note over it.
+            Console.Error.WriteLine($"Failed to apply shared media placeholders: {ex.Message}");
+        }
     }
 }

--- a/Vanadium.Note.Web/Pages/Share.razor.css
+++ b/Vanadium.Note.Web/Pages/Share.razor.css
@@ -57,6 +57,36 @@
     overflow-x: auto;
 }
 
+/* Placeholder shown in place of an image that failed to load (authenticated
+   endpoint, unreachable for anonymous viewers). Injected by JS, so it lives in
+   the raw-markup subtree and needs ::deep to receive these scoped styles. */
+.shared-note-content ::deep .shared-media-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem 1.25rem;
+    margin: 0.5rem 0;
+    border: 1px dashed var(--vn-editor-title-border, #d0d0d0);
+    border-radius: 8px;
+    background: var(--vn-page-bg, #f5f6f8);
+    color: var(--vn-text-muted, #8a8a8a);
+    font-size: 0.85rem;
+    text-align: center;
+}
+
+.shared-note-content ::deep .shared-attachment-unavailable {
+    color: var(--vn-text-muted, #9a9a9a);
+    text-decoration: line-through;
+    cursor: default;
+    pointer-events: none;
+}
+
+.shared-note-content ::deep .shared-attachment-note {
+    text-decoration: none;
+    font-size: 0.78rem;
+    font-style: italic;
+}
+
 .shared-note-footer {
     margin-top: 2.5rem;
     padding-top: 1rem;

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -407,6 +407,46 @@ window.tiptapInterop = {
         }
     },
 
+    // Replace authenticated media that anonymous viewers cannot load with an
+    // inline placeholder (for the read-only Share page). Embedded images and
+    // file attachments reference authenticated endpoints (/api/images/*,
+    // /api/files/*) that return 401 without a JWT, so images render as the
+    // browser's broken-image icon and attachment links download nothing. Swap
+    // those for a friendly placeholder / notice. Pass a CSS selector string or
+    // a DOM element reference. Runs after the sanitized content is in the DOM,
+    // mirroring renderMermaidIn.
+    applySharedPlaceholders(root) {
+        const el = typeof root === 'string' ? document.querySelector(root) : root;
+        if (!el) return;
+
+        // Images: swap on load failure, and immediately for any that already
+        // finished loading and failed before this handler was attached.
+        for (const img of el.querySelectorAll('img')) {
+            const replace = () => {
+                if (!img.isConnected) return;
+                const placeholder = document.createElement('div');
+                placeholder.className = 'shared-media-placeholder';
+                placeholder.textContent = 'Image not available in shared view';
+                img.replaceWith(placeholder);
+            };
+            img.addEventListener('error', replace, { once: true });
+            if (img.complete && img.naturalWidth === 0) replace();
+        }
+
+        // Attachments cannot be downloaded anonymously — disable the link and
+        // append an explicit notice so the reader is not left clicking a dead link.
+        for (const link of el.querySelectorAll('a.file-attachment')) {
+            link.classList.add('shared-attachment-unavailable');
+            link.removeAttribute('href');
+            link.removeAttribute('download');
+            link.setAttribute('aria-disabled', 'true');
+            const note = document.createElement('span');
+            note.className = 'shared-attachment-note';
+            note.textContent = ' (not available in shared view)';
+            link.appendChild(note);
+        }
+    },
+
     destroy(elementId) {
         const entry = _editors[elementId];
         if (entry) {


### PR DESCRIPTION
Closes #208

## 목적

익명 공유 뷰(`/share/{token}`)의 이미지·첨부는 인증 엔드포인트(`/api/images/*`, `/api/files/*`)를 참조하므로 익명 뷰어에게 로드 실패한다. `onerror` fallback이 없어 브라우저 기본 '깨진 이미지' 아이콘이 그대로 노출되고 첨부 링크는 아무 반응 없는 dead link가 된다.

## 변경 내용

- **`wwwroot/js/tiptap/interop.js`** — `tiptapInterop.applySharedPlaceholders(root)` 추가 (기존 `renderMermaidIn`과 동일한 read-only DOM 후처리 패턴).
  - 이미지: `error` 이벤트 시(그리고 이미 로드 실패한 경우 즉시) placeholder `div`로 교체. 정상 로드되는 외부 이미지는 그대로 유지.
  - 첨부(`a.file-attachment`): `href`/`download` 제거, 비활성화 클래스 부여, "(not available in shared view)" 안내 span 추가.
- **`Pages/Share.razor`** — `OnAfterRenderAsync`에서 mermaid 렌더 직후 `applySharedPlaceholders` 호출. 실패해도 노트 렌더를 깨지 않도록 `JSException`을 흡수.
- **`Pages/Share.razor.css`** — placeholder/비활성 첨부 스타일 추가. placeholder는 JS로 raw-markup 서브트리에 주입되므로 기존 `::deep img` 규칙과 동일하게 `::deep` 사용.

## 완료 조건 검증

- [x] **익명 공유 뷰에서 렌더 실패한 이미지가 깨진 아이콘 대신 placeholder로 표시된다** — `img` `onerror` → `.shared-media-placeholder` 교체로 구현. Blazor Web 프로젝트에는 테스트 인프라가 없어(CLAUDE.md 명시) 자동화 테스트 대신 실제 공유 페이지 확인이 필요한 항목(수동 확인).
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` → 경고 0, 오류 0.

## 범위

인증 asset 프록시(근본 해결책)는 설계상 out of scope. placeholder 시각 처리만 추가했으며 백엔드/스키마 변경 없음.