### PR TITLE
#204 노트 계층 재귀 인라인 확장 지원

### DIFF
--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -10,6 +10,86 @@
 
 <PageTitle>Notes</PageTitle>
 
+@{
+    // Recursive fragment: renders a note's children and, for any expanded child, its own
+    // descendants — so the hierarchy expands to arbitrary depth. Children are loaded lazily
+    // via ToggleExpand (one GetChildren call per expanded node), so deep/large trees never
+    // inflate the initial page load. depth drives the staircase indentation (top-level
+    // children start at depth 1).
+    RenderFragment<(Guid parentId, int depth)> childBranch = null!;
+    childBranch = ctx =>
+    @<text>
+        @if (loadingChildrenIds.Contains(ctx.parentId))
+        {
+            <div class="note-row note-child-row">
+                <div class="col-check"></div>
+                <div class="col-title note-child-loading" style="padding-left:calc(@(ctx.depth)rem + 0.75rem)">Loading...</div>
+                <div class="col-date"></div>
+            </div>
+        }
+        else if (childrenCache.TryGetValue(ctx.parentId, out var children))
+        {
+            @foreach (var child in children)
+            {
+                <div class="note-row note-item note-child-row @(selectedIds.Contains(child.Id) ? "selected" : "")">
+                    <div class="col-check">
+                        <input type="checkbox"
+                               class="note-checkbox"
+                               checked="@selectedIds.Contains(child.Id)"
+                               @onchange="() => ToggleSelect(child.Id)"
+                               @onclick:stopPropagation="true" />
+                    </div>
+                    <div class="col-title" @onclick="() => EditNote(child.Id)">
+                        <div class="note-title-row" style="padding-left:@(ctx.depth)rem">
+                            @if (child.ChildCount > 0)
+                            {
+                                <button class="expand-btn @(expandedNoteIds.Contains(child.Id) ? "expanded" : "")"
+                                        @onclick:stopPropagation="true"
+                                        @onclick="() => ToggleExpand(child.Id)">
+                                    ▶
+                                </button>
+                            }
+                            else
+                            {
+                                <span class="child-indicator">└</span>
+                            }
+                            <a class="note-title-text"
+                               href="/editor/@child.Id"
+                               @onclick:stopPropagation="true">
+                                @(string.IsNullOrWhiteSpace(child.Title) ? "(No title)" : child.Title)
+                            </a>
+                        </div>
+                        @if (child.Labels?.Any() == true)
+                        {
+                            <div class="note-label-chips" style="padding-left:calc(@(ctx.depth)rem + 0.75rem)">
+                                @foreach (var label in child.Labels)
+                                {
+                                    <span class="note-label-chip @(label.CategoryId.HasValue ? "note-label-chip-cat" : "")"
+                                          @onclick:stopPropagation="true"
+                                          @onclick="() => ToggleFilter(label.Id)">
+                                        @if (label.CategoryId.HasValue)
+                                        {
+                                            <span class="note-label-cat-prefix">@label.CategoryName:</span>
+                                        }
+                                        @label.Name
+                                    </span>
+                                }
+                            </div>
+                        }
+                    </div>
+                    <div class="col-date" @onclick="() => EditNote(child.Id)">
+                        @child.UpdatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")
+                    </div>
+                </div>
+                @if (expandedNoteIds.Contains(child.Id))
+                {
+                    @childBranch((child.Id, ctx.depth + 1))
+                }
+            }
+        }
+    </text>;
+}
+
 <div class="home-page">
     <div class="notes-header">
         <h1>Notes</h1>
@@ -165,63 +245,7 @@
 
                 @if (expandedNoteIds.Contains(note.Id))
                 {
-                    @if (loadingChildrenIds.Contains(note.Id))
-                    {
-                        <div class="note-row note-child-row">
-                            <div class="col-check"></div>
-                            <div class="col-title" style="opacity:0.45; font-size:0.82rem; padding-left:1.75rem;">Loading...</div>
-                            <div class="col-date"></div>
-                        </div>
-                    }
-                    else if (childrenCache.TryGetValue(note.Id, out var children))
-                    {
-                        @foreach (var child in children)
-                        {
-                            <div class="note-row note-item note-child-row @(selectedIds.Contains(child.Id) ? "selected" : "")">
-                                <div class="col-check">
-                                    <input type="checkbox"
-                                           class="note-checkbox"
-                                           checked="@selectedIds.Contains(child.Id)"
-                                           @onchange="() => ToggleSelect(child.Id)"
-                                           @onclick:stopPropagation="true" />
-                                </div>
-                                <div class="col-title" @onclick="() => EditNote(child.Id)">
-                                    <div class="note-title-row note-child-indent">
-                                        <span class="child-indicator">└</span>
-                                        <a class="note-title-text"
-                                           href="/editor/@child.Id"
-                                           @onclick:stopPropagation="true">
-                                            @(string.IsNullOrWhiteSpace(child.Title) ? "(No title)" : child.Title)
-                                        </a>
-                                        @if (child.ChildCount > 0)
-                                        {
-                                            <span class="child-count-badge">+@child.ChildCount</span>
-                                        }
-                                    </div>
-                                    @if (child.Labels?.Any() == true)
-                                    {
-                                        <div class="note-label-chips" style="padding-left:1.75rem;">
-                                            @foreach (var label in child.Labels)
-                                            {
-                                                <span class="note-label-chip @(label.CategoryId.HasValue ? "note-label-chip-cat" : "")"
-                                                      @onclick:stopPropagation="true"
-                                                      @onclick="() => ToggleFilter(label.Id)">
-                                                    @if (label.CategoryId.HasValue)
-                                                    {
-                                                        <span class="note-label-cat-prefix">@label.CategoryName:</span>
-                                                    }
-                                                    @label.Name
-                                                </span>
-                                            }
-                                        </div>
-                                    }
-                                </div>
-                                <div class="col-date" @onclick="() => EditNote(child.Id)">
-                                    @child.UpdatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")
-                                </div>
-                            </div>
-                        }
-                    }
+                    @childBranch((note.Id, 1))
                 }
             }
         </div>

