### PR TITLE
#259 취약한 AngleSharp 0.17.1 제거 (HtmlSanitizer 9.1.966-beta 상향)

### DIFF
--- a/Vanadium.Note.REST/Vanadium.Note.REST.csproj
+++ b/Vanadium.Note.REST/Vanadium.Note.REST.csproj
@@ -11,7 +11,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
+    <!-- Upgraded to patch GHSA-pgww-w46g-26qg (mXSS, AngleSharp < 1.5.0). The 9.0.x line
+         hard-pins the vulnerable AngleSharp 0.17.1 / AngleSharp.Css 0.17.0; 9.1.x is the first
+         release train that depends on the patched AngleSharp 1.5.2 (+ AngleSharp.Css 1.0.0-beta,
+         which has no stable 1.x). AngleSharp 1.x is a breaking API change vs 0.17.x, so pinning
+         AngleSharp alone against a 9.0.x HtmlSanitizer compiled for 0.17 is not runtime-safe
+         (NU1608); upgrading the sanitizer keeps the AngleSharp graph vendor-coherent. -->
+    <PackageReference Include="HtmlSanitizer" Version="9.1.966-beta" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <!-- Pinned to patch GHSA-v5pm-xwqc-g5wc; Swashbuckle.AspNetCore 10.1.7 pulls in the vulnerable 2.4.1 transitively. -->
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />


### PR DESCRIPTION
Closes #259

## 배경
전이 의존성으로 끌려오던 `AngleSharp 0.17.1`에 mXSS 취약점(GHSA-pgww-w46g-26qg, CVSS 6.9)이 있어 `Vanadium.Note.REST`·`Vanadium.Note.REST.Tests` 양쪽에서 `NU1902` 경고가 발생했다. 이 라이브러리는 `HtmlSanitizerService`의 XSS 방어 파싱에 직접 관여하므로 실제 영향 대상에 해당한다.

## 조사 결과
- `HtmlSanitizer 9.0.892`(최신 stable)는 `AngleSharp [0.17.1]`·`AngleSharp.Css [0.17.0]`을 **정확한 버전**으로 고정 참조한다.
- `AngleSharp.Css`는 **stable 1.x가 존재하지 않으며**(1.0.0-beta.* 만 존재), 따라서 AngleSharp ≥ 1.5.0에 도달하는 완전 stable 조합은 어디에도 없다.
- `AngleSharp`만 직접 상향 고정(1.5.2)하는 방식은 `HtmlSanitizer 9.0.892`(0.17 API로 컴파일됨)와 충돌하여 **`NU1608` 경고 4건 + 런타임 바이너리 불일치 위험**을 유발한다 → 채택 불가.
- `HtmlSanitizer 9.1.x`가 패치된 `AngleSharp 1.5.2`(+ `AngleSharp.Css 1.0.0-beta.216`)에 의존하는 첫 릴리스 라인이다.

## 변경
- `Vanadium.Note.REST.csproj`의 `HtmlSanitizer`를 `9.0.892` → `9.1.966-beta`로 상향. GHSA 번호를 명시한 주석을 함께 남김(기존 `Microsoft.OpenApi` 핀 스타일).
- 이는 이슈가 명시적으로 허용한 대안("호환되지 않으면 HtmlSanitizer를 패치된 AngleSharp에 의존하는 상위 버전으로 올린다")이며, sanitizer 라이브러리 교체나 allowlist 정책 변경은 없음.
- Tests 프로젝트는 REST 프로젝트 참조를 통해 패치된 AngleSharp 1.5.2를 전이로 받으므로 별도 수정 불필요.

## 완료 조건 검증
- [x] **NU1902 경고 제거**: `dotnet build Vanadium.slnx` → **경고 0개, 오류 0개** (양쪽 프로젝트 모두).
- [x] **AngleSharp ≥ 1.5.0**: `dotnet list Vanadium.slnx package --include-transitive` → `AngleSharp 1.5.2`.
- [x] **테스트 통과**: `dotnet test Vanadium.slnx` → 실패 0, 통과 157, 건너뜀 3(PostgreSQL 트라이그램 전용, 무관). `HtmlSanitizerServiceTests` 8건 전부 통과 → AngleSharp 1.5.2 런타임 호환 확인.
- [x] **빌드 클린**: 위와 동일.

## 참고 (수동 확인 권장)
`HtmlSanitizer 9.1.966-beta`는 prerelease다. `AngleSharp.Css`에 stable 1.x가 없어 AngleSharp ≥ 1.5.0 요구를 만족하려면 prerelease가 불가피하며, 벤더가 함께 컴파일/배포한 일관된 조합이라 임의 버전 혼합보다 안전하다. stable 릴리스 등장 시 재고정을 권장한다.