### PR TITLE
#220 백링크/제목 전파/mention 스캔 인덱스화

### DIFF
--- a/Vanadium.Note.REST.Tests/BacklinkServiceTests.cs
+++ b/Vanadium.Note.REST.Tests/BacklinkServiceTests.cs
@@ -5,10 +5,11 @@ namespace Vanadium.Note.REST.Tests;
 
 /// <summary>
 /// Service-level tests for the backlink ("what links here") query (issue #141).
-/// The scan uses <c>Content.Contains</c> (SQL LIKE), which runs on the in-memory
-/// SQLite host — unlike the trigram <c>EF.Functions.ILike</c> search path — so the
-/// visibility rules (soft-delete exclusion, archive inclusion, self-exclusion) are
-/// verified directly here.
+/// The scan goes through the shared reference probe (<c>WhereReferencesNote</c>): an
+/// index-friendly <c>LIKE</c> on PostgreSQL (issue #220) and a case-sensitive
+/// <c>Content.Contains</c> fallback on the in-memory SQLite host, which is the branch
+/// exercised here — so the visibility rules (soft-delete exclusion, archive inclusion,
+/// self-exclusion) are verified directly.
 /// </summary>
 public class BacklinkServiceTests
 {

--- a/Vanadium.Note.REST.Tests/ReferenceScanTests.cs
+++ b/Vanadium.Note.REST.Tests/ReferenceScanTests.cs
@@ -1,0 +1,86 @@
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression tests for issue #220: backlinks, page-link title propagation and
+/// mention cleanup all share the reference probe (<c>NoteService.WhereReferencesNote</c>),
+/// which on PostgreSQL became an index-friendly <c>LIKE</c> over <c>Content</c> and on the
+/// SQLite test host falls back to a case-sensitive <c>Contains</c>. These cover the
+/// common ACTIVE (non-recycle-bin) referencing note — the soft-deleted variants live in
+/// <see cref="ReferenceCleanupRecycleBinTests"/> — so the refactor is proven not to have
+/// changed which notes the scan reaches.
+/// </summary>
+public class ReferenceScanTests
+{
+    /// <summary>Inserts a note with exact raw content, bypassing the service sanitizer so the
+    /// reference markup under test is preserved verbatim.</summary>
+    private static async Task<NoteItem> AddNoteAsync(TestHost h, string title, string content)
+    {
+        var note = new NoteItem { Title = title, Content = content, ContentText = content };
+        h.Db.Notes.Add(note);
+        await h.Db.SaveChangesAsync();
+        return note;
+    }
+
+    [Fact]
+    public async Task TitleChange_UpdatesPageLink_InActiveReferencingNote()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Old Title");
+
+        var pageLink =
+            $"<div data-type=\"pageLink\" data-note-id=\"{target.Id}\" " +
+            $"data-title=\"Old Title\">\U0001F4C4 Old Title</div>";
+        var referencing = await AddNoteAsync(h, "Has page link", pageLink);
+
+        var (updated, conflict, archived) = await h.Notes.Update(
+            target.Id,
+            new NoteItem { Title = "New Title", Content = target.Content, UpdatedAt = default },
+            forceSave: true);
+        Assert.NotNull(updated);
+        Assert.False(conflict);
+        Assert.False(archived);
+
+        var reloaded = await h.FindAsync(referencing.Id);
+        Assert.NotNull(reloaded);
+        Assert.Contains("New Title", reloaded!.Content);
+        Assert.DoesNotContain("Old Title", reloaded.Content);
+    }
+
+    [Fact]
+    public async Task PermanentDelete_StripsMentions_FromActiveReferencingNote()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Target");
+
+        var mention =
+            $"<p><a data-type=\"noteMention\" data-note-id=\"{target.Id}\" " +
+            $"data-title=\"Target\">@Target</a></p>";
+        var referencing = await AddNoteAsync(h, "Mentions target", mention);
+
+        Assert.True(await h.Notes.Delete(target.Id));
+        var (found, wasInBin) = await h.Notes.DeletePermanent(target.Id);
+        Assert.True(found);
+        Assert.True(wasInBin);
+
+        var reloaded = await h.FindAsync(referencing.Id);
+        Assert.NotNull(reloaded);
+        Assert.DoesNotContain($"data-note-id=\"{target.Id}\"", reloaded!.Content);
+        // The plain "@Target" text remains (the link wrapper is stripped, not the text).
+        Assert.Contains("@Target", reloaded.Content);
+    }
+
+    [Fact]
+    public async Task Probe_DoesNotMatch_NoteWithoutReference()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Target");
+        // A note that merely contains the raw GUID text but no data-note-id attribute
+        // must not be treated as a reference.
+        await AddNoteAsync(h, "Bare guid text", $"<p>see {target.Id} for details</p>");
+
+        Assert.Empty(await h.Notes.GetBacklinks(target.Id));
+    }
+}

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -391,14 +391,38 @@ public class NoteService(
         return (existing, false, false);
     }
 
