### PR TITLE
#213 모바일/터치 지원 (보드 드래그 + 에디터 메뉴)

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/board-drag-drop.js
+++ b/Vanadium.Note.Web/wwwroot/js/board-drag-drop.js
@@ -100,6 +100,168 @@ window.boardDragDrop = (() => {
         }
     };
 
+    // ── Touch drag ───────────────────────────────────────────────────────────
+    // HTML5 drag events never fire from touch input, so touch devices get a
+    // parallel long-press drag path that reuses the same OnDropFromJs handler.
+    // A quick tap still falls through to the card's Blazor @onclick (open note);
+    // only a deliberate long-press turns the card into a draggable ghost.
+    const LONG_PRESS_MS = 220;   // hold time before a card becomes draggable
+    const MOVE_SLOP_PX  = 10;    // pre-drag finger travel that reads as a scroll, not a drag
+    const EDGE_ZONE_PX  = 48;    // distance from the container edge that triggers auto-scroll
+    const EDGE_SPEED_PX = 12;    // horizontal auto-scroll step per animation frame
+
+    const _t = {
+        card: null, noteId: null, fromLabelId: null,
+        startX: 0, startY: 0, lastX: 0, lastY: 0,
+        offsetX: 0, offsetY: 0,
+        pressTimer: null, dragging: false,
+        ghost: null, currentCol: null,
+        scrollDir: 0, scrollRAF: null,
+    };
+
+    function stopAutoScroll() {
+        if (_t.scrollRAF) { cancelAnimationFrame(_t.scrollRAF); _t.scrollRAF = null; }
+        _t.scrollDir = 0;
+    }
+
+    function resetTouch() {
+        if (_t.pressTimer) { clearTimeout(_t.pressTimer); _t.pressTimer = null; }
+        stopAutoScroll();
+        if (_t.ghost) { _t.ghost.remove(); _t.ghost = null; }
+        if (_t.card) _t.card.classList.remove('is-dragging');
+        clearDropTargets();
+        setIsDragging(false);
+        _t.card = _t.noteId = _t.fromLabelId = null;
+        _t.currentCol = null;
+        _t.dragging = false;
+    }
+
+    function beginTouchDrag() {
+        if (!_t.card) return;
+        _t.dragging = true;
+        _t.card.classList.add('is-dragging');
+        setIsDragging(true);
+
+        // Floating clone that trails the finger. pointer-events:none is essential
+        // so document.elementFromPoint resolves the column underneath, not the ghost.
+        const rect = _t.card.getBoundingClientRect();
+        const ghost = _t.card.cloneNode(true);
+        ghost.classList.add('board-card-touch-ghost');
+        Object.assign(ghost.style, {
+            position: 'fixed',
+            left: `${rect.left}px`,
+            top: `${rect.top}px`,
+            width: `${rect.width}px`,
+            margin: '0',
+            pointerEvents: 'none',
+            zIndex: '10000',
+            opacity: '0.92',
+            transform: 'scale(1.03)',
+            boxShadow: '0 8px 24px rgba(0, 0, 0, 0.3)',
+        });
+        document.body.appendChild(ghost);
+        _t.ghost = ghost;
+        _t.offsetX = _t.startX - rect.left;
+        _t.offsetY = _t.startY - rect.top;
+    }
+
+    function highlightColumnUnderFinger() {
+        const el = document.elementFromPoint(_t.lastX, _t.lastY);
+        const col = getColumn(el);
+        clearDropTargets();
+        if (col && col.dataset.labelId !== _t.fromLabelId) col.classList.add('drop-target');
+        _t.currentCol = col;
+    }
+
+    function updateAutoScroll(clientX) {
+        const container = document.querySelector('.board-columns');
+        if (!container) { stopAutoScroll(); return; }
+        const rect = container.getBoundingClientRect();
+        let dir = 0;
+        if (clientX < rect.left + EDGE_ZONE_PX) dir = -1;
+        else if (clientX > rect.right - EDGE_ZONE_PX) dir = 1;
+        _t.scrollDir = dir;
+
+        if (dir !== 0 && !_t.scrollRAF) {
+            const step = () => {
+                if (_t.scrollDir === 0 || !_t.dragging) { _t.scrollRAF = null; return; }
+                container.scrollLeft += _t.scrollDir * EDGE_SPEED_PX;
+                // Columns slide under a stationary finger, so refresh the target.
+                highlightColumnUnderFinger();
+                _t.scrollRAF = requestAnimationFrame(step);
+            };
+            _t.scrollRAF = requestAnimationFrame(step);
+        }
+    }
+
+    _h.touchstart = (e) => {
+        if (e.touches.length !== 1) return;   // ignore multi-touch (pinch/zoom)
+        const card = getCard(e.target);
+        if (!card) return;
+        const touch = e.touches[0];
+        _t.card = card;
+        _t.noteId = card.dataset.noteId;
+        _t.fromLabelId = card.dataset.labelId;
+        _t.startX = _t.lastX = touch.clientX;
+        _t.startY = _t.lastY = touch.clientY;
+        _t.dragging = false;
+        _t.pressTimer = setTimeout(() => {
+            _t.pressTimer = null;
+            beginTouchDrag();
+        }, LONG_PRESS_MS);
+    };
+
+    _h.touchmove = (e) => {
+        if (!_t.card) return;
+        const touch = e.touches[0];
+
+        if (!_t.dragging) {
+            // Long-press still pending: enough travel means the user is scrolling,
+            // so abandon the drag candidate and let the native scroll proceed.
+            const dx = Math.abs(touch.clientX - _t.startX);
+            const dy = Math.abs(touch.clientY - _t.startY);
+            if (dx > MOVE_SLOP_PX || dy > MOVE_SLOP_PX) {
+                if (_t.pressTimer) { clearTimeout(_t.pressTimer); _t.pressTimer = null; }
+                _t.card = _t.noteId = _t.fromLabelId = null;
+            }
+            return;
+        }
+
+        // Dragging: keep the page/list from scrolling out from under the finger.
+        e.preventDefault();
+        _t.lastX = touch.clientX;
+        _t.lastY = touch.clientY;
+        if (_t.ghost) {
+            _t.ghost.style.left = `${touch.clientX - _t.offsetX}px`;
+            _t.ghost.style.top  = `${touch.clientY - _t.offsetY}px`;
+        }
+        highlightColumnUnderFinger();
+        updateAutoScroll(touch.clientX);
+    };
+
+    _h.touchend = (e) => {
+        if (!_t.card) { resetTouch(); return; }
+        if (!_t.dragging) {
+            // Quick tap: leave the emulated click alone so @onclick opens the note.
+            resetTouch();
+            return;
+        }
+        // A real drag: suppress the emulated click so the card doesn't also open.
+        e.preventDefault();
+        const noteId      = _t.noteId;
+        const fromLabelId = _t.fromLabelId;
+        const toLabelId   = _t.currentCol?.dataset.labelId;
+        resetTouch();
+
+        if (toLabelId && toLabelId !== fromLabelId && _dotNetRef) {
+            console.debug(`[board] Touch drop: noteId=${noteId}, from=${fromLabelId} -> to=${toLabelId}`);
+            _dotNetRef.invokeMethodAsync('OnDropFromJs', noteId, fromLabelId, toLabelId)
+                .catch(err => console.error('[board] OnDropFromJs (touch) failed', err));
+        }
+    };
+
+    _h.touchcancel = () => resetTouch();
+
     return {
         init(dotNetRef) {
             _dotNetRef = dotNetRef;
@@ -110,6 +272,10 @@ window.boardDragDrop = (() => {
             document.addEventListener('dragenter',  _h.dragenter);
             document.addEventListener('dragleave',  _h.dragleave);
             document.addEventListener('drop',       _h.drop);
+            document.addEventListener('touchstart', _h.touchstart, { passive: true });
+            document.addEventListener('touchmove',  _h.touchmove,  { passive: false });
+            document.addEventListener('touchend',   _h.touchend);
+            document.addEventListener('touchcancel', _h.touchcancel);
         },
         dispose() {
             document.removeEventListener('dragstart',  _h.dragstart);
@@ -118,6 +284,11 @@ window.boardDragDrop = (() => {
             document.removeEventListener('dragenter',  _h.dragenter);
             document.removeEventListener('dragleave',  _h.dragleave);
             document.removeEventListener('drop',       _h.drop);
+            document.removeEventListener('touchstart', _h.touchstart, { passive: true });
+            document.removeEventListener('touchmove',  _h.touchmove,  { passive: false });
+            document.removeEventListener('touchend',   _h.touchend);
+            document.removeEventListener('touchcancel', _h.touchcancel);
+            resetTouch();
             _dotNetRef = null;
             console.debug('[board] Drag-drop disposed.');
         }

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/slash-commands.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/slash-commands.js
@@ -69,10 +69,15 @@ export function createSlashCommandsExtension(dotnetRef) {
                                 const row = document.createElement('div');
                                 row.className = 'slash-menu-item' + (i === selectedIndex ? ' slash-menu-item-active' : '');
                                 row.innerHTML = `<span class="slash-menu-icon">${item.icon}</span><div class="slash-menu-text"><span class="slash-menu-label">${item.label}</span><span class="slash-menu-desc">${item.desc}</span></div>`;
-                                row.addEventListener('mousedown', e => {
+                                // Bind touchstart alongside mousedown so a tap selects
+                                // the command on mobile; preventDefault on touchstart also
+                                // suppresses the emulated mousedown, avoiding a double fire.
+                                const pick = e => {
                                     e.preventDefault();
                                     currentCommand?.(item);
-                                });
+                                };
+                                row.addEventListener('mousedown', pick);
+                                row.addEventListener('touchstart', pick, { passive: false });
                                 menu.appendChild(row);
                             });
                             menu.querySelector('.slash-menu-item-active')

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/ui/bubble-menu.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/ui/bubble-menu.js
@@ -33,14 +33,20 @@ export function createBubbleMenu(editorId) {
             const btn = document.createElement('button');
             btn.textContent = item.label;
             btn.title = item.title;
-            btn.addEventListener('mousedown', (e) => {
+            // preventDefault keeps the editor selection from collapsing when the
+            // button takes focus. Bind touchstart too so taps fire immediately and
+            // reliably on mobile; preventDefault there also suppresses the emulated
+            // mousedown, so the handler never runs twice for one tap.
+            const activate = (e) => {
                 e.preventDefault();
                 if (item.cmd === 'link') {
                     showLinkPopover(editorId);
                 } else {
                     runCommand(_editors[editorId]?.editor, item.cmd);
                 }
-            });
+            };
+            btn.addEventListener('mousedown', activate);
+            btn.addEventListener('touchstart', activate, { passive: false });
             menu.appendChild(btn);
         }
     }


### PR DESCRIPTION
## 개요

Closes #213

모바일/터치 환경 지원을 추가한다. 보드 드래그가 터치에서 전혀 동작하지 않던 문제를 해결하고, 에디터의 버블/슬래시 메뉴가 터치 탭으로 확실히 조작되도록 한다.

## 변경 사항

### 1. 보드 카드 터치 드래그 (`board-drag-drop.js`)
HTML5 `draggable`은 터치 입력에서 드래그 이벤트가 발동하지 않으므로, 기존 마우스용 HTML5 드래그 경로는 그대로 두고 **길게 눌러 시작하는 터치 드래그 경로**를 병렬로 추가했다.
- **탭 vs 드래그 구분**: 짧은 탭은 카드의 Blazor `@onclick`(노트 열기)으로 그대로 전달. 이동 슬롭(10px)을 넘는 스크롤 제스처는 드래그로 오인하지 않고 네이티브 스크롤 유지.
- **길게 누르기(220ms)** 시 손가락을 따라다니는 고스트 클론 생성(`pointer-events:none`으로 `elementFromPoint`가 아래 컬럼을 인식).
- 대상 컬럼 하이라이트 후 `touchend`에서 기존 `OnDropFromJs`를 그대로 재사용해 라벨 이동/롤백 처리.
- 모바일에서 컬럼이 82vw라 대상 컬럼이 화면 밖에 있을 수 있어 **가장자리 자동 스크롤** 추가.
- 드래그로 판정된 경우 `touchend`에서 `preventDefault`로 에뮬레이션된 클릭을 억제(노트가 함께 열리지 않도록).

### 2. 버블/슬래시 메뉴 터치 조작 (`bubble-menu.js`, `slash-commands.js`)
버튼/항목에 기존 `mousedown`과 함께 `touchstart` 핸들러를 바인딩해 모바일 탭이 즉시·확실하게 명령을 실행하도록 했다. `touchstart`의 `preventDefault`가 에뮬레이션된 `mousedown`을 억제하므로 한 번의 탭으로 핸들러가 중복 실행되지 않는다. 데스크톱 마우스 경로는 그대로 유지.

## 완료 조건 검증

- [x] **모바일에서 노트 열람과 기본 편집이 가능하다** — 레이아웃은 이미 반응형(≤640px 햄버거 내비/스택 사이드바, 페이지별 미디어 쿼리, 뷰포트 메타 존재). 텍스트 입력은 네이티브 동작, 버블/슬래시 메뉴에 터치 핸들링 추가로 조작 가능.
- [x] **보드에서 터치로 노트를 이동할 수 있다** — 길게 눌러 시작하는 터치 드래그 + 가장자리 자동 스크롤 구현.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 오류 0, 신규 경고 없음(기존 NU1902 4건만). `dotnet test` 156 통과/3 스킵(PostgreSQL 전용)/0 실패.

## 범위 / 참고
- 변경은 프론트 JS 3개 파일에 한정. C#/스키마/마이그레이션 변경 없음. 데스크톱 키보드·마우스 워크플로우는 훼손하지 않음.
- Web 프로젝트에는 테스트 프로젝트가 없고(CLAUDE.md 참고) 터치 제스처는 헤드리스 환경에서 자동 검증이 불가하여, **실제 모바일/터치 기기에서의 동작 확인은 수동 검증이 필요**하다.
