### PR TITLE
#200 최소 CI(GitHub Actions) + 스모크 E2E 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+# Build the whole solution and run the test suite (unit + smoke E2E) on every
+# push to the default branch and on every pull request targeting it, so a broken
+# build or a failing test shows a red check before merge (issue #200).
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore Vanadium.slnx
+
+      - name: Build
+        run: dotnet build Vanadium.slnx --configuration Release --no-restore
+
+      # The smoke E2E test runs in-process against SQLite (see the test project's
+      # WebApplicationFactory), so no PostgreSQL service container is required.
+      - name: Test
+        run: dotnet test Vanadium.slnx --configuration Release --no-build --verbosity normal

--- a/Vanadium.Note.REST.Tests/SmokeE2E/NoteLifecycleSmokeTests.cs
+++ b/Vanadium.Note.REST.Tests/SmokeE2E/NoteLifecycleSmokeTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests.SmokeE2E;
+
+/// <summary>
+/// Smoke E2E for the core happy path (issue #200): log in for a JWT, then create,
+/// edit/save and re-read a note — driven over real HTTP through the full application
+/// pipeline (authentication, middleware, routing, controllers, EF Core). This is the
+/// deterministic, dependency-light stand-in for a browser E2E: it needs no PostgreSQL
+/// and no running frontend, so it stays green in CI while still exercising the whole
+/// request path end-to-end.
+/// </summary>
+public sealed class NoteLifecycleSmokeTests(VanadiumWebApplicationFactory factory)
+    : IClassFixture<VanadiumWebApplicationFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task Login_Create_Edit_Save_HappyPath()
+    {
+        var client = factory.CreateClient();
+
+        // 1. Log in with the configured owner password and obtain a JWT.
+        var loginResponse = await client.PostAsJsonAsync(
+            "/api/auth/login",
+            new { Password = VanadiumWebApplicationFactory.OwnerPassword });
+        Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
+
+        var login = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>(JsonOptions);
+        Assert.False(string.IsNullOrWhiteSpace(login?.Token));
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login!.Token);
+
+        // 2. Create a note.
+        var createResponse = await client.PostAsJsonAsync(
+            "/api/notes",
+            new { Title = "Smoke note", Content = "<p>original</p>" });
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var created = await createResponse.Content.ReadFromJsonAsync<NoteResponse>(JsonOptions);
+        Assert.NotNull(created);
+        Assert.NotEqual(Guid.Empty, created!.Id);
+
+        // 3. Edit and save. The server treats UpdatedAt as the optimistic-concurrency
+        //    token, so a normal save round-trips the version the create returned.
+        var updateResponse = await client.PutAsJsonAsync(
+            $"/api/notes/{created.Id}",
+            new { Title = "Smoke note (edited)", Content = "<p>edited</p>", created.UpdatedAt });
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+
+        // 4. Re-read and confirm the edit was persisted.
+        var fetched = await client.GetFromJsonAsync<NoteResponse>($"/api/notes/{created.Id}", JsonOptions);
+        Assert.NotNull(fetched);
+        Assert.Equal("Smoke note (edited)", fetched!.Title);
+        Assert.Contains("edited", fetched.Content);
+    }
+
+    private sealed record LoginResponse(string Token);
+
+    private sealed record NoteResponse(Guid Id, string Title, string Content, DateTime UpdatedAt);
+}

