### PR TITLE
#209 아카이브/휴지통 다중 선택 벌크 액션

### DIFF
--- a/Vanadium.Note.Web/Pages/Archive.razor
+++ b/Vanadium.Note.Web/Pages/Archive.razor
@@ -27,8 +27,22 @@
     }
     else
     {
+        @if (selected.Count > 0)
+        {
+            <div class="bulk-bar">
+                <span class="bulk-count">@selected.Count selected</span>
+                <button class="row-btn" @onclick="BulkUnarchive">Unarchive selected</button>
+                <button class="row-btn row-btn-danger" @onclick="BulkDelete">Delete selected</button>
+                <button class="row-btn" @onclick="ClearSelection">Clear</button>
+            </div>
+        }
+
         <div class="note-table">
             <div class="note-row note-header">
+                <div class="col-select">
+                    <input type="checkbox" aria-label="Select all notes on this page"
+                           checked="@AllSelected" @onchange="ToggleSelectAll" />
+                </div>
                 <div class="col-title">Title</div>
                 <div class="col-date">Archived</div>
                 <div class="col-actions"></div>
@@ -36,6 +50,11 @@
             @foreach (var item in items)
             {
                 <div class="note-row note-item">
+                    <div class="col-select">
+                        <input type="checkbox" aria-label="Select note"
+                               checked="@selected.Contains(item.Id)"
+                               @onchange="e => ToggleSelect(item.Id, e)" />
+                    </div>
                     <div class="col-title">
                         <div class="note-title-row">
                             <div class="note-title-text note-title-link" @onclick="() => OpenNote(item.Id)">
@@ -69,11 +88,14 @@
     private const int PageSize = 30;
 
     private List<ArchivedNoteSummary> items = [];
+    private readonly HashSet<Guid> selected = [];
     private int totalCount;
     private int currentPage = 1;
     private bool isLoading = true;
 
     private int TotalPages => Math.Max(1, (int)Math.Ceiling((double)totalCount / PageSize));
+
+    private bool AllSelected => items.Count > 0 && items.All(i => selected.Contains(i.Id));
 
     protected override async Task OnInitializedAsync() => await LoadPage(1);
 
@@ -81,6 +103,8 @@
     {
         currentPage = page;
         isLoading = true;
+        // Selection is per-visible-page; a page change or reload starts fresh.
+        selected.Clear();
 
         var result = await NoteService.GetArchiveAsync(page, PageSize);
         if (result.IsSuccess)
@@ -102,6 +126,75 @@
         if (items.Count <= 1 && page > 1)
             page--;
         await LoadPage(page);
+    }
+
+    // If every item on the current page was removed, step back a page.
+    private async Task ReloadAfterBulk(int removedCount)
+    {
+        var page = currentPage;
+        if (removedCount >= items.Count && page > 1)
+            page--;
+        await LoadPage(page);
+    }
+
+    private void ToggleSelect(Guid id, ChangeEventArgs e)
+    {
+        if (e.Value is true)
+            selected.Add(id);
+        else
+            selected.Remove(id);
+    }
+
+    private void ToggleSelectAll(ChangeEventArgs e)
+    {
+        selected.Clear();
+        if (e.Value is true)
+            foreach (var item in items)
+                selected.Add(item.Id);
+    }
+
+    private void ClearSelection() => selected.Clear();
+
+    private void ReportBulk(int ok, int total, string verb)
+    {
+        if (ok == total)
+            Snackbar.Add($"{ok} note(s) {verb}.", Severity.Success);
+        else
+            Snackbar.Add($"{ok} of {total} note(s) {verb}; {total - ok} failed.", Severity.Warning);
+    }
+
+    private async Task BulkUnarchive()
+    {
+        var ids = selected.ToList();
+        var ok = 0;
+        foreach (var id in ids)
+        {
+            var result = await NoteService.UnarchiveAsync(id);
+            if (result.IsSuccess)
+                ok++;
+        }
+        ReportBulk(ok, ids.Count, "unarchived");
+        await ReloadAfterBulk(ok);
+    }
+
+    private async Task BulkDelete()
+    {
+        var count = selected.Count;
+        var message = $"Move {count} selected note(s) and any sub-note(s) to the Recycle Bin? "
+                    + "Items in the Recycle Bin are deleted permanently after 30 days.";
+        if (!await Confirm.ConfirmAsync("Move to Recycle Bin", message, "Move to Recycle Bin")) return;
+
+        var ids = selected.ToList();
+        var ok = 0;
+        foreach (var id in ids)
+        {
+            var result = await NoteService.DeleteAsync(id);
+            if (result.IsSuccess)
+                ok++;
+        }
+        Logger.LogInformation("Bulk moved {Count} archived note(s) to the recycle bin.", ok);
+        ReportBulk(ok, ids.Count, "moved to the Recycle Bin");
+        await ReloadAfterBulk(ok);
     }
 
     private void OpenNote(Guid id) =>

--- a/Vanadium.Note.Web/Pages/Archive.razor.css
+++ b/Vanadium.Note.Web/Pages/Archive.razor.css
@@ -39,10 +39,38 @@
 
 .note-row {
     display: grid;
-    grid-template-columns: 1fr 10rem 13rem;
+    grid-template-columns: 2.2rem 1fr 10rem 13rem;
     align-items: center;
     padding: 0.6rem 1rem;
     border-bottom: 1px solid var(--mud-palette-divider);
+}
+
+.col-select {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.col-select input {
+    cursor: pointer;
+    margin: 0;
+}
+
+.bulk-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.6rem;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--mud-palette-divider);
+    border-radius: 4px;
+    background-color: var(--vn-note-header-bg);
+}
+
+.bulk-count {
+    font-size: 0.8rem;
+    opacity: 0.7;
+    margin-right: auto;
 }
 
 .note-row:last-child {

--- a/Vanadium.Note.Web/Pages/RecycleBin.razor
+++ b/Vanadium.Note.Web/Pages/RecycleBin.razor
@@ -27,8 +27,22 @@
     }
     else
     {
+        @if (selected.Count > 0)
+        {
+            <div class="bulk-bar">
+                <span class="bulk-count">@selected.Count selected</span>
+                <button class="row-btn" @onclick="BulkRestore">Restore selected</button>
+                <button class="row-btn row-btn-danger" @onclick="BulkDeleteForever">Delete forever</button>
+                <button class="row-btn" @onclick="ClearSelection">Clear</button>
+            </div>
+        }
+
         <div class="note-table">
             <div class="note-row note-header">
+                <div class="col-select">
+                    <input type="checkbox" aria-label="Select all notes on this page"
+                           checked="@AllSelected" @onchange="ToggleSelectAll" />
+                </div>
                 <div class="col-title">Title</div>
                 <div class="col-date">Deleted</div>
                 <div class="col-actions"></div>
@@ -36,6 +50,11 @@
             @foreach (var item in items)
             {
                 <div class="note-row note-item">
+                    <div class="col-select">
+                        <input type="checkbox" aria-label="Select note"
+                               checked="@selected.Contains(item.Id)"
+                               @onchange="e => ToggleSelect(item.Id, e)" />
+                    </div>
                     <div class="col-title">
                         <div class="note-title-row">
                             <div class="note-title-text">
@@ -75,11 +94,14 @@
     private const int PageSize = 30;
 
     private List<RecycleBinNoteSummary> items = [];
+    private readonly HashSet<Guid> selected = [];
     private int totalCount;
     private int currentPage = 1;
     private bool isLoading = true;
 
     private int TotalPages => Math.Max(1, (int)Math.Ceiling((double)totalCount / PageSize));
+
+    private bool AllSelected => items.Count > 0 && items.All(i => selected.Contains(i.Id));
 
     protected override async Task OnInitializedAsync() => await LoadPage(1);
 
@@ -87,6 +109,8 @@
     {
         currentPage = page;
         isLoading = true;
+        // Selection is per-visible-page; a page change or reload starts fresh.
+        selected.Clear();
 
         var result = await NoteService.GetRecycleBinAsync(page, PageSize);
         if (result.IsSuccess)
@@ -108,6 +132,74 @@
         if (items.Count <= 1 && page > 1)
             page--;
         await LoadPage(page);
+    }
+
+    // If every item on the current page was removed, step back a page.
+    private async Task ReloadAfterBulk(int removedCount)
+    {
+        var page = currentPage;
+        if (removedCount >= items.Count && page > 1)
+            page--;
+        await LoadPage(page);
+    }
+
+    private void ToggleSelect(Guid id, ChangeEventArgs e)
+    {
+        if (e.Value is true)
+            selected.Add(id);
+        else
+            selected.Remove(id);
+    }
+
+    private void ToggleSelectAll(ChangeEventArgs e)
+    {
+        selected.Clear();
+        if (e.Value is true)
+            foreach (var item in items)
+                selected.Add(item.Id);
+    }
+
+    private void ClearSelection() => selected.Clear();
+
+    private void ReportBulk(int ok, int total, string verb)
+    {
+        if (ok == total)
+            Snackbar.Add($"{ok} note(s) {verb}.", Severity.Success);
+        else
+            Snackbar.Add($"{ok} of {total} note(s) {verb}; {total - ok} failed.", Severity.Warning);
+    }
+
+    private async Task BulkRestore()
+    {
+        var ids = selected.ToList();
+        var ok = 0;
+        foreach (var id in ids)
+        {
+            var result = await NoteService.RestoreAsync(id);
+            if (result.IsSuccess)
+                ok++;
+        }
+        ReportBulk(ok, ids.Count, "restored");
+        await ReloadAfterBulk(ok);
+    }
+
+    private async Task BulkDeleteForever()
+    {
+        var count = selected.Count;
+        var message = $"Permanently delete {count} selected note(s) and any sub-note(s)? This cannot be undone.";
+        if (!await Confirm.ConfirmAsync("Delete forever", message, "Delete forever")) return;
+
+        var ids = selected.ToList();
+        var ok = 0;
+        foreach (var id in ids)
+        {
+            var result = await NoteService.DeletePermanentAsync(id);
+            if (result.IsSuccess)
+                ok++;
+        }
+        Logger.LogInformation("Bulk permanently deleted {Count} note(s) from the recycle bin.", ok);
+        ReportBulk(ok, ids.Count, "permanently deleted");
+        await ReloadAfterBulk(ok);
     }
 
     private static int DaysRemaining(DateTime deletedAtUtc)

--- a/Vanadium.Note.Web/Pages/RecycleBin.razor.css
+++ b/Vanadium.Note.Web/Pages/RecycleBin.razor.css
@@ -39,10 +39,38 @@
 
 .note-row {
     display: grid;
-    grid-template-columns: 1fr 10rem 13rem;
+    grid-template-columns: 2.2rem 1fr 10rem 13rem;
     align-items: center;
     padding: 0.6rem 1rem;
     border-bottom: 1px solid var(--mud-palette-divider);
+}
+
+.col-select {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.col-select input {
+    cursor: pointer;
+    margin: 0;
+}
+
+.bulk-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.6rem;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--mud-palette-divider);
+    border-radius: 4px;
+    background-color: var(--vn-note-header-bg);
+}
+
+.bulk-count {
+    font-size: 0.8rem;
+    opacity: 0.7;
+    margin-right: auto;
 }
 
 .note-row:last-child {


### PR DESCRIPTION
Closes #209

## 요약
아카이브/휴지통 페이지에 다중 선택 기반 벌크 액션을 추가한다. 서버 신규 endpoint 없이(이슈에서 구현 판단에 위임) 프론트에서 기존 단건 endpoint를 순회 호출하는 방식으로 구현 — 스키마/마이그레이션/DTO 변경 없음.

## 변경 내용
- **Archive.razor** — 행별 선택 체크박스 + 전체 선택 헤더 체크박스, 선택 시 벌크 바(Unarchive selected / Delete selected / Clear). `BulkUnarchive`, `BulkDelete`(휴지통 이동, 확인 다이얼로그).
- **RecycleBin.razor** — 동일 선택 UI, 벌크 바(Restore selected / Delete forever / Clear). `BulkRestore`, `BulkDeleteForever`(확인 다이얼로그).
- 부분 실패는 성공/실패 개수로 스낵바 안내, 전부 성공 시 성공 스낵바.
- 페이지 이동/새로고침 시 선택 초기화(선택은 현재 보이는 페이지 범위).
- 각 `*.razor.css` — 체크박스 열(`col-select`)과 벌크 바(`bulk-bar`) 스타일, 그리드 열 추가.

## 완료 조건 검증
- [x] 아카이브에서 여러 항목 선택 후 한 번에 복원/삭제 — `BulkUnarchive`/`BulkDelete`
- [x] 휴지통에서 여러 항목 선택 후 한 번에 복원/영구삭제 — `BulkRestore`/`BulkDeleteForever`
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 증가(기존 NU1902 4건 baseline), 오류 0
- 기존 서버 제약(영구삭제 활성 노트 409 등)은 단건 endpoint 재사용으로 그대로 유지

## 범위
프론트 4개 파일만 변경(이슈 관련 위치와 동일). 백엔드/스키마 무변경. Web 프로젝트는 테스트가 없어 단위 테스트 추가 없음(백엔드 156개 테스트 통과 확인).