### PR TITLE
#215 JWT 기본 수명 단축(1440→480분) 및 토큰 저장 방식 결정 문서화

### DIFF
--- a/Vanadium.Note.REST/Controllers/AuthController.cs
+++ b/Vanadium.Note.REST/Controllers/AuthController.cs
@@ -101,7 +101,10 @@ public class AuthController(
     {
         var secret = config["Auth:JwtSecret"]
             ?? throw new InvalidOperationException("Auth:JwtSecret is not configured.");
-        var expirationMinutes = config.GetValue<int>("Auth:JwtExpirationMinutes", 1440);
+        // Default kept intentionally short (8h). The JWT lives in browser localStorage and
+        // cannot be revoked server-side (no refresh tokens by design), so the token lifetime
+        // is the whole XSS-theft exposure window — see docs/plannings/jwt-lifetime-and-storage.md.
+        var expirationMinutes = config.GetValue<int>("Auth:JwtExpirationMinutes", 480);
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);

--- a/Vanadium.Note.REST/appsettings.json
+++ b/Vanadium.Note.REST/appsettings.json
@@ -4,7 +4,7 @@
   },
   "Auth": {
     "JwtSecret": "",
-    "JwtExpirationMinutes": 1440,
+    "JwtExpirationMinutes": 480,
     "PasswordHash": "",
     "PasswordPolicy": {
       "MinLength": 15,

--- a/docs/plannings/jwt-lifetime-and-storage.md
+++ b/docs/plannings/jwt-lifetime-and-storage.md
@@ -1,0 +1,82 @@
+# Decision Record: JWT Lifetime & Token Storage
+
+Status: Decided
+Author: smoh (written with Claude)
+Date: 2026-07-20
+Issue: #215 — localStorage JWT 수명 단축 / httpOnly 쿠키 검토
+Related: #199 (Content-Security-Policy)
+
+## 1. Context
+
+Vanadium is a single-user, password-only app. A successful login mints a JWT
+(`AuthController.GenerateJwtToken`) that the Blazor WASM frontend stores in
+browser `localStorage` (`TokenStore`) and parses client-side
+(`JwtAuthenticationStateProvider`) to expose auth state.
+
+Two properties of this design compound each other:
+
+- **No server-side revocation.** There are no refresh tokens and no server session
+  store (a deliberate constraint, see CLAUDE.md "No refresh tokens"). Once a JWT is
+  issued it is valid until it expires; nothing can invalidate it early.
+- **Readable by JavaScript.** A token in `localStorage` is reachable by any script
+  running on the origin, so a single XSS foothold can exfiltrate it.
+
+Together these mean **the JWT lifetime is the entire theft-exposure window**: if a
+token leaks, an attacker has full owner access until it expires, with no way to cut
+it off. The prior default was **1440 minutes (24h)**.
+
+## 2. Decision
+
+### 2.1 Shorten the JWT lifetime (adopted)
+
+The default `Auth:JwtExpirationMinutes` is reduced **1440 → 480 (8 hours)**, in
+`appsettings.json`, `appsettings.Development.json`, and the code fallback in
+`AuthController.GenerateJwtToken`.
+
+Rationale: 8 hours covers a normal working session without forcing constant
+re-login, while cutting the un-revocable exposure window to a third of the previous
+value. Because there are no refresh tokens, the lifetime cannot be pushed much
+lower without a materially worse UX (the user must fully re-login at each expiry).
+The value stays configuration-driven, so a deployment with stricter requirements
+can lower it further without a code change.
+
+### 2.2 httpOnly cookie storage (considered, deferred)
+
+Moving the token to an `HttpOnly` cookie would put it out of reach of page
+JavaScript and largely neutralise the `localStorage` XSS-exfiltration path. It is
+**not adopted now** for the following reasons:
+
+- **The frontend depends on reading the token.** `JwtAuthenticationStateProvider`
+  parses the JWT in the browser to derive auth state, and `AuthTokenHandler`
+  attaches it as a bearer header per request. An `HttpOnly` cookie is by definition
+  unreadable by that code, so this is not a config toggle — it requires reworking
+  how the WASM client learns it is authenticated and how the API authenticates
+  requests (cookie auth scheme server-side).
+- **Cookies reintroduce CSRF surface.** Bearer headers are immune to CSRF; an
+  ambient cookie is not, so adopting it pulls in anti-forgery handling that the
+  current stateless bearer model does not need.
+- **Revocation is the deeper gap.** An `HttpOnly` cookie hides the token from
+  script but still cannot be revoked server-side under the no-refresh-token
+  constraint, so it does not by itself close the "can't invalidate a leaked token"
+  hole — that would need the refresh-token / session work that is explicitly out of
+  scope here (CLAUDE.md, and issue #215 범위 밖).
+
+The decision is therefore recorded here rather than implemented. Revisiting it is
+best coupled with a future refresh-token / session discussion, since the two share
+the same server-side surface.
+
+### 2.3 CSP to shrink the XSS surface (adopted elsewhere: #199)
+
+The most effective mitigation for the `localStorage` token is to prevent the XSS in
+the first place. A Content-Security-Policy that constrains script sources is tracked
+separately in **#199** and is the primary follow-up; it is out of scope for this
+change, which is limited to the token-lifetime knob and this record.
+
+## 3. Outcome vs. acceptance criteria (#215)
+
+- **JWT lifetime adjusted to a reasonable level vs. risk** — 24h → 8h default,
+  still configuration-overridable.
+- **httpOnly cookie method or its decision rationale documented** — deferral and
+  rationale recorded in §2.2 above.
+- **Build clean** — no code-shape change beyond the default constant and a comment;
+  `dotnet build Vanadium.slnx` stays clean.


### PR DESCRIPTION
Closes #215

## 목적

localStorage에 저장되는 JWT는 서버측 폐기가 불가능하고(리프레시 토큰 없음), 페이지 JS가 읽을 수 있어 XSS 한 건으로도 탈취될 수 있다. 탈취 시 무효화 수단이 없으므로 **토큰 수명 자체가 탈취 노출 창구**다.

## 변경 사항

- **JWT 기본 수명 1440분(24h) → 480분(8h)** 로 단축
  - `appsettings.json` 및 `AuthController.GenerateJwtToken` 폴백 상수
  - 설정(`Auth:JwtExpirationMinutes`) 기반이라 배포별로 추가 하향 가능. 리프레시 토큰이 없어 재로그인 UX를 고려하면 8h가 세션 길이 대비 합리적 하한.
- **토큰 저장 방식 결정 기록** 신규 문서 `docs/plannings/jwt-lifetime-and-storage.md`
  - httpOnly 쿠키를 검토했으나 (1) 프론트(`JwtAuthenticationStateProvider`)가 토큰을 직접 파싱하는 구조라 단순 토글이 아니고, (2) 쿠키는 CSRF 표면을 다시 들이며, (3) 무revocation 한계는 그대로여서 보류. 근거를 문서화.
  - CSP(#199)는 XSS 표면 축소의 본 대응으로 별도 이슈에서 진행.

## 완료 조건 검증

- [x] JWT 수명이 위험 대비 합리적 수준으로 조정 — 24h→8h, 설정 override 유지
- [x] httpOnly 쿠키 방식 또는 결정 근거 문서화 — `docs/plannings/jwt-lifetime-and-storage.md` §2.2
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 baseline 유지(NU1902 4건), 오류 0; `dotnet test` 156 통과/3 skip/0 실패

## 범위 밖 (건드리지 않음)

- 리프레시 토큰 미도입 (CLAUDE.md 제약)
- JWT issuer/audience 검증 미추가 (단일 테넌트)