--- a/Vanadium.Note.REST.Tests/SmokeE2E/VanadiumWebApplicationFactory.cs
+++ b/Vanadium.Note.REST.Tests/SmokeE2E/VanadiumWebApplicationFactory.cs
@@ -1,0 +1,100 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Vanadium.Note.REST.Data;
+using Vanadium.Note.REST.Security;
+
+namespace Vanadium.Note.REST.Tests.SmokeE2E;
+
+/// <summary>
+/// Boots the real REST application pipeline in-process (TestServer) for the smoke
+/// E2E test, with two production-safe substitutions:
+/// <list type="bullet">
+///   <item>the Npgsql <see cref="NoteDbContext"/> is swapped for a shared in-memory
+///     SQLite database, so the happy path runs deterministically in CI without a
+///     PostgreSQL service container;</item>
+///   <item>the background hosted jobs are removed, so they cannot race the single
+///     in-memory SQLite connection during the test.</item>
+/// </list>
+/// Every middleware, the JWT/PAT authentication, routing and the controllers are
+/// exercised exactly as in a real request — only the database provider differs.
+/// </summary>
+public sealed class VanadiumWebApplicationFactory : WebApplicationFactory<Program>
+{
+    /// <summary>The owner password the factory configures a hash for; used by the test to log in.</summary>
+    public const string OwnerPassword = "smoke-e2e-owner-password";
+
+    // A 32+ byte secret so JwtSecretValidator (HS256 requires a 256-bit key) accepts it.
+    private const string JwtSecret = "smoke-e2e-jwt-secret-value-0123456789-abcdef";
+
+    // Kept open for the factory's lifetime: an in-memory SQLite database only exists
+    // while at least one connection to it is open.
+    private readonly SqliteConnection _connection = new("DataSource=:memory:");
+
+    public VanadiumWebApplicationFactory()
+    {
+        _connection.Open();
+
+        // Program validates Auth:JwtSecret eagerly during WebApplication.CreateBuilder,
+        // before the host is built — earlier than any ConfigureAppConfiguration source
+        // takes effect. Environment variables are read at that point (the default builder
+        // calls AddEnvironmentVariables), so the auth config is supplied this way.
+        // "__" maps to the ":" configuration separator.
+        Environment.SetEnvironmentVariable("Auth__JwtSecret", JwtSecret);
+        Environment.SetEnvironmentVariable("Auth__PasswordHash", PasswordHasher.Hash(OwnerPassword));
+        // Never used (the provider is replaced below) but present so the Npgsql option
+        // builder never observes a null connection string while services are configured.
+        Environment.SetEnvironmentVariable(
+            "ConnectionStrings__DefaultConnection",
+            "Host=localhost;Database=vanadium_test;Username=test;Password=test");
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureTestServices(services =>
+        {
+            // Drop the Npgsql registration and its options, plus the background jobs.
+            // EF Core 9/10 applies the provider via IDbContextOptionsConfiguration<T>,
+            // so that descriptor must go too — otherwise the Npgsql config keeps
+            // applying alongside SQLite ("only a single provider" error).
+            services.RemoveAll<IDbContextOptionsConfiguration<NoteDbContext>>();
+            services.RemoveAll<DbContextOptions<NoteDbContext>>();
+            services.RemoveAll<DbContextOptions>();
+            services.RemoveAll<NoteDbContext>();
+            services.RemoveAll<IHostedService>();
+
+            services.AddDbContext<NoteDbContext>(options => options.UseSqlite(_connection));
+        });
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var host = base.CreateHost(builder);
+
+        // Create the schema on the shared in-memory connection once, before any request.
+        using var scope = host.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<NoteDbContext>().Database.EnsureCreated();
+
+        return host;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (!disposing)
+            return;
+
+        _connection.Dispose();
+        Environment.SetEnvironmentVariable("Auth__JwtSecret", null);
+        Environment.SetEnvironmentVariable("Auth__PasswordHash", null);
+        Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", null);
+    }
+}

--- a/Vanadium.Note.REST.Tests/Vanadium.Note.REST.Tests.csproj
+++ b/Vanadium.Note.REST.Tests/Vanadium.Note.REST.Tests.csproj
@@ -16,6 +16,9 @@
       SQLitePCLRaw.lib.e_sqlite3 to SourceGear.sqlite3 and ships SQLite 3.50.4+.
     -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <!-- Hosts the real application pipeline in-process (TestServer) for the smoke E2E test.
