### PR TITLE
#212 슬래시 커맨드 힌트 + 업로드 전 클라 크기/타입 가드

### DIFF
--- a/Vanadium.Note.Web/wwwroot/css/app.css
+++ b/Vanadium.Note.Web/wwwroot/css/app.css
@@ -463,6 +463,17 @@ body.dark-mode .hljs-deletion                       { color: #ffa198; }
 .upload-toast-error .upload-toast-bar { background: #dc3545; }
 .upload-toast-error .upload-toast-pct::after { content: ' Failed'; color: #dc3545; }
 
+/* Rejection notice — full wrapped message, no progress bar, red accent. */
+.upload-toast-notice {
+    border-left: 3px solid #dc3545;
+}
+
+.upload-toast-notice-msg {
+    flex: 1;
+    white-space: normal;
+    word-break: break-word;
+}
+
 /* File attachment link */
 a.file-attachment {
     display: inline-flex;

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -30,7 +30,7 @@ import { AccordionGroup } from './nodes/accordion.js'
 import { createBubbleMenu } from './ui/bubble-menu.js'
 import { createLinkPopover, showLinkPopover } from './ui/link-popover.js'
 import { showCalloutEmojiPicker, hideCalloutPicker } from './ui/callout-picker.js'
-import { uploadWithProgress, createProgressToast } from './upload.js'
+import { uploadWithProgress, createProgressToast, validateUpload, showUploadNotice } from './upload.js'
 import { resolveAuthenticatedImages } from './images.js'
 
 // ── Public API ───────────────────────────────────────────────────────────────
@@ -74,7 +74,7 @@ window.tiptapInterop = {
                     includeChildren: true,
                     showOnlyCurrent: false,
                     placeholder: ({ node }) =>
-                        node.type.name === 'toggleSummary' ? 'Toggle summary' : 'Write something...',
+                        node.type.name === 'toggleSummary' ? 'Toggle summary' : "Write something, or type '/' for commands",
                 }),
                 Link.configure({
                     autolink: true,
@@ -138,6 +138,15 @@ window.tiptapInterop = {
                     e.preventDefault();
                     const file = item.getAsFile();
                     if (!file) return;
+
+                    // Guard before uploading — reject unsupported/oversized images
+                    // client-side so the paste fails fast (server stays authoritative).
+                    const notice = validateUpload(file, 'image');
+                    if (notice) {
+                        showUploadNotice(notice);
+                        console.warn('[tiptap] Paste image rejected by client guard', { file: file.name, type: file.type, size: file.size });
+                        break;
+                    }
 
                     const formData = new FormData();
                     formData.append('file', file);
@@ -235,12 +244,23 @@ window.tiptapInterop = {
             const headers = authToken ? { 'Authorization': `Bearer ${authToken}` } : {};
 
             for (const file of files) {
+                // Images route to /api/images (10 MB, image types), everything
+                // else to /api/files (100 MB, whitelist). Guard against each
+                // endpoint's real limits before uploading; server stays authoritative.
+                const isImage = file.type.startsWith('image/');
+                const notice = validateUpload(file, isImage ? 'image' : 'file');
+                if (notice) {
+                    showUploadNotice(notice);
+                    console.warn('[tiptap] Dropped file rejected by client guard', { file: file.name, type: file.type, size: file.size });
+                    continue;
+                }
+
                 const formData = new FormData();
                 formData.append('file', file);
                 const toast = createProgressToast(file.name);
 
                 try {
-                    if (file.type.startsWith('image/')) {
+                    if (isImage) {
                         // Image files are inserted as inline images
                         const { url } = await uploadWithProgress(
                             `${apiBaseUrl}/api/images`, formData, headers,

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/upload.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/upload.js
@@ -1,5 +1,72 @@
 // ── Upload helpers ───────────────────────────────────────────────────────────
 
+// ── Client-side pre-upload guard ─────────────────────────────────────────────
+// Rejects oversized / unsupported files before any bytes leave the browser, so
+// the user gets instant feedback instead of streaming (up to) 100 MB only to be
+// refused by the server. This is an ADDITIONAL defense line: the server checks
+// (magic-byte sniffing, size limits) remain authoritative and are never relaxed.
+//
+// Keep these in sync with the server:
+//   - ImagesController: 10 MB cap, JPEG/PNG/GIF/WebP
+//   - FilesController:  100 MB cap, AllowedContentTypes whitelist
+export const IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+export const FILE_MAX_BYTES = 100 * 1024 * 1024;
+
+export const IMAGE_CONTENT_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+export const FILE_CONTENT_TYPES = [
+    'application/pdf',
+    'application/zip',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'text/plain',
+    'text/markdown',
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+];
+
+function formatMb(bytes) {
+    return `${Math.round(bytes / (1024 * 1024))} MB`;
+}
+
+// Validate a file for the given upload kind ('image' → /api/images,
+// 'file' → /api/files). Returns null when acceptable, otherwise a user-facing
+// rejection message. Matching on file.type mirrors the server's Content-Type
+// whitelist check (the browser sends the same type it reports here).
+export function validateUpload(file, kind) {
+    const isImage = kind === 'image';
+    const maxBytes = isImage ? IMAGE_MAX_BYTES : FILE_MAX_BYTES;
+    const allowed = isImage ? IMAGE_CONTENT_TYPES : FILE_CONTENT_TYPES;
+
+    if (!allowed.includes(file.type)) {
+        return `"${file.name}" was not uploaded: unsupported ${isImage ? 'image' : 'file'} type.`;
+    }
+    if (file.size > maxBytes) {
+        return `"${file.name}" was not uploaded: exceeds the ${formatMb(maxBytes)} limit.`;
+    }
+    return null;
+}
+
+// Transient bottom-right notice for a rejected upload. Reuses the upload-toast
+// look (error variant) but carries a full wrapped message instead of a progress
+// bar; auto-dismisses after a few seconds.
+export function showUploadNotice(message) {
+    const toast = document.createElement('div');
+    toast.className = 'upload-toast upload-toast-notice';
+
+    const msgEl = document.createElement('span');
+    msgEl.className = 'upload-toast-notice-msg';
+    msgEl.textContent = message;
+
+    toast.appendChild(msgEl);
+    document.body.appendChild(toast);
+    setTimeout(() => toast.remove(), 4000);
+}
+
 export function uploadWithProgress(url, formData, headers, onProgress) {
     return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();


### PR DESCRIPTION
Closes #212

## 변경 요약

슬래시 커맨드 발견성을 높이고, 업로드 전 클라이언트에서 크기/타입을 사전 검증하는 방어선을 추가한다. 서버 검증은 그대로 유지(완화 없음)하며 클라 가드는 빠른 피드백을 위한 추가 방어선이다.

### 1. 슬래시 커맨드 힌트
- 빈 에디터 placeholder를 `Write something, or type '/' for commands`로 변경 (`interop.js`).
- 기존 `p.is-editor-empty:first-child::before` 규칙이 그대로 렌더링하므로 빈 에디터에서 힌트가 보인다.
- 선택 항목인 삽입 '+' 어포던스는 범위/최소 변경 원칙상 제외.

### 2. 업로드 전 클라 크기/타입 가드
- `upload.js`에 `validateUpload(file, kind)` 추가 — 서버 상한/화이트리스트와 일치:
  - 이미지(`/api/images`): **10MB** + `image/jpeg,png,gif,webp` (`ImagesController`와 일치)
  - 파일(`/api/files`): **100MB** + `AllowedContentTypes` 12종 화이트리스트 (`FilesController`와 일치)
- 붙여넣기/드래그드롭 업로드 경로에서 **업로드 시작 전** 검증하고, 실패 시 `showUploadNotice`로 하단 토스트 안내 후 해당 파일을 건너뛴다.
- 드롭은 이미지/일반 파일을 엔드포인트별 상한에 맞춰 각각 검증.

## 완료 조건 검증
- [x] 빈 에디터에 슬래시 커맨드 힌트가 보인다 — placeholder 텍스트 변경, 기존 CSS가 렌더.
- [x] 상한 초과/미허용 타입 파일은 업로드 시작 전에 거부되고 안내된다 — `validateUpload`가 `FormData` 생성/전송 이전에 실행, `showUploadNotice`로 안내.
- [x] 클라 검증 기준이 서버 화이트리스트/상한과 일치 — 이미지 10MB/이미지4종, 파일 100MB/화이트리스트12종을 각 컨트롤러에서 그대로 반영.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 오류 0, 신규 경고 없음(기존 AngleSharp NU1902 4건만).

## 참고
- 프론트엔드(JS/CSS) 전용 변경. Web 프로젝트는 테스트 프로젝트가 없어 자동 테스트는 추가하지 않음(CLAUDE.md). 백엔드 테스트 156건 통과.
- 범위 밖 준수: interop 호출은 interop 모듈 내부에서만, 서버 검증 미완화.