+    /// <summary>
+    /// Filters <paramref name="notes"/> to those whose HTML <c>Content</c> references note
+    /// <paramref name="id"/> via a <c>data-note-id="{id}"</c> attribute — the shared scan behind
+    /// backlinks, page-link title propagation and mention cleanup.
+    /// <para>
+    /// On PostgreSQL the probe is a case-sensitive <c>LIKE '%…%'</c> substring match, which the
+    /// <c>gin_trgm_ops</c> index on <c>Content</c> (issue #219) accelerates instead of a full
+    /// corpus scan (issue #220) — the reference lives in an HTML attribute value that
+    /// <c>StripHtml</c> discards, so it never reaches <c>ContentText</c> and that column's trigram
+    /// index cannot serve the scan. The needle is a fixed attribute name plus a GUID and never
+    /// contains a LIKE wildcard, so the pattern needs no escaping. Other providers (the SQLite
+    /// test host, which does not translate <c>LIKE</c> to an indexed probe) fall back to the
+    /// original case-sensitive <c>Contains</c>, preserving identical match semantics.
+    /// </para>
+    /// </summary>
+    private IQueryable<NoteItem> WhereReferencesNote(IQueryable<NoteItem> notes, Guid id)
+    {
+        var needle = $"data-note-id=\"{id}\"";
+        if (db.Database.IsNpgsql())
+        {
+            var pattern = $"%{needle}%";
+            return notes.Where(n => EF.Functions.Like(n.Content, pattern));
+        }
+        return notes.Where(n => n.Content.Contains(needle));
+    }
+
     private async Task UpdatePageLinkReferences(Guid noteId, string newTitle, CancellationToken ct = default)
     {
-        var idStr = noteId.ToString();
         // IgnoreQueryFilters so recycle-bin (soft-deleted) notes referencing this
         // note also get their page-link title refreshed — otherwise a restored note
         // keeps a stale title.
-        var referencingNotes = await db.Notes.IgnoreQueryFilters()
-            .Where(n => n.Content.Contains($"data-note-id=\"{idStr}\""))
+        var referencingNotes = await WhereReferencesNote(db.Notes.IgnoreQueryFilters(), noteId)
             .ToListAsync(ct);
 
         if (referencingNotes.Count == 0) return;
@@ -572,9 +596,10 @@ public class NoteService(
 
     /// <summary>
     /// "What links here": returns notes whose HTML content references the given note via a
-    /// <c>data-note-id="{id}"</c> attribute (mentions and page links). Reuses the same
-    /// <c>Content.Contains</c> scan as title propagation (<see cref="UpdatePageLinkReferences"/>);
-    /// a normalized reference table is intentionally out of scope (issue #141).
+    /// <c>data-note-id="{id}"</c> attribute (mentions and page links). Reuses the same indexed
+    /// reference probe (<see cref="WhereReferencesNote"/>) as title propagation
+    /// (<see cref="UpdatePageLinkReferences"/>); a normalized reference table is intentionally out
+    /// of scope (issue #141).
     /// Soft-deleted notes are excluded by the default global query filter (no
     /// <c>IgnoreQueryFilters()</c>); archived notes are INCLUDED and flagged via
     /// <see cref="BacklinkResult.IsArchived"/>, mirroring full-text/Quick Navigation search so
@@ -583,10 +608,9 @@ public class NoteService(
     public async Task<List<BacklinkResult>> GetBacklinks(Guid id, int limit = 50, CancellationToken ct = default)
     {
         limit = Math.Clamp(limit, 1, 200);
-        var needle = $"data-note-id=\"{id}\"";
 
-        var rows = await db.Notes
-            .Where(n => n.Id != id && n.Content.Contains(needle))
+        var rows = await WhereReferencesNote(db.Notes, id)
+            .Where(n => n.Id != id)
             .OrderByDescending(n => n.UpdatedAt)
             .Take(limit)
             .Select(n => new { n.Id, n.Title, n.ContentText, n.ArchivedAt })
@@ -1009,12 +1033,10 @@ public class NoteService(
 
     private async Task StripMentionReferencesAsync(Guid noteId, CancellationToken ct = default)
     {
-        var idStr = noteId.ToString();
         // IgnoreQueryFilters so recycle-bin (soft-deleted) notes referencing this
         // note also get their dead mention links stripped — otherwise a restored
         // note keeps a dead mention pointing at a permanently-deleted note.
-        var referencingNotes = await db.Notes.IgnoreQueryFilters()
-            .Where(n => n.Content.Contains($"data-note-id=\"{idStr}\""))
+        var referencingNotes = await WhereReferencesNote(db.Notes.IgnoreQueryFilters(), noteId)
             .ToListAsync(ct);
 
         foreach (var n in referencingNotes)


### PR DESCRIPTION
Closes #220

## 배경
`GetBacklinks`, `UpdatePageLinkReferences`, `StripMentionReferencesAsync`가 `data-note-id="{id}"` 참조를 `Content.Contains(...)`로 스캔했다. Npgsql은 이를 `strpos()`로 번역해 코퍼스 크기에 비례하는 풀스캔이 되어, #219가 추가한 `Content` `gin_trgm_ops` GIN 인덱스를 활용하지 못했다.

## 변경
- 세 스캔을 공유 헬퍼 `NoteService.WhereReferencesNote(notes, id)`로 통합.
  - **PostgreSQL**: `EF.Functions.Like(n.Content, "%data-note-id=\"{id}\"%")` — #219의 `Content` 트라이그램 GIN 인덱스가 가속. 니들은 고정 속성명 + GUID라 LIKE 와일드카드가 없어 이스케이프 불필요.
  - **SQLite(테스트 호스트)**: 기존 대소문자 구분 `Contains`로 폴백 → 매칭 의미 동일.
- 대소문자 구분 `LIKE`를 사용해 원래 ordinal `Contains`와 동일한 정확도 유지(회귀 없음).
- 참조 테이블/신규 인덱스를 도입하지 않고 **기존 인덱스를 재사용**하므로 EF Core 마이그레이션 없음.

## 완료 조건 검증
- [x] 백링크/제목 전파/mention 정리가 전체 코퍼스 LIKE 풀스캔에 의존하지 않는다 — 세 경로 모두 인덱스 가능한 `LIKE` 프로브 사용.
- [x] 백링크 결과가 기존과 동일하게 정확하다(회귀 없음) — 대소문자 구분 `LIKE`로 의미 보존, `dotnet test` 148 통과(`BacklinkServiceTests`, `ReferenceCleanupRecycleBinTests`, 신규 `ReferenceScanTests` 포함).
- [x] (참조 테이블/인덱스 도입 시) 마이그레이션 추가 — 신규 테이블/인덱스 없음(#219 인덱스 재사용), 해당 없음.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 오류 0, 신규 경고 없음(기존 NU1902만).

## 범위 밖 준수
- `data-note-id` 등 PageLink/NoteMention HTML 직렬화 형식 미변경.
- 정규화 테이블 미도입 → 백필 전략 불필요.

## 참고
- PostgreSQL 전용 인덱스 경로(트라이그램 `LIKE`)는 SQLite 단위 테스트로 검증 불가 — CLAUDE.md/#219와 동일한 한계. 신규 테스트는 SQLite 폴백 경로에서 매칭 대상이 바뀌지 않았음을 보증한다.