### PR TITLE
#262 에디터→에디터 이동 시 미저장 편집 플러시 없이 소멸 수정

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -322,30 +322,28 @@
     private Guid? NewLabelCategoryId =>
         Guid.TryParse(newLabelCategoryStr, out var g) && g != Guid.Empty ? g : null;
 
-    // Blazor reuses this component instance across editor→editor navigations (backlink,
-    // breadcrumb parent link, peek dialog "open in full page"). The incoming parameters
-    // overwrite the outgoing note's Id/title/content BEFORE OnParametersSetAsync runs, so any
-    // unsaved edits of the OUTGOING note must be flushed here — while Id and content still
-    // point at it — rather than in OnParametersSetAsync, which already sees the new note. Without
-    // this, typing then clicking a backlink within the 1500ms auto-save debounce window dropped
-    // the edit silently, and the stray pending debounce timer could PUT empty content to the
-    // newly-loaded note (a false 409). Cancelling the timer also covers the stray-timer case,
-    // since an armed timer always implies HasPendingChanges (#262).
-    public override async Task SetParametersAsync(ParameterView parameters)
+    protected override async Task OnParametersSetAsync()
     {
-        parameters.TryGetValue<Guid?>(nameof(Id), out var incomingId);
-        if (incomingId != Id && Id is not null
-            && HasPendingChanges && !_hasConflict && !IsArchived)
+        if (_currentId == Id && _currentParentId == ParentId) return;
+
+        // Blazor reuses this component instance across editor→editor navigations (backlink,
+        // breadcrumb parent link, peek dialog "open in full page"). Flush the OUTGOING note's
+        // unsaved edits before the reset below wipes them: at this point _currentId/title/content/
+        // _serverUpdatedAt still describe the outgoing note (the Id *parameter* already points at
+        // the incoming note, which is why the flush targets _currentId — SaveOnceAsync builds its
+        // payload from _currentId, not Id). Cancelling the debounce timer also stops a stray
+        // pending save from PUTting empty content to the newly-loaded note (a false 409); an armed
+        // timer always implies HasPendingChanges (#262).
+        //
+        // This must run here, NOT in a SetParametersAsync override: a ParameterView cannot be read
+        // after an await, so awaiting the flush there and then calling base.SetParametersAsync
+        // throws "The ParameterView instance can no longer be read because it has expired".
+        if (_currentId is not null && HasPendingChanges && !_hasConflict && !IsArchived)
         {
             _autoSave.Cancel();
             await SaveCoreAsync();
         }
-        await base.SetParametersAsync(parameters);
-    }
 
