### PR TITLE
#209 아카이브/휴지통 다중 선택 벌크 액션

### DIFF
--- a/Vanadium.Note.Web/Pages/Archive.razor
+++ b/Vanadium.Note.Web/Pages/Archive.razor
@@ -27,8 +27,23 @@
     }
     else
     {
+        @if (selected.Count > 0)
+        {
+            <div class="bulk-bar">
+                <span class="bulk-count">@selected.Count selected</span>
+                <button class="row-btn" disabled="@isBusy" @onclick="BulkUnarchive">Unarchive</button>
+                <button class="row-btn row-btn-danger" disabled="@isBusy" @onclick="BulkDelete">Delete</button>
+                <button class="row-btn bulk-clear" disabled="@isBusy" @onclick="ClearSelection">Clear</button>
+            </div>
+        }
+
         <div class="note-table">
             <div class="note-row note-header">
+                <div class="col-select">
+                    <input type="checkbox" aria-label="Select all"
+                           checked="@AllOnPageSelected"
+                           @onchange="ToggleSelectAll" />
+                </div>
                 <div class="col-title">Title</div>
                 <div class="col-date">Archived</div>
                 <div class="col-actions"></div>
@@ -36,6 +51,11 @@
             @foreach (var item in items)
             {
                 <div class="note-row note-item">
+                    <div class="col-select">
+                        <input type="checkbox" aria-label="Select note"
+                               checked="@selected.Contains(item.Id)"
+                               @onchange="e => ToggleSelection(item.Id, e)" />
+                    </div>
                     <div class="col-title">
                         <div class="note-title-row">
                             <div class="note-title-text note-title-link" @onclick="() => OpenNote(item.Id)">
@@ -69,11 +89,15 @@
     private const int PageSize = 30;
 
     private List<ArchivedNoteSummary> items = [];
+    private readonly HashSet<Guid> selected = [];
     private int totalCount;
     private int currentPage = 1;
     private bool isLoading = true;
+    private bool isBusy;
 
     private int TotalPages => Math.Max(1, (int)Math.Ceiling((double)totalCount / PageSize));
+
+    private bool AllOnPageSelected => items.Count > 0 && items.All(i => selected.Contains(i.Id));
 
     protected override async Task OnInitializedAsync() => await LoadPage(1);
 
@@ -81,6 +105,7 @@
     {
         currentPage = page;
         isLoading = true;
+        selected.Clear();
 
         var result = await NoteService.GetArchiveAsync(page, PageSize);
         if (result.IsSuccess)
@@ -97,12 +122,32 @@
 
     private async Task ReloadAfterRemoval()
     {
-        // If the last item on the current page was removed, step back a page.
-        var page = currentPage;
-        if (items.Count <= 1 && page > 1)
-            page--;
-        await LoadPage(page);
+        // Reload the current page; if it emptied out (e.g. the whole page was
+        // removed in one bulk action), step back to the previous page.
+        await LoadPage(currentPage);
+        if (items.Count == 0 && currentPage > 1)
+            await LoadPage(currentPage - 1);
     }
+
+    private void ToggleSelection(Guid id, ChangeEventArgs e)
+    {
+        if (e.Value is true) selected.Add(id);
+        else selected.Remove(id);
+    }
+
+    private void ToggleSelectAll(ChangeEventArgs e)
+    {
+        if (e.Value is true)
+        {
+            foreach (var item in items) selected.Add(item.Id);
+        }
+        else
+        {
+            selected.Clear();
+        }
+    }
+
+    private void ClearSelection() => selected.Clear();
 
     private void OpenNote(Guid id) =>
         Nav.NavigateTo($"/editor/{id}?returnUrl=/archive");
@@ -136,5 +181,63 @@
         Logger.LogInformation("Archived note moved to recycle bin from archive page.");
         Snackbar.Add("Note moved to the Recycle Bin.", Severity.Normal);
         await ReloadAfterRemoval();
+    }
+
+    private async Task BulkUnarchive()
+    {
+        var ids = SelectedIdsOnPage();
+        if (ids.Count == 0) return;
+
+        isBusy = true;
+        var (ok, failed) = await RunBulk(ids, id => NoteService.UnarchiveAsync(id));
+        isBusy = false;
+
+        ReportBulk(ok, failed, "unarchived", "unarchive");
+        await ReloadAfterRemoval();
+    }
+
+    private async Task BulkDelete()
+    {
+        var ids = SelectedIdsOnPage();
+        if (ids.Count == 0) return;
+
+        var message = $"Move {ids.Count} archived note(s) and their sub-note(s) to the Recycle Bin? "
+            + "Items in the Recycle Bin are deleted permanently after 30 days.";
+        if (!await Confirm.ConfirmAsync("Move to Recycle Bin", message, "Move to Recycle Bin")) return;
+
+        isBusy = true;
+        var (ok, failed) = await RunBulk(ids, id => NoteService.DeleteAsync(id));
+        isBusy = false;
+
+        if (ok > 0)
+            Logger.LogInformation("{Count} archived note(s) moved to recycle bin from archive page.", ok);
+        ReportBulk(ok, failed, "moved to the Recycle Bin", "move");
+        await ReloadAfterRemoval();
+    }
+
+    private List<Guid> SelectedIdsOnPage() =>
+        items.Where(i => selected.Contains(i.Id)).Select(i => i.Id).ToList();
+
+    private static async Task<(int ok, int failed)> RunBulk(
+        List<Guid> ids, Func<Guid, Task<ServiceResult<bool>>> action)
+    {
+        int ok = 0, failed = 0;
+        foreach (var id in ids)
+        {
+            var result = await action(id);
+            if (result.IsSuccess) ok++;
+            else failed++;
+        }
+        return (ok, failed);
+    }
+
+    private void ReportBulk(int ok, int failed, string doneVerb, string failVerb)
+    {
+        if (failed == 0)
+            Snackbar.Add($"{ok} note(s) {doneVerb}.", Severity.Success);
+        else if (ok == 0)
+            Snackbar.Add($"Failed to {failVerb} {failed} note(s).", Severity.Error);
+        else
+            Snackbar.Add($"{ok} note(s) {doneVerb}, {failed} failed.", Severity.Warning);
     }
 }

--- a/Vanadium.Note.Web/Pages/Archive.razor.css
+++ b/Vanadium.Note.Web/Pages/Archive.razor.css
@@ -39,10 +39,44 @@
 
 .note-row {
     display: grid;
-    grid-template-columns: 1fr 10rem 13rem;
+    grid-template-columns: 2rem 1fr 10rem 13rem;
     align-items: center;
     padding: 0.6rem 1rem;
     border-bottom: 1px solid var(--mud-palette-divider);
+}
+
+.col-select {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.col-select input {
+    cursor: pointer;
+    margin: 0;
+}
+
+/* ── Bulk action bar ─────────────────────────────────────────────────────── */
+
+.bulk-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.6rem;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--mud-palette-divider);
+    border-radius: 4px;
+    background-color: var(--vn-note-header-bg);
+}
+
+.bulk-count {
+    font-size: 0.8rem;
+    opacity: 0.7;
+    margin-right: 0.25rem;
+}
+
+.bulk-clear {
+    margin-left: auto;
 }
 
 .note-row:last-child {
@@ -204,9 +238,20 @@
     }
 
     .note-row {
-        grid-template-columns: 1fr;
+        grid-template-columns: auto 1fr;
         row-gap: 0.4rem;
         padding: 0.6rem 0.75rem;
+    }
+
+    .col-title,
+    .col-date,
+    .col-actions {
+        grid-column: 2;
+    }
+
+    .col-select {
+        grid-row: 1;
+        justify-content: flex-start;
     }
 
     .col-date {

--- a/Vanadium.Note.Web/Pages/RecycleBin.razor
+++ b/Vanadium.Note.Web/Pages/RecycleBin.razor
@@ -27,8 +27,23 @@
     }
     else
     {
+        @if (selected.Count > 0)
+        {
+            <div class="bulk-bar">
+                <span class="bulk-count">@selected.Count selected</span>
+                <button class="row-btn" disabled="@isBusy" @onclick="BulkRestore">Restore</button>
+                <button class="row-btn row-btn-danger" disabled="@isBusy" @onclick="BulkDeleteForever">Delete forever</button>
+                <button class="row-btn bulk-clear" disabled="@isBusy" @onclick="ClearSelection">Clear</button>
+            </div>
+        }
+
         <div class="note-table">
             <div class="note-row note-header">
+                <div class="col-select">
+                    <input type="checkbox" aria-label="Select all"
+                           checked="@AllOnPageSelected"
+                           @onchange="ToggleSelectAll" />
+                </div>
                 <div class="col-title">Title</div>
                 <div class="col-date">Deleted</div>
                 <div class="col-actions"></div>
@@ -36,6 +51,11 @@
             @foreach (var item in items)
             {
                 <div class="note-row note-item">
+                    <div class="col-select">
+                        <input type="checkbox" aria-label="Select note"
+                               checked="@selected.Contains(item.Id)"
+                               @onchange="e => ToggleSelection(item.Id, e)" />
+                    </div>
                     <div class="col-title">
                         <div class="note-title-row">
                             <div class="note-title-text">
@@ -75,11 +95,15 @@
     private const int PageSize = 30;
 
     private List<RecycleBinNoteSummary> items = [];
+    private readonly HashSet<Guid> selected = [];
     private int totalCount;
     private int currentPage = 1;
     private bool isLoading = true;
+    private bool isBusy;
 
     private int TotalPages => Math.Max(1, (int)Math.Ceiling((double)totalCount / PageSize));
+
+    private bool AllOnPageSelected => items.Count > 0 && items.All(i => selected.Contains(i.Id));
 
     protected override async Task OnInitializedAsync() => await LoadPage(1);
 
@@ -87,6 +111,7 @@
     {
         currentPage = page;
         isLoading = true;
+        selected.Clear();
 
         var result = await NoteService.GetRecycleBinAsync(page, PageSize);
         if (result.IsSuccess)
@@ -103,11 +128,11 @@
 
     private async Task ReloadAfterRemoval()
     {
-        // If the last item on the current page was removed, step back a page.
-        var page = currentPage;
-        if (items.Count <= 1 && page > 1)
-            page--;
-        await LoadPage(page);
+        // Reload the current page; if it emptied out (e.g. the whole page was
+        // removed in one bulk action), step back to the previous page.
+        await LoadPage(currentPage);
+        if (items.Count == 0 && currentPage > 1)
+            await LoadPage(currentPage - 1);
     }
 
     private static int DaysRemaining(DateTime deletedAtUtc)
@@ -115,6 +140,26 @@
         var remaining = deletedAtUtc.AddDays(RetentionDays) - DateTime.UtcNow;
         return Math.Max(0, (int)Math.Ceiling(remaining.TotalDays));
     }
+
+    private void ToggleSelection(Guid id, ChangeEventArgs e)
+    {
+        if (e.Value is true) selected.Add(id);
+        else selected.Remove(id);
+    }
+
+    private void ToggleSelectAll(ChangeEventArgs e)
+    {
+        if (e.Value is true)
+        {
+            foreach (var item in items) selected.Add(item.Id);
+        }
+        else
+        {
+            selected.Clear();
+        }
+    }
+
+    private void ClearSelection() => selected.Clear();
 
     private async Task RestoreNote(RecycleBinNoteSummary item)
     {
@@ -146,6 +191,37 @@
         await ReloadAfterRemoval();
     }
 
+    private async Task BulkRestore()
+    {
+        var ids = SelectedIdsOnPage();
+        if (ids.Count == 0) return;
+
+        isBusy = true;
+        var (ok, failed) = await RunBulk(ids, id => NoteService.RestoreAsync(id));
+        isBusy = false;
+
+        ReportBulk(ok, failed, "restored", "restore");
+        await ReloadAfterRemoval();
+    }
+
+    private async Task BulkDeleteForever()
+    {
+        var ids = SelectedIdsOnPage();
+        if (ids.Count == 0) return;
+
+        var message = $"Permanently delete {ids.Count} note(s) and their sub-note(s)? This cannot be undone.";
+        if (!await Confirm.ConfirmAsync("Delete forever", message, "Delete forever")) return;
+
+        isBusy = true;
+        var (ok, failed) = await RunBulk(ids, id => NoteService.DeletePermanentAsync(id));
+        isBusy = false;
+
+        if (ok > 0)
+            Logger.LogInformation("{Count} note(s) permanently deleted from recycle bin page.", ok);
+        ReportBulk(ok, failed, "permanently deleted", "delete");
+        await ReloadAfterRemoval();
+    }
+
     private async Task EmptyRecycleBin()
     {
         var message = $"Permanently delete all {totalCount} note(s) in the recycle bin? This cannot be undone.";
@@ -159,5 +235,31 @@
         }
         Snackbar.Add("Recycle bin emptied.", Severity.Success);
         await LoadPage(1);
+    }
+
+    private List<Guid> SelectedIdsOnPage() =>
+        items.Where(i => selected.Contains(i.Id)).Select(i => i.Id).ToList();
+
+    private static async Task<(int ok, int failed)> RunBulk(
+        List<Guid> ids, Func<Guid, Task<ServiceResult<bool>>> action)
+    {
+        int ok = 0, failed = 0;
+        foreach (var id in ids)
+        {
+            var result = await action(id);
+            if (result.IsSuccess) ok++;
+            else failed++;
+        }
+        return (ok, failed);
+    }
+
+    private void ReportBulk(int ok, int failed, string doneVerb, string failVerb)
+    {
+        if (failed == 0)
+            Snackbar.Add($"{ok} note(s) {doneVerb}.", Severity.Success);
+        else if (ok == 0)
+            Snackbar.Add($"Failed to {failVerb} {failed} note(s).", Severity.Error);
+        else
+            Snackbar.Add($"{ok} note(s) {doneVerb}, {failed} failed.", Severity.Warning);
     }
 }

