### PR TITLE
#263 충돌(409) 상태 편집 내용 드래프트 보존 및 Reload 백업

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -578,8 +578,10 @@
             // The save can never win against this stale snapshot, so back the in-progress edit up
             // to a draft that a reopen / reload restores instead of dropping it — mirroring the
             // SubNoteDialog conflict pattern (#192/#263). Continued typing rides the same draft on
-            // dispose/reload below.
-            await DraftStore.SaveAsync(Id, title, content);
+            // dispose/reload below. Key by startId, not Id: during an editor→editor navigation flush
+            // Id already points at the incoming note while title/content describe the outgoing one,
+            // so Id would stash the outgoing draft under the wrong note (#262/#263).
+            await DraftStore.SaveAsync(startId, title, content);
             return null;
         }
         if (result.IsForbidden)
@@ -593,7 +595,9 @@
             Logger.LogError("Save failed for note {NoteId}.", note.Id);
             // The session may have expired (401 → redirect to login). Stash the draft
             // so the in-progress edit survives re-login and is restored on return (#117).
-            await DraftStore.SaveAsync(Id, title, content);
+            // Key by startId (the saved note), not Id, for the same navigation-flush reason
+            // as the conflict branch above (#262/#263).
+            await DraftStore.SaveAsync(startId, title, content);
             return null;
         }
         // Only fold the save result back into editor state when we're still on the note this

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -575,6 +575,11 @@
         if (result.IsConflict)
         {
             _hasConflict = true;
+            // The save can never win against this stale snapshot, so back the in-progress edit up
+            // to a draft that a reopen / reload restores instead of dropping it — mirroring the
+            // SubNoteDialog conflict pattern (#192/#263). Continued typing rides the same draft on
+            // dispose/reload below.
+            await DraftStore.SaveAsync(Id, title, content);
             return null;
         }
         if (result.IsForbidden)
@@ -741,6 +746,11 @@
     private async Task ReloadNote()
     {
         if (Id is null) { Nav.NavigateTo("/"); return; }
+        // Back up the local (conflicting) text to a draft before the server copy overwrites it, so
+        // 'Reload Latest' preserves the user's in-progress edits for recovery instead of discarding
+        // them without any backup (#263). A later successful save clears the draft.
+        if (HasPendingChanges)
+            await DraftStore.SaveAsync(Id, title, content);
         var result = await NoteService.GetAsync(Id.Value);
         if (!result.IsSuccess) { Nav.NavigateTo("/"); return; }
         title = result.Value!.Title;
@@ -1101,8 +1111,16 @@
         _isDisposing = true;
         _autoSave.Dispose();
 
-        if (HasPendingChanges && !_hasConflict && !IsArchived)
-            await SaveCoreAsync();
+        if (HasPendingChanges && !IsArchived)
+        {
+            if (_hasConflict)
+                // A save can only 409 again against this stale snapshot; back the edit up to a
+                // draft that a reopen restores instead of silently dropping it on teardown —
+                // mirroring SubNoteDialog (#263).
+                await DraftStore.SaveAsync(Id, title, content);
+            else
+                await SaveCoreAsync();
+        }
 
         // Tear down the beforeunload guard so it can never outlive this editor
         // instance (e.g. when an unresolved conflict left changes unsaved above).


### PR DESCRIPTION
Closes #263

## 문제
충돌(409) 상태에서 계속 타이핑한 내용이 저장도 드래프트도 되지 않고 사라지며, 'Reload Latest'가 백업 없이 로컬 텍스트를 서버 값으로 덮어썼다. 같은 상황에서 `SubNoteDialog`는 드래프트를 스태시해 동작이 비일관했다.

## 변경 내용
`Vanadium.Note.Web/Pages/NoteEditor.razor`를 `SubNoteDialog`(#192)의 충돌 드래프트 패턴과 일관되게 수정:

1. **`SaveOnceAsync` 409 분기** — `_hasConflict` 설정에 더해 `DraftStore.SaveAsync`로 충돌 시점 편집을 드래프트에 백업.
2. **`DisposeAsync`** — 기존엔 `!_hasConflict` 조건으로 충돌 시 저장을 스킵했으나, 이제 충돌 상태에서도 최신 편집을 드래프트로 스태시.
3. **`ReloadNote`** — 서버 값으로 덮어쓰기 전에 로컬 텍스트를 드래프트로 백업해 파기 방지.

## 완료 조건 검증
- [x] 충돌 상태에서 계속 타이핑한 내용이 DraftStore에 저장됨 — 충돌 시점(1) + 페이지 이탈/리로드 시점(2·3)에 `content`/`title` 최신값을 스태시. 타이핑은 `OnEditorContentChanged`가 `content`를 갱신하므로 이탈 시 최신 내용이 보존됨.
- [x] `DisposeAsync`가 충돌 상태에서도 드래프트를 스태시 — 변경 2.
- [x] 'Reload Latest'가 리로드 전에 로컬 텍스트를 드래프트로 백업 — 변경 3.
- [x] 충돌 관련 드래프트 동작이 `SubNoteDialog`와 일관 — 세 지점 모두 `SubNoteDialog`의 `SaveCoreAsync`/`Close`/`DisposeAsync` 패턴을 그대로 반영.
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0.

## 참고
- 범위 밖(서버측 409 판정 로직, 자동저장 디바운스/단일 저장 진입점 구조)은 건드리지 않음.
- Web 프로젝트에는 테스트 인프라(bUnit 등)가 없어 Blazor 컴포넌트 단위 회귀 테스트는 추가하지 못함. `dotnet test`(157 통과) 회귀 없음 확인.