-    protected override async Task OnParametersSetAsync()
-    {
-        if (_currentId == Id && _currentParentId == ParentId) return;
         _currentId = Id;
         _currentParentId = ParentId;
 
@@ -547,10 +545,13 @@
 
     private async Task<NoteItem?> SaveOnceAsync()
     {
-        // The note this save targets, captured before the awaited PUT. If the user navigates
-        // to another note while the request is in flight, the completion callback below must
-        // not fold this save's result into the now-current note's state (#262).
-        var startId = Id;
+        // The note this save targets, captured before the awaited PUT. Uses _currentId (the note
+        // the editor currently represents), not the Id route parameter: during an editor→editor
+        // navigation the flush in OnParametersSetAsync runs this while Id already points at the
+        // incoming note but _currentId still points at the outgoing one. If the user navigates
+        // away while the request is in flight, the completion callback below must not fold this
+        // save's result into the now-current note's state (#262).
+        var startId = _currentId;
 
         // Normalize the title before saving so a whitespace-only or empty title
         // never lands in the list. Mirrors the Board create path (which trims) and
@@ -561,7 +562,7 @@
 
         var note = new NoteItem
         {
-            Id = Id ?? Guid.Empty,
+            Id = startId ?? Guid.Empty,
             Title = normalizedTitle,
             Content = content,
             ParentNoteId = parentNoteId,
@@ -594,7 +595,7 @@
         // save targeted. A save that started for note A but completes after the user navigated
         // to note B must not overwrite B's _serverUpdatedAt — doing so makes B's next save a
         // false 409 (#262).
-        if (startId == Id)
+        if (startId == _currentId)
         {
             _serverUpdatedAt = result.Value!.UpdatedAt;
             HasPendingChanges = false;

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -322,6 +322,27 @@
     private Guid? NewLabelCategoryId =>
         Guid.TryParse(newLabelCategoryStr, out var g) && g != Guid.Empty ? g : null;
 
+    // Blazor reuses this component instance across editor→editor navigations (backlink,
+    // breadcrumb parent link, peek dialog "open in full page"). The incoming parameters
+    // overwrite the outgoing note's Id/title/content BEFORE OnParametersSetAsync runs, so any
+    // unsaved edits of the OUTGOING note must be flushed here — while Id and content still
+    // point at it — rather than in OnParametersSetAsync, which already sees the new note. Without
+    // this, typing then clicking a backlink within the 1500ms auto-save debounce window dropped
+    // the edit silently, and the stray pending debounce timer could PUT empty content to the
+    // newly-loaded note (a false 409). Cancelling the timer also covers the stray-timer case,
+    // since an armed timer always implies HasPendingChanges (#262).
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        parameters.TryGetValue<Guid?>(nameof(Id), out var incomingId);
+        if (incomingId != Id && Id is not null
+            && HasPendingChanges && !_hasConflict && !IsArchived)
+        {
+            _autoSave.Cancel();
+            await SaveCoreAsync();
+        }
+        await base.SetParametersAsync(parameters);
+    }
+
     protected override async Task OnParametersSetAsync()
     {
         if (_currentId == Id && _currentParentId == ParentId) return;
@@ -526,6 +547,11 @@
 
     private async Task<NoteItem?> SaveOnceAsync()
     {
+        // The note this save targets, captured before the awaited PUT. If the user navigates
+        // to another note while the request is in flight, the completion callback below must
+        // not fold this save's result into the now-current note's state (#262).
+        var startId = Id;
+
         // Normalize the title before saving so a whitespace-only or empty title
         // never lands in the list. Mirrors the Board create path (which trims) and
         // falls back to "Untitled" for an empty result (#203).
@@ -564,9 +590,16 @@
             await DraftStore.SaveAsync(Id, title, content);
             return null;
         }
-        _serverUpdatedAt = result.Value!.UpdatedAt;
-        HasPendingChanges = false;
-        await DraftStore.ClearAsync();
+        // Only fold the save result back into editor state when we're still on the note this
+        // save targeted. A save that started for note A but completes after the user navigated
+        // to note B must not overwrite B's _serverUpdatedAt — doing so makes B's next save a
+        // false 409 (#262).
+        if (startId == Id)
+        {
+            _serverUpdatedAt = result.Value!.UpdatedAt;
+            HasPendingChanges = false;
+            await DraftStore.ClearAsync();
+        }
         return result.Value;
     }
 


### PR DESCRIPTION
Closes #262

## 문제
Blazor가 `NoteEditor` 컴포넌트 인스턴스를 에디터→에디터 이동(백링크, 브레드크럼 부모 링크, 피크 다이얼로그의 "전체 페이지로 열기")에서 재사용한다. `OnParametersSetAsync`는 `Id`가 바뀌면 상태를 즉시 리셋하지만, 나가는 노트의 자동저장 타이머 취소도 `HasPendingChanges` 플러시도 하지 않았다. Blazor는 `OnParametersSetAsync` 실행 **전에** `Id` 파라미터를 이미 덮어쓰므로, 리셋 시점에는 나가는 노트를 식별할 수 없다.

이로 인해:
- 타이핑 직후(자동저장 디바운스 1500ms 이내) 백링크/부모 링크 클릭 시 편집분이 경고 없이 소실
- 리셋 후 잔존 디바운스 타이머가 새로 로드된 노트에 빈 content를 PUT → 가짜 409 배너
- A의 in-flight 저장이 B 로드 후 완료되면 B의 `_serverUpdatedAt`을 A의 타임스탬프로 덮어 B의 다음 저장이 409

## 변경
1. **`SetParametersAsync` 재정의** — 파라미터가 적용되기 전(즉, `Id`/`title`/`content`/`_serverUpdatedAt`이 아직 나가는 노트를 가리킬 때) `Id`가 실제로 바뀌는 경우 `_autoSave.Cancel()` 후 `HasPendingChanges`이면 `SaveCoreAsync()`로 플러시한다. 타이머 취소가 잔존-타이머 케이스도 함께 처리한다(무장된 타이머는 항상 `HasPendingChanges==true`를 함의). `Id is not null`/`!_hasConflict`/`!IsArchived` 가드로 신규 노트·충돌·아카이브 상태는 건드리지 않는다.
2. **`SaveOnceAsync`에 `startId == Id` 가드** — 저장 시작 시점의 `Id`를 캡처하고, 결과를 편집 상태(`_serverUpdatedAt`/`HasPendingChanges`/draft clear)에 반영하는 성공 블록을 현재 노트가 그대로일 때만 실행한다.

기존 자동저장 디바운스 간격(1500ms)과 `SaveCoreAsync`/`SaveOnceAsync` 단일 저장 진입점 구조는 변경하지 않았다(범위 밖).

## 완료 조건 검증
- [x] 같은 라우트 이동 시 리셋 전에 이전 Id 문맥으로 자동저장 타이머 취소 + 플러시 — `SetParametersAsync`가 `base.SetParametersAsync`(→리셋) 이전에 실행
- [x] 타이핑 직후 백링크/부모 링크 클릭 시 편집분 소실 없음 — 플러시로 서버에 저장
- [x] in-flight 저장 완료 콜백이 `startId == Id`일 때만 `_serverUpdatedAt` 갱신
- [x] 리셋 후 잔존 디바운스 타이머가 빈 content로 PUT하지 않음 — `_autoSave.Cancel()`
- [x] 빌드 클린 (`dotnet build Vanadium.slnx` — 경고 0, 오류 0)
- [x] `dotnet test Vanadium.slnx` — 157 통과, 3 스킵(PostgreSQL 전용), 0 실패

## 테스트 노트
Web 프로젝트에는 테스트 하네스가 없고(bUnit 미도입), 이 수정은 REST의 SQLite 테스트 프로젝트가 커버하지 않는 Blazor 컴포넌트 생명주기 로직이다. bUnit 도입은 새로운 최상위 의존성으로 CLAUDE.md 지침상 정당화 없이 추가하지 않는다. 따라서 자동 회귀 테스트는 추가하지 않았으며 빌드/테스트 통과와 코드 리뷰로 검증한다.
