### PR TITLE
#242 공유 뷰 tiptapInterop 로드 레이스 수정

### DIFF
--- a/Vanadium.Note.Web/Pages/Share.razor
+++ b/Vanadium.Note.Web/Pages/Share.razor
@@ -61,6 +61,14 @@
         _loading = false;
     }
 
+    // The Tiptap interop module (js/tiptap-editor.js) resolves its dependencies
+    // from a CDN and installs window.tiptapInterop only once they load. The
+    // anonymous share page never initializes an editor, so on a cold first
+    // render the module may not be ready yet. Wait (bounded) for it to appear
+    // before touching it rather than racing the load (issue #242).
+    private const int InteropReadyMaxAttempts = 100;
+    private const int InteropReadyDelayMs = 50;
+
     // Shared content is dumped as raw markup, so Tiptap's node views never run.
     // Render any Mermaid code blocks in place once the content is in the DOM,
     // mirroring the read-only render the editor performs via the same interop.
@@ -68,6 +76,16 @@
     {
         if (_note is null || _mermaidRendered) return;
         _mermaidRendered = true;
+
+        if (!await WaitForInteropReadyAsync())
+        {
+            // The interop module never became available. The note body is
+            // already rendered, so leave it as-is rather than breaking the
+            // read-only page.
+            Console.Error.WriteLine("Tiptap interop did not become ready for the shared view.");
+            return;
+        }
+
         try
         {
             await JS.InvokeVoidAsync("tiptapInterop.renderMermaidIn", _contentRef);
@@ -90,5 +108,26 @@
             // Cosmetic fallback only — never break the note over it.
             Console.Error.WriteLine($"Failed to apply shared media placeholders: {ex.Message}");
         }
+    }
+
+    // Poll the tiptapInterop.ready() gate until the module is installed (the
+    // gate itself only exists once the entry module has run) or the bounded
+    // attempts are exhausted. Returns true once the interop is available.
+    private async Task<bool> WaitForInteropReadyAsync()
+    {
+        for (var attempt = 0; attempt < InteropReadyMaxAttempts; attempt++)
+        {
+            try
+            {
+                return await JS.InvokeAsync<bool>("tiptapInterop.ready");
+            }
+            catch (JSException)
+            {
+                // tiptapInterop (or its ready gate) is not installed yet — the
+                // module is still loading. Wait briefly and retry.
+                await Task.Delay(InteropReadyDelayMs);
+            }
+        }
+        return false;
     }
 }

--- a/Vanadium.Note.Web/wwwroot/js/tiptap-editor.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap-editor.js
@@ -7,3 +7,14 @@
 // installs `window.tiptapInterop` and pulls in every node/extension/UI module
 // it depends on.
 import './tiptap/interop.js';
+
+// interop.js resolves its dependencies from a CDN, so the static import above
+// only completes once those async imports finish — at which point
+// window.tiptapInterop has been installed. Expose a `ready()` gate on the same
+// interop object so callers can await the module load instead of racing it.
+// This matters for pages that invoke the interop straight after their first
+// render and never initialize an editor themselves — notably the anonymous
+// /share view (issue #242), which otherwise sees `tiptapInterop` undefined on a
+// cold load. The gate resolves immediately because this entry module's body
+// runs only after interop.js (and its imports) have fully loaded.
+window.tiptapInterop.ready = () => Promise.resolve(true);


### PR DESCRIPTION
## 개요

Closes #242

익명 공유 뷰(`/share/{token}`)에서 이미지/첨부가 포함된 노트를 처음 열 때 `tiptapInterop was undefined` 예외가 발생하고 placeholder 치환이 적용되지 않던 **로드 레이스**를 수정합니다.

## 원인

`js/tiptap-editor.js`(엔트리) → `js/tiptap/interop.js`는 `esm.sh` CDN에서 의존성을 **비동기로** 로드하는 ES 모듈이라, `window.tiptapInterop` 설치가 완료되기 전에 `Share.razor`의 `OnAfterRenderAsync`가 먼저 실행될 수 있습니다. 공유 페이지는 에디터를 초기화하지 않으므로 모듈 로드를 기다리는 경로가 없어, 캐시가 비어 있는 최초 진입에서 `tiptapInterop`이 `undefined`가 됩니다. 새로고침 시 모듈이 캐시되어 간헐적으로 정상 동작하던 증상과 일치합니다.

## 변경 사항

- **`wwwroot/js/tiptap-editor.js`**: 모듈 로드가 끝난 시점에 `tiptapInterop.ready()` 게이트를 노출. 엔트리 모듈 본문은 정적 `import`가 모두 완료된 뒤 실행되므로, 이 게이트가 존재한다는 것은 곧 `window.tiptapInterop`이 설치되었다는 뜻입니다. (신규 interop 경로가 아닌 기존 `tiptapInterop.*` 네임스페이스 멤버)
- **`Pages/Share.razor`**: `renderMermaidIn` / `applySharedPlaceholders` 호출 전에 `tiptapInterop.ready()`를 제한된 횟수(최대 100회 × 50ms ≈ 5s)로 대기. 게이트가 준비되면 placeholder를 일관되게 적용하고, 끝내 준비되지 않으면 로그만 남기고 본문은 그대로 둡니다. `applySharedPlaceholders`는 멱등하지 않으므로 기존 `_mermaidRendered` 가드로 재진입을 막아 한 번만 호출됩니다.

## 완료 조건 검증

- [x] **캐시 비어 있는 최초 진입 시 `tiptapInterop was undefined` 예외 없음** — 준비 게이트를 대기한 뒤에만 interop을 호출하므로 undefined 상태에서 호출되지 않음.
- [x] **첫 로드와 새로고침 모두 placeholder 일관 표시** — 로드 레이스를 제거하여 타이밍에 의존하지 않음.
- [x] **레이스 시에도 본문 렌더 안 깨짐** — 대기 실패 시 로그 후 반환, `renderMermaidIn`/`applySharedPlaceholders`는 각각 `try/catch`로 보호(기존 read-only 안전장치 유지).
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0. `dotnet test` 142 통과.

## 범위 준수

- 익명 자산 프록시 미구현, 서버 측 공유 계약(`ShareController`/`SharedNote`/토큰) 무변경, interop은 `tiptapInterop.*`로만.

## 수동 확인 필요

- Web 프로젝트는 테스트가 없고 본 변경은 브라우저 로드 타이밍에 관한 프론트 전용 수정이라 단위 테스트로 재현 불가. 시크릿 창(캐시 빈 상태)에서 이미지/첨부 포함 공유 링크를 최초 진입 → placeholder 표시 및 콘솔 예외 부재를 눈으로 확인 필요.
