### PR TITLE
#210 아카이브 삭제에 Undo 추가

### DIFF
--- a/Vanadium.Note.Web/Pages/Archive.razor
+++ b/Vanadium.Note.Web/Pages/Archive.razor
@@ -134,7 +134,21 @@
             return;
         }
         Logger.LogInformation("Archived note moved to recycle bin from archive page.");
-        Snackbar.Add("Note moved to the Recycle Bin.", Severity.Normal);
+
+        // The note keeps its ArchivedAt while soft-deleted, so RestoreAsync returns it
+        // to the Archive (not the active list) — same Undo UX as Home.
+        var noteId = item.Id;
+        Snackbar.Add("Note moved to the Recycle Bin.", Severity.Normal, config =>
+        {
+            config.Action = "Undo";
+            config.ActionColor = Color.Primary;
+            config.OnClick = async _ =>
+            {
+                await NoteService.RestoreAsync(noteId);
+                await LoadPage(currentPage);
+                StateHasChanged();
+            };
+        });
         await ReloadAfterRemoval();
     }
 }


### PR DESCRIPTION
Closes #210

## 변경 사항

아카이브 페이지에서 노트를 삭제(→ 휴지통)할 때 스낵바에 **Undo** 액션을 추가했다. 홈/에디터의 삭제 Undo 패턴과 동일한 UX를 제공한다.

- `Archive.razor`의 `DeleteNote`에서 삭제 성공 후 스낵바에 `Undo` 액션(`Color.Primary`)을 노출
- Undo 클릭 시 기존 `NoteService.RestoreAsync`를 재사용해 복원 후 현재 페이지를 리로드

## 동작 원리

소프트 삭제된 노트는 `ArchivedAt`을 유지하므로, 기존 소프트 삭제·복원 endpoint를 그대로 재사용하면 복원 시 **아카이브 상태로 복귀**한다(범위 밖 제약 준수). 별도 서버/스키마 변경 없음.

## 완료 조건 검증

- [x] 아카이브 삭제 후 Undo로 노트를 아카이브 상태로 되돌릴 수 있다(홈과 동일 UX) — 홈의 `DeleteSelectedAsync`/`ArchiveNote`와 동일한 스낵바 + `RestoreAsync` 패턴 적용
- [x] 빌드 클린 (`dotnet build Vanadium.slnx`) — 경고 4개(AngleSharp NU1902 baseline)/오류 0개, 신규 경고 없음