--- a/Vanadium.Note.Web/Pages/RecycleBin.razor.css
+++ b/Vanadium.Note.Web/Pages/RecycleBin.razor.css
@@ -39,10 +39,44 @@
 
 .note-row {
     display: grid;
-    grid-template-columns: 1fr 10rem 13rem;
+    grid-template-columns: 2rem 1fr 10rem 13rem;
     align-items: center;
     padding: 0.6rem 1rem;
     border-bottom: 1px solid var(--mud-palette-divider);
+}
+
+.col-select {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.col-select input {
+    cursor: pointer;
+    margin: 0;
+}
+
+/* ── Bulk action bar ─────────────────────────────────────────────────────── */
+
+.bulk-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.6rem;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--mud-palette-divider);
+    border-radius: 4px;
+    background-color: var(--vn-note-header-bg);
+}
+
+.bulk-count {
+    font-size: 0.8rem;
+    opacity: 0.7;
+    margin-right: 0.25rem;
+}
+
+.bulk-clear {
+    margin-left: auto;
 }
 
 .note-row:last-child {
@@ -215,9 +249,20 @@
     }
 
     .note-row {
-        grid-template-columns: 1fr;
+        grid-template-columns: auto 1fr;
         row-gap: 0.4rem;
         padding: 0.6rem 0.75rem;
+    }
+
+    .col-title,
+    .col-date,
+    .col-actions {
+        grid-column: 2;
+    }
+
+    .col-select {
+        grid-row: 1;
+        justify-content: flex-start;
     }
 
     .col-date {


### PR DESCRIPTION
Closes #209

## 목적
아카이브/휴지통 페이지에 다중 선택 벌크 액션을 추가한다. 기존에는 모두 행별 처리였고 '휴지통 비우기'만 유일한 벌크 액션이었다.

## 변경 사항
- 각 행에 체크박스 추가, 헤더에 전체 선택 체크박스 추가
- 선택 항목이 있을 때만 벌크 액션 바 표시(선택 개수 + 액션 버튼 + Clear)
- **아카이브**: 벌크 복원(unarchive) / 벌크 삭제(휴지통 이동, 확인 다이얼로그)
- **휴지통**: 벌크 복원 / 벌크 영구삭제(확인 다이얼로그)
- 벌크 작업은 기존 단건 endpoint를 순차 호출 — 신규 서버 endpoint/스키마 변경 없음(이슈에서 구현 판단에 위임)
- 진행 중 버튼 비활성화(`isBusy`), 성공/실패 건수 요약 스낵바
- 페이지 이동/작업 후 선택 초기화, 페이지가 비면 이전 페이지로 이동

## 구현 판단
- 서버 벌크 endpoint 대신 프론트 단건 반복 호출을 택함: 최소 변경 원칙, 백엔드/스키마 표면 없음, 영구삭제 409 등 기존 서버 제약 그대로 유지.

## 완료 조건 검증
- [x] 아카이브에서 여러 항목 선택 → 한 번에 복원/삭제 (`BulkUnarchive`/`BulkDelete`)
- [x] 휴지통에서 여러 항목 선택 → 한 번에 복원/영구삭제 (`BulkRestore`/`BulkDeleteForever`)
- [x] 빌드 클린 (`dotnet build Vanadium.slnx` — 신규 경고 0), 백엔드 테스트 157 통과

## 비고
- Web 프로젝트에는 테스트 프로젝트가 없어(문서화된 제약) 프론트 자동 테스트는 추가하지 않음.
