### PR TITLE
#218 PAT 인증 경로 실패 스로틀 추가 + 로그 토큰 조각 제거

### DIFF
--- a/Vanadium.Note.REST.Tests/ApiTokenThrottleTests.cs
+++ b/Vanadium.Note.REST.Tests/ApiTokenThrottleTests.cs
@@ -1,0 +1,171 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Vanadium.Note.REST.Security;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression tests for the global PAT authentication backoff (issue #218): consecutive failed
+/// PAT authentications past a threshold must trigger an exponentially growing lockout that is
+/// shared across all sources (so IP distribution / XFF forgery cannot bypass it), resets on a
+/// successful authentication, and does not let attempts during a lockout extend it indefinitely.
+/// The lockout is what caps the per-request <c>ApiTokens</c> DB lookups under a flood.
+/// </summary>
+public class ApiTokenThrottleTests
+{
+    private const int Threshold = 10;
+    private const double BaseDelay = 30;
+    private const int MaxDelay = 900;
+
+    /// <summary>Minimal manual <see cref="TimeProvider"/> so tests control the clock without a new dependency.</summary>
+    private sealed class MutableTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+
+    private static (ApiTokenThrottle Throttle, MutableTimeProvider Clock) CreateThrottle()
+    {
+        var clock = new MutableTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = Options.Create(new ApiTokenThrottleOptions
+        {
+            FailureThreshold = Threshold,
+            BaseDelaySeconds = BaseDelay,
+            MaxDelaySeconds = MaxDelay,
+        });
+        var throttle = new ApiTokenThrottle(options, clock, NullLogger<ApiTokenThrottle>.Instance);
+        return (throttle, clock);
+    }
+
+    [Fact]
+    public void FailuresBelowThreshold_DoNotLock()
+    {
+        var (throttle, _) = CreateThrottle();
+
+        for (var i = 0; i < Threshold - 1; i++)
+            throttle.RegisterFailure();
+
+        Assert.False(throttle.IsLocked(out var retryAfter));
+        Assert.Equal(TimeSpan.Zero, retryAfter);
+    }
+
+    [Fact]
+    public void FailuresAtThreshold_LockForBaseDelay()
+    {
+        var (throttle, _) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+
+        Assert.True(throttle.IsLocked(out var retryAfter));
+        Assert.Equal(TimeSpan.FromSeconds(BaseDelay), retryAfter);
+    }
+
+    [Fact]
+    public void EachWindow_DoublesTheLockout_Exponentially()
+    {
+        var (throttle, clock) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out var first));
+        Assert.Equal(TimeSpan.FromSeconds(30), first);
+
+        clock.Advance(TimeSpan.FromSeconds(30));
+        throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out var second));
+        Assert.Equal(TimeSpan.FromSeconds(60), second);
+
+        clock.Advance(TimeSpan.FromSeconds(60));
+        throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out var third));
+        Assert.Equal(TimeSpan.FromSeconds(120), third);
+    }
+
+    [Fact]
+    public void Lockout_IsCappedAtMaxDelay()
+    {
+        var (throttle, clock) = CreateThrottle();
+
+        // Drive far past the threshold, waiting out each window so every failure counts.
+        for (var i = 0; i < Threshold + 20; i++)
+        {
+            throttle.RegisterFailure();
+            throttle.IsLocked(out var retryAfter);
+            clock.Advance(retryAfter);
+        }
+
+        throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out var capped));
+        Assert.Equal(TimeSpan.FromSeconds(MaxDelay), capped);
+    }
+
+    [Fact]
+    public void IsLocked_BecomesFalse_AfterWindowExpires()
+    {
+        var (throttle, clock) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out _));
+
+        clock.Advance(TimeSpan.FromSeconds(BaseDelay));
+        Assert.False(throttle.IsLocked(out _));
+    }
+
+    [Fact]
+    public void RegisterSuccess_ClearsFailuresAndLockout()
+    {
+        var (throttle, _) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out _));
+
+        throttle.RegisterSuccess();
+
+        Assert.False(throttle.IsLocked(out _));
+        // The counter reset too: a fresh run of sub-threshold failures must not re-lock.
+        for (var i = 0; i < Threshold - 1; i++)
+            throttle.RegisterFailure();
+        Assert.False(throttle.IsLocked(out _));
+    }
+
+    [Fact]
+    public void FailuresDuringActiveLockout_DoNotExtendIt()
+    {
+        var (throttle, clock) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+        Assert.True(throttle.IsLocked(out var initial));
+        Assert.Equal(TimeSpan.FromSeconds(BaseDelay), initial);
+
+        // Hammer the locked path. These must be ignored — the window must neither
+        // grow nor its remaining time reset (lock-extension DoS protection).
+        clock.Advance(TimeSpan.FromSeconds(10));
+        for (var i = 0; i < 50; i++)
+            throttle.RegisterFailure();
+
+        Assert.True(throttle.IsLocked(out var remaining));
+        Assert.Equal(TimeSpan.FromSeconds(BaseDelay - 10), remaining);
+
+        clock.Advance(TimeSpan.FromSeconds(BaseDelay - 10));
+        Assert.False(throttle.IsLocked(out _));
+    }
+
+    [Fact]
+    public void CounterIsSharedGlobally_RegardlessOfSource()
+    {
+        // The throttle holds no notion of client IP: every RegisterFailure feeds one counter,
+        // which is exactly why spreading attempts across IPs / forged XFF cannot bypass it.
+        var (throttle, _) = CreateThrottle();
+
+        for (var i = 0; i < Threshold; i++)
+            throttle.RegisterFailure();
+
+        Assert.True(throttle.IsLocked(out _));
+    }
+}

