### PR TITLE
#245 프론트 개발 환경 ApiBaseUrl 지원 (appsettings.Development.json)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # ASP.NET Core environment-specific settings (may contain secrets)
 appsettings.Development.json
+# Frontend dev config holds only a non-secret ApiBaseUrl and is tracked intentionally
+!Vanadium.Note.Web/wwwroot/appsettings.Development.json
 
 # User-specific files
 *.rsuser

--- a/Vanadium.Note.Web/wwwroot/appsettings.Development.json
+++ b/Vanadium.Note.Web/wwwroot/appsettings.Development.json
@@ -1,0 +1,3 @@
+{
+  "ApiBaseUrl": "https://localhost:7711"
+}


### PR DESCRIPTION
## 개요

Closes #245

디버그(개발) 모드로 프론트(`Vanadium.Note.Web`)를 실행할 때 `ApiBaseUrl`이 프로덕션 플레이스홀더 문자열(`${API_BASE_URL}`)로 해석되던 문제를 해결한다. Blazor WASM은 환경이 `Development`일 때 `wwwroot/appsettings.Development.json`을 자동으로 로드하여 기본 `appsettings.json`을 덮어쓴다. `launchSettings.json`이 `ASPNETCORE_ENVIRONMENT=Development`를 설정하므로 이 파일이 디버그 실행 시 우선 적용된다.

## 변경 사항

- `Vanadium.Note.Web/wwwroot/appsettings.Development.json` 신규 추가 — 개발용 `ApiBaseUrl = https://localhost:7711`.
- `.gitignore` — `appsettings.Development.json` 전역 무시 규칙에 대해 이 프론트 파일만 예외(`!...`) 처리. 해당 파일은 시크릿 없이 로컬 API 주소만 담으므로 추적 대상으로 둔다. 백엔드 `appsettings.Development.json`(시크릿 포함)은 기존과 동일하게 무시된다.

## 완료 조건 검증

- **디버그 실행 시 개발용 값으로 해석**: `launchSettings.json`이 `ASPNETCORE_ENVIRONMENT=Development`를 지정 → Blazor가 `appsettings.Development.json`을 fetch. 정적 웹 자산 매니페스트(`staticwebassets.build.json`)에 신규 파일이 등록됨을 확인. `Program.cs`의 `builder.Configuration["ApiBaseUrl"]`가 `https://localhost:7711`로 해석됨.
- **프로덕션 경로 불변**: `appsettings.template.json` → `appsettings.json` `envsubst` 흐름과 `entrypoint.sh`는 손대지 않음. 프로덕션 환경(비-Development)에서는 `appsettings.Development.json`을 요청하지 않으므로 영향 없음.
- **빌드 클린**: `dotnet build Vanadium.slnx` — 기존 baseline(AngleSharp NU1902 4건) 외 신규 경고 0, 오류 0.
- **테스트**: `dotnet test Vanadium.slnx` — 145 통과 / 0 실패. (Web 프로젝트는 테스트 프로젝트가 없어 자동 회귀 테스트는 추가하지 않음.)

## 범위 밖 준수

프로덕션 `appsettings.json` 플레이스홀더 및 `entrypoint.sh`/`envsubst` 방식 미변경, 커밋된 개발 시크릿의 user-secrets 이전 없음, `Vanadium.Note.Shared` 신설 없음.