+         First-party ASP.NET Core test package, pinned to the shared-framework band (10.0.x). -->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -262,8 +262,13 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-using (var scope = app.Services.CreateScope())
+// Skip the relational migration step under the integration-test host: the smoke
+// E2E factory swaps the Npgsql provider for in-memory SQLite (which cannot run
+// Npgsql migrations) and creates the schema itself. Every real environment
+// (Development/Production) still migrates on startup as before.
+if (!app.Environment.IsEnvironment("Testing"))
 {
+    using var scope = app.Services.CreateScope();
     var startupLogger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
     startupLogger.LogInformation("Applying database migrations...");
     scope.ServiceProvider.GetRequiredService<NoteDbContext>().Database.Migrate();
@@ -294,3 +299,7 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+
+// Exposes the implicit top-level Program class to the test assembly so the smoke
+// E2E WebApplicationFactory<Program> can bootstrap the real application pipeline.
+public partial class Program;


### PR DESCRIPTION
## 개요

Closes #200

테스트 커버리지 공백 + CI 부재를 해소한다. GitHub Actions로 빌드/테스트를 자동화하고, 로그인→노트 생성/편집/저장 해피패스를 검증하는 스모크 E2E를 추가한다.

## 변경 내용

### 1. 최소 CI 워크플로우 (`.github/workflows/ci.yml`)
- `push`(main) / `pull_request`(→main) 트리거
- `dotnet restore` → `dotnet build -c Release` → `dotnet test -c Release` 순으로 실행
- 빌드/테스트 실패 시 job이 non-zero로 종료되어 빨간불이 뜬다
- 스모크 E2E가 인메모리 SQLite로 인프로세스 실행되므로 PostgreSQL 서비스 컨테이너가 불필요

### 2. 스모크 E2E 테스트
- `Vanadium.Note.REST.Tests/SmokeE2E/`
  - `VanadiumWebApplicationFactory` — 실제 애플리케이션 파이프라인(인증·미들웨어·라우팅·컨트롤러·EF)을 `WebApplicationFactory<Program>`로 인프로세스 기동. Npgsql → 공유 인메모리 SQLite로 교체, 백그라운드 hosted job 제거로 결정적 실행 보장
  - `NoteLifecycleSmokeTests.Login_Create_Edit_Save_HappyPath` — 로그인(JWT) → 노트 생성 → 편집/저장 → 재조회 검증
- `Program.cs`
  - `Testing` 환경에서는 시작 시 Npgsql 마이그레이션을 건너뜀(SQLite로 교체되므로). Development/Production은 기존과 동일하게 마이그레이션 수행
  - 최상위 `Program`을 테스트 어셈블리에 노출(`public partial class Program;`)
- 테스트 전용 first-party 패키지 `Microsoft.AspNetCore.Mvc.Testing` 1개만 추가

## 설계 결정: 브라우저 대신 HTTP 레벨 E2E

이슈는 "예: Playwright"로 브라우저 E2E를 예시했으나, 아래 이유로 **HTTP 레벨 E2E**를 택했다:

- **제약 준수** — "신규 top-level 의존성 최소화". Playwright 도입은 브라우저 러너 + 프론트엔드 서빙 + PostgreSQL 서비스까지 요구해 "최소 CI" 취지와 상충. 본 방식은 테스트 전용 패키지 1개만 추가한다.
- **결정성/그린 유지** — 실제 Kestrel 테스트 서버로 로그인→생성→편집→저장 전체 요청 경로를 그대로 통과하되, DB만 인메모리 SQLite로 바꿔 CI에서 안정적으로 통과한다.
- 브라우저 레벨 커버리지가 별도로 필요하면 후속 이슈로 Playwright를 추가할 수 있다.

## 완료 조건 검증

- [x] **PR/push 시 CI가 build + test 실행, 실패 시 빨간불** — `ci.yml`이 `push`/`pull_request`에서 build+test 실행, 실패 시 job 실패
- [x] **최소 1개 이상 스모크 E2E 통과** — `Login_Create_Edit_Save_HappyPath` 통과
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` Debug/Release 모두 오류 0 (기존 AngleSharp NU1902 경고 외 신규 경고 없음)

## 검증 방법

- `dotnet build Vanadium.slnx -c Release` → 오류 0
- `dotnet test Vanadium.slnx -c Release` → 통과 157 / 건너뜀 3 (PostgreSQL 전용 트라이그램 테스트) / 실패 0
- 신규 스모크 테스트 단독 실행 통과 확인

## 범위 밖 준수

- 신규 top-level 앱 의존성 없음(테스트 전용 패키지 1개만)
- `Vanadium.Note.Shared` 신설하지 않음
