### PR TITLE
#264 드래프트 슬롯 노트별 분리 — 다른 노트 저장이 남의 드래프트를 삭제/덮어쓰지 않도록 수정

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -608,7 +608,11 @@
         {
             _serverUpdatedAt = result.Value!.UpdatedAt;
             HasPendingChanges = false;
-            await DraftStore.ClearAsync();
+            // Clear only the saved note's draft slot. Key by startId (the note this save
+            // targeted), not Id — a save that started for A but completes after navigating
+            // to B must clear A's draft, and must never touch a stash belonging to another
+            // note (#264, matching the startId keying of the stash paths above).
+            await DraftStore.ClearAsync(startId);
         }
         return result.Value;
     }

--- a/Vanadium.Note.Web/Pages/SubNoteDialog.razor
+++ b/Vanadium.Note.Web/Pages/SubNoteDialog.razor
@@ -259,7 +259,9 @@
         {
             _serverUpdatedAt = result.Value!.UpdatedAt;
             HasPendingChanges = false;
-            await DraftStore.ClearAsync();
+            // Clear only this note's draft slot so a successful save here never discards a
+            // draft stashed for a different note (#264).
+            await DraftStore.ClearAsync(NoteId);
         }
         else if (result.IsConflict)
         {

--- a/Vanadium.Note.Web/Services/DraftStore.cs
+++ b/Vanadium.Note.Web/Services/DraftStore.cs
@@ -6,20 +6,27 @@ namespace Vanadium.Note.Web.Services;
 /// <summary>
 /// Persists the in-progress editor draft to the browser's <c>sessionStorage</c>
 /// so that a mid-session auth expiry (401 → redirect to login) does not discard
-/// unsaved work. Only a single draft slot is kept; it is keyed by note id so a
-/// stashed draft is restored only when the same note is reopened after re-login
-/// (issue #117). Mirrors <see cref="Vanadium.Note.Web.Auth.TokenStore"/>.
+/// unsaved work. Each note gets its own slot, keyed by note id, so that saving
+/// (or failing to save) one note never overwrites or clears another note's stashed
+/// draft (issue #264). A stashed draft is restored only when the same note is
+/// reopened after re-login (issue #117). Mirrors
+/// <see cref="Vanadium.Note.Web.Auth.TokenStore"/>.
 /// </summary>
 public class DraftStore(IJSRuntime js, ILogger<DraftStore> logger)
 {
-    private const string StorageKey = "vanadium.editor-draft.v1";
+    private const string StorageKeyPrefix = "vanadium.editor-draft.v1";
+
+    // A per-note sessionStorage key. A new, not-yet-persisted note (null id) uses a
+    // fixed "new" suffix so its draft is isolated from every saved note's slot.
+    private static string StorageKey(Guid? noteId) =>
+        $"{StorageKeyPrefix}.{(noteId.HasValue ? noteId.Value.ToString() : "new")}";
 
     public async Task SaveAsync(Guid? noteId, string title, string content)
     {
         try
         {
             var json = JsonSerializer.Serialize(new EditorDraft(noteId, title, content));
-            await js.InvokeVoidAsync("sessionStorage.setItem", StorageKey, json);
+            await js.InvokeVoidAsync("sessionStorage.setItem", StorageKey(noteId), json);
         }
         catch (Exception ex)
         {
@@ -28,14 +35,15 @@ public class DraftStore(IJSRuntime js, ILogger<DraftStore> logger)
     }
 
     /// <summary>
-    /// Returns the stashed draft only when it belongs to <paramref name="noteId"/>
-    /// (both <c>null</c> matches a new-note draft); otherwise <c>null</c>.
+    /// Returns the stashed draft for <paramref name="noteId"/> (a <c>null</c> id
+    /// reads the new-note slot); otherwise <c>null</c>. The stored note id is
+    /// re-checked as a defensive guard against a mismatched/corrupt entry.
     /// </summary>
     public async Task<EditorDraft?> GetAsync(Guid? noteId)
     {
         try
         {
-            var json = await js.InvokeAsync<string?>("sessionStorage.getItem", StorageKey);
+            var json = await js.InvokeAsync<string?>("sessionStorage.getItem", StorageKey(noteId));
             if (string.IsNullOrEmpty(json))
                 return null;
             var draft = JsonSerializer.Deserialize<EditorDraft>(json);
@@ -48,11 +56,16 @@ public class DraftStore(IJSRuntime js, ILogger<DraftStore> logger)
         }
     }
 
-    public async Task ClearAsync()
+    /// <summary>
+    /// Clears only <paramref name="noteId"/>'s draft slot (a <c>null</c> id clears the
+    /// new-note slot), so a successful save of one note never discards another note's
+    /// stashed draft (issue #264).
+    /// </summary>
+    public async Task ClearAsync(Guid? noteId)
     {
         try
         {
-            await js.InvokeVoidAsync("sessionStorage.removeItem", StorageKey);
+            await js.InvokeVoidAsync("sessionStorage.removeItem", StorageKey(noteId));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## 요약
`DraftStore`가 단일 sessionStorage 슬롯(`vanadium.editor-draft.v1`)만 사용해, 저장 성공 시 소유자 확인 없이 무조건 `ClearAsync()`를 호출하던 문제를 고친다. A 편집 중 401로 드래프트가 스태시된 뒤, 재로그인 후 B를 먼저 열어 저장하면 A의 드래프트가 소리 없이 삭제되고(성공 시), B 저장 실패 시엔 B 드래프트가 A 드래프트를 덮어썼다.

## 변경 내용
- **`DraftStore.cs`**: 슬롯 키를 노트별로 분리 — `vanadium.editor-draft.v1.{noteId}` (신규 노트는 `.new`). `SaveAsync`/`GetAsync`는 해당 노트 키에만 접근하고, `ClearAsync(Guid? noteId)`로 시그니처를 바꿔 인자로 받은 노트의 슬롯만 삭제한다. `GetAsync`의 저장 NoteId 재확인은 손상 방지용 방어 로직으로 유지.
- **`NoteEditor.razor`**: 저장 성공 시 `ClearAsync(startId)` — 이 저장이 대상으로 한 노트(=스태시 경로와 동일한 startId 키)만 정리.
- **`SubNoteDialog.razor`**: 저장 성공 시 `ClearAsync(NoteId)`.

## 완료 조건 검증
- [x] **드래프트가 노트별로 격리** — 노트별 키로 A/B 슬롯이 물리적으로 분리됨. B를 저장/삭제해도 A 키는 손대지 않음. (코드 검토 + 빌드로 확인)
- [x] **다른 노트 저장 실패가 남의 드래프트를 덮어쓰지 않음** — `SaveAsync(B, …)`는 B 키에만 기록.
- [x] **저장 성공 시 해당 노트의 드래프트만 삭제** — `ClearAsync(startId)` / `ClearAsync(NoteId)`로 대상 노트 슬롯만 제거.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0. `dotnet test Vanadium.slnx` 157 통과 / 3 스킵(PostgreSQL 전용, 기존).

## 범위 / 참고
- 범위 밖(sessionStorage 저장 매체, 401 세션 만료·재로그인 흐름)은 건드리지 않음.
- **테스트:** 영향 코드는 Web(Blazor WASM) 프로젝트에 있고, 기존 `Vanadium.Note.REST.Tests`는 REST 프로젝트만 참조하는 순수 net10.0 어셈블리라 `DraftStore`의 sessionStorage interop을 단위 테스트할 수 없음. Web 테스트 프로젝트 신규 추가는 의존성 확대라 이번 최소 변경 범위에서 제외 — 빌드/코드 검토로 검증.
- 배포 시 기존 `vanadium.editor-draft.v1` 단일 키에 남아있던 드래프트는 새 키 스킴과 호환되지 않아 고아가 되지만, sessionStorage는 탭 세션 한정이라 영향 미미(마이그레이션 미포함).

Closes #264