--- a/Vanadium.Note.Web/Pages/Home.razor.css
+++ b/Vanadium.Note.Web/Pages/Home.razor.css
@@ -180,8 +180,9 @@ button.col-title.sortable {
     background-color: var(--mud-palette-background);
 }
 
-.note-child-indent {
-    padding-left: 1rem;
+.note-child-loading {
+    opacity: 0.45;
+    font-size: 0.82rem;
 }
 
 .child-indicator {
@@ -189,13 +190,6 @@ button.col-title.sortable {
     font-size: 0.75rem;
     opacity: 0.35;
     margin-right: 0.1rem;
-}
-
-.child-count-badge {
-    flex-shrink: 0;
-    font-size: 0.65rem;
-    opacity: 0.45;
-    margin-left: 0.25rem;
 }
 
 .archived-badge {


### PR DESCRIPTION
Closes #204

## 목적
노트 계층이 한 단계만 인라인 확장되어 손자 이하 노트를 UI에서 펼쳐 탐색할 수 없던 문제를 해결한다.

## 변경 내용
- `Home.razor`의 자식 노트 렌더링을 **재귀 `RenderFragment`(`childBranch`)** 로 변경하여 임의 깊이까지 인라인 확장 가능하도록 함.
- 자식 노트 중 `ChildCount > 0` 인 항목은 기존 `+N` 뱃지 대신 **확장 버튼(▶)** 을 노출하고, 최상위 노트와 동일하게 `ToggleExpand`/`GetChildrenAsync` 경로를 재사용해 **확장 시점에만 지연 로드**한다.
- 깊이(`depth`)에 따라 들여쓰기가 단계적으로 증가(`padding-left`)하도록 하여 계층 구조가 시각적으로 드러나게 함.
- `Home.razor.css`: 미사용이 된 `.note-child-indent`/`.child-count-badge` 규칙 제거, 로딩 행 인라인 스타일을 `.note-child-loading` 으로 이동.

## 설계 결정 (범위 밖 항목)
이슈의 "접근 방식(재귀 인라인 vs 트리 사이드바)은 설계 단계에서 확정 필요"에 대해, **기존 1단계 인라인 확장 패턴을 그대로 확장하는 재귀 인라인 방식**을 선택했다. 최소 변경으로 모든 완료 조건을 충족하며, 기존에 검증된 코드 경로(`ToggleExpand`/`GetChildren`/`childrenCache`)를 재사용한다. 별도 트리 사이드바가 필요하면 별도 이슈로 논의.

## 완료 조건 검증
- **손자 이상 깊이 노트를 UI에서 펼쳐 탐색 가능** — 자식 행에도 확장 버튼이 붙어 손자·증손자까지 재귀 확장되고, 제목 링크/행 클릭으로 편집 화면 이동 가능.
- **대량 계층에서도 초기 로드가 무거워지지 않음** — 자식은 노드를 펼칠 때 노드당 `GetChildren` 1회로 지연 로드. 초기 로드는 최상위 페이지(30건)만 조회하므로 변화 없음.
- **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0(기존 NU1902 4건 baseline 외 신규 없음)·오류 0. `dotnet test Vanadium.slnx` 156 통과.
- **범위 밖 준수** — 아카이브/휴지통 노트는 백엔드 `GetChildren`이 `ArchivedAt == null` + 전역 소프트삭제 필터로 이미 제외(백엔드 무변경). 변경 파일은 `Home.razor`/`Home.razor.css` 뿐.

## 참고
프론트엔드 렌더링 변경이며 Web 프로젝트에는 테스트 프로젝트가 없어 자동화 테스트는 추가하지 않았다. 실제 브라우저에서 손자 노드 확장/이동은 수동 확인 권장.