--- a/Vanadium.Note.REST/Auth/ApiTokenAuthHandler.cs
+++ b/Vanadium.Note.REST/Auth/ApiTokenAuthHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Vanadium.Note.REST.Controllers;
 using Vanadium.Note.REST.Data;
+using Vanadium.Note.REST.Security;
 using Vanadium.Note.REST.Services;
 
 namespace Vanadium.Note.REST.Auth;
@@ -19,7 +20,8 @@ public class ApiTokenAuthHandler(
     IOptionsMonitor<AuthenticationSchemeOptions> options,
     ILoggerFactory loggerFactory,
     UrlEncoder encoder,
-    NoteDbContext db)
+    NoteDbContext db,
+    IApiTokenThrottle throttle)
     : AuthenticationHandler<AuthenticationSchemeOptions>(options, loggerFactory, encoder)
 {
     public const string SchemeName = "vanadium-pat";
@@ -34,6 +36,14 @@ public class ApiTokenAuthHandler(
         if (!plaintext.StartsWith(ApiTokenService.TokenPrefix, StringComparison.Ordinal))
             return AuthenticateResult.NoResult();
 
+        // Reject before touching the DB while a lockout is active, so a flood of invalid
+        // tokens cannot keep issuing one ApiTokens query per request.
+        if (throttle.IsLocked(out _))
+        {
+            Logger.LogWarning("Rejected API token: authentication is throttled after repeated failures.");
+            return AuthenticateResult.Fail("Too many failed API token attempts.");
+        }
+
         var hash = ApiTokenService.HashToken(plaintext);
 
         var record = await db.ApiTokens
@@ -41,16 +51,21 @@ public class ApiTokenAuthHandler(
 
         if (record is null)
         {
-            Logger.LogWarning("Rejected unknown API token (suffix {Suffix})",
-                plaintext.Length >= 4 ? plaintext[^4..] : "????");
+            throttle.RegisterFailure();
+            Logger.LogWarning("Rejected unknown API token.");
             return AuthenticateResult.Fail("Invalid API token.");
         }
 
         if (record.ExpiresAt is { } expiry && expiry <= DateTime.UtcNow)
         {
+            throttle.RegisterFailure();
             Logger.LogWarning("Rejected expired API token {TokenId}", record.Id);
             return AuthenticateResult.Fail("API token has expired.");
         }
+
+        // A valid token clears any accumulated failures so a legitimate client is never
+        // caught behind a lockout that an attacker's invalid attempts triggered.
+        throttle.RegisterSuccess();
 
         // Record usage, but avoid a write on every single request.
         var now = DateTime.UtcNow;

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -178,6 +178,15 @@ builder.Services.Configure<LoginLockoutOptions>(
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<ILoginThrottle, LoginThrottle>();
 
+// Global (IP-independent) PAT authentication backoff. The PAT handler runs during
+// authentication and issues one ApiTokens lookup per request, and is not covered by the
+// per-IP "login" rate limiter, so a flood of invalid tokens could hammer the DB. The
+// singleton throttle shares one failure counter across all sources and, once locked,
+// short-circuits attempts before the DB lookup.
+builder.Services.Configure<ApiTokenThrottleOptions>(
+    builder.Configuration.GetSection(ApiTokenThrottleOptions.SectionName));
+builder.Services.AddSingleton<IApiTokenThrottle, ApiTokenThrottle>();
+
 builder.Services.AddHostedService<OrphanFileCleanupJob>();
 builder.Services.AddHostedService<RecycleBinPurgeJob>();
 builder.Services.AddEndpointsApiExplorer();

--- a/Vanadium.Note.REST/Security/ApiTokenThrottle.cs
+++ b/Vanadium.Note.REST/Security/ApiTokenThrottle.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.Options;
+
+namespace Vanadium.Note.REST.Security;
+
+/// <summary>
+/// In-memory, process-global implementation of <see cref="IApiTokenThrottle"/>. A single
+/// shared counter of consecutive failures drives an exponential backoff: the first
+/// <see cref="ApiTokenThrottleOptions.FailureThreshold"/> failures are free, after which each
+/// failure locks PAT authentication for <c>BaseDelaySeconds * 2^n</c> (capped at
+/// <c>MaxDelaySeconds</c>). A successful authentication resets everything.
+/// </summary>
+/// <remarks>
+/// Registered as a singleton so the counter is shared across all requests. State is held in
+/// memory only, so it resets on restart — acceptable for a single-owner app whose goal is to
+/// blunt token guessing and cap the resulting DB lookups, not to provide durable lock records.
+/// The lock is a cheap short critical section; the <c>ApiTokens</c> query happens outside it.
+/// This deliberately mirrors <see cref="LoginThrottle"/> (issue #218 / #198).
+/// </remarks>
+public sealed class ApiTokenThrottle : IApiTokenThrottle
+{
+    private readonly ApiTokenThrottleOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<ApiTokenThrottle> _logger;
+    private readonly object _gate = new();
+
+    private int _consecutiveFailures;
+    private DateTimeOffset _lockedUntil = DateTimeOffset.MinValue;
+
+    public ApiTokenThrottle(
+        IOptions<ApiTokenThrottleOptions> options,
+        TimeProvider timeProvider,
+        ILogger<ApiTokenThrottle> logger)
+    {
+        _options = options.Value;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public bool IsLocked(out TimeSpan retryAfter)
+    {
+        lock (_gate)
+        {
+            var now = _timeProvider.GetUtcNow();
+            if (now < _lockedUntil)
+            {
+                retryAfter = _lockedUntil - now;
+                return true;
+            }
+
+            retryAfter = TimeSpan.Zero;
+            return false;
+        }
+    }
+
+    public void RegisterFailure()
+    {
+        lock (_gate)
+        {
+            var now = _timeProvider.GetUtcNow();
+
+            // Ignore failures that arrive during an active lockout window. Counting them
+            // would let an attacker who keeps hammering a locked path extend the window
+            // forever, locking the legitimate owner out indefinitely (a self-inflicted DoS).
+            if (now < _lockedUntil)
+                return;
+
+            _consecutiveFailures++;
+            if (_consecutiveFailures < _options.FailureThreshold)
+                return;
+
+            var exponent = _consecutiveFailures - _options.FailureThreshold;
+            var seconds = Math.Min(
+                _options.BaseDelaySeconds * Math.Pow(2, exponent),
+                _options.MaxDelaySeconds);
+            _lockedUntil = now.AddSeconds(seconds);
+
+            _logger.LogWarning(
+                "Global PAT authentication lockout engaged after {Failures} consecutive failures; locked for {Seconds}s.",
+                _consecutiveFailures, seconds);
+        }
+    }
+
+    public void RegisterSuccess()
+    {
+        lock (_gate)
+        {
+            _consecutiveFailures = 0;
+            _lockedUntil = DateTimeOffset.MinValue;
+        }
+    }
+}

--- a/Vanadium.Note.REST/Security/ApiTokenThrottleOptions.cs
+++ b/Vanadium.Note.REST/Security/ApiTokenThrottleOptions.cs
@@ -1,0 +1,32 @@
+namespace Vanadium.Note.REST.Security;
+
+/// <summary>
+/// Configuration for <see cref="ApiTokenThrottle"/>, the global (IP-independent) PAT
+/// authentication failure backoff. Bound from the <c>Auth:PatThrottle</c> configuration section.
+/// </summary>
+/// <remarks>
+/// The PAT authentication path performs one <c>ApiTokens</c> lookup per request and, unlike
+/// <c>/api/auth/login</c>, is not covered by the per-IP fixed-window rate limiter (the limiter
+/// is applied per endpoint, whereas the handler runs during authentication across all endpoints).
+/// This throttle caps the total rate of failing attempts so a flood of invalid tokens — from
+/// distributed sources or forged <c>X-Forwarded-For</c> headers — cannot keep hammering the DB.
+/// </remarks>
+public sealed class ApiTokenThrottleOptions
+{
+    public const string SectionName = "Auth:PatThrottle";
+
+    /// <summary>
+    /// Number of consecutive global failures tolerated before any lockout applies.
+    /// Keeps an occasional misconfigured client from immediately locking out valid tokens.
+    /// </summary>
+    public int FailureThreshold { get; set; } = 10;
+
+    /// <summary>
+    /// Lockout duration applied at the threshold. Each additional failure beyond the
+    /// threshold doubles this (exponential backoff), capped at <see cref="MaxDelaySeconds"/>.
+    /// </summary>
+    public double BaseDelaySeconds { get; set; } = 30;
+
+    /// <summary>Upper bound on a single lockout window, so the backoff never grows without limit.</summary>
+    public int MaxDelaySeconds { get; set; } = 900;
+}

--- a/Vanadium.Note.REST/Security/IApiTokenThrottle.cs
+++ b/Vanadium.Note.REST/Security/IApiTokenThrottle.cs
@@ -1,0 +1,25 @@
+namespace Vanadium.Note.REST.Security;
+
+/// <summary>
+/// A process-global, IP-independent throttle on personal access token (PAT) authentication
+/// attempts. Tracks consecutive failed PAT authentications across every source and, past a
+/// threshold, imposes an exponentially growing lockout window during which further attempts
+/// are rejected before any database lookup. This blunts a flood of guessed/invalid tokens
+/// that would otherwise cause one <c>ApiTokens</c> query per request. Because the counter is
+/// global (not partitioned by client IP), it cannot be bypassed by spreading attempts across
+/// many IPs or forging <c>X-Forwarded-For</c> headers — mirroring <see cref="ILoginThrottle"/>.
+/// </summary>
+public interface IApiTokenThrottle
+{
+    /// <summary>
+    /// Returns <c>true</c> if PAT authentication is currently locked out. When locked,
+    /// <paramref name="retryAfter"/> is the remaining time until attempts are accepted again.
+    /// </summary>
+    bool IsLocked(out TimeSpan retryAfter);
+
+    /// <summary>Records a failed PAT authentication, extending the lockout once the threshold is crossed.</summary>
+    void RegisterFailure();
+
+    /// <summary>Records a successful PAT authentication, clearing the failure count and any active lockout.</summary>
+    void RegisterSuccess();
+}


### PR DESCRIPTION
## 개요

Closes #218

PAT(personal access token) 인증 경로를 강화한다. 기존에는 인증 경로에 스로틀이 없어 잘못된 토큰이 요청마다 `ApiTokens` DB 조회를 유발할 수 있었고, 인증 실패 로그에 토큰 끝 4자(suffix)가 남았다.

## 변경 사항

- **PAT 실패 스로틀 추가** — 기존 로그인 백오프(`LoginThrottle`)와 동일한 패턴의 전역(IP 비의존) 스로틀 `ApiTokenThrottle`을 도입. 연속 실패가 임계치를 넘으면 지수 백오프로 잠기고, 잠금 중에는 해시 계산·DB 조회 이전에 즉시 거절해 DB 플러드를 차단한다.
  - `Security/IApiTokenThrottle.cs`, `Security/ApiTokenThrottle.cs`, `Security/ApiTokenThrottleOptions.cs` (`Auth:PatThrottle` 섹션, 기본값 임계치 10 / 30s / 900s cap)
  - `Program.cs`에 싱글턴 등록(`TimeProvider.System`은 로그인 스로틀용으로 이미 등록됨)
- **핸들러 통합** — `ApiTokenAuthHandler`가 DB 조회 전 `IsLocked` 확인, 알 수 없는/만료 토큰은 `RegisterFailure`, 유효 토큰은 `RegisterSuccess`로 카운터 리셋.
- **로그에서 토큰 조각 제거** — 실패 로그를 `"Rejected unknown API token (suffix ...)"` → `"Rejected unknown API token."`로 변경.
- **회귀 테스트** — `ApiTokenThrottleTests` 8개(임계치/지수 백오프/상한/성공 리셋/잠금 연장 방지/전역 카운터).

## 완료 조건 검증

- [x] **PAT 인증 경로에 rate-limit(실패 스로틀) 적용** — `ApiTokenThrottle`이 DB 조회 전 게이트. `ApiTokenThrottleTests` 통과로 검증.
- [x] **인증 실패 로그에 토큰 조각 미노출** — suffix 로깅 코드 제거(diff 확인).
- [x] **정상 PAT 인증 흐름 유지** — 성공 경로는 `RegisterSuccess()` 리셋만 추가, 전체 테스트 156개 통과.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 오류 0, 신규 경고 없음(기존 NU1902 4건만).

## 범위 밖 준수

PAT 발급/해시 저장 스킴(`ApiTokenService`)은 변경하지 않음.
