### PR TITLE
#265 Ctrl+S를 flush-and-stay로 변경, Save & close 버튼 분리

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -48,7 +48,8 @@
         }
         @if (!IsArchived)
         {
-            <button class="btn btn-primary" @onclick="SaveNote">Save</button>
+            <button class="btn btn-outline-primary" @onclick="DoAutoSave">Save</button>
+            <button class="btn btn-primary" @onclick="SaveAndClose">Save &amp; close</button>
         }
     </div>
 </div>
@@ -474,7 +475,11 @@
             {
                 await JS.InvokeVoidAsync("tiptapInterop.init", _editorId, _objRef, content, apiBase, !IsArchived && !_loadFailed);
                 _editorMounted = true;
-                await ShortcutService.RegisterAsync("ctrl+s", "Save note", () => InvokeAsync(SaveNote));
+                // Ctrl+S flushes the current edit and STAYS in the editor (flush-and-stay),
+                // matching SubNoteDialog's Ctrl+S (OnSaveShortcut → DoAutoSave). Leaving to the
+                // list is the separate "Save & close" button, so a habitual Ctrl+S no longer
+                // ejects keyboard users from the editor (#265).
+                await ShortcutService.RegisterAsync("ctrl+s", "Save note", () => InvokeAsync(DoAutoSave));
             }
             catch (Exception ex)
             {
@@ -682,7 +687,10 @@
         saveStatusCss = css;
     }
 
-    private async Task SaveNote()
+    /// <summary>Flushes any pending edit and then navigates back to the list — the
+    /// explicit "Save &amp; close" action. Ctrl+S and the plain "Save" button use the
+    /// flush-and-stay <see cref="DoAutoSave"/> path instead and never leave the editor (#265).</summary>
+    private async Task SaveAndClose()
     {
         _autoSave.Cancel();
 


### PR DESCRIPTION
## 요약
Ctrl+S가 항상 저장 후 목록으로 이탈하던 동작을 **flush-and-stay**(즉시 저장 후 에디터 유지)로 바꾸고, 저장 후 목록 이동은 별도의 **"Save & close"** 버튼으로 분리한다. 이로써 NoteEditor의 Ctrl+S 의미가 SubNoteDialog의 Ctrl+S(`OnSaveShortcut → DoAutoSave`)와 일치한다.

## 변경 내용 (`NoteEditor.razor` 단일 파일)
- **Ctrl+S 등록**: `SaveNote` → `DoAutoSave`. `DoAutoSave`는 현재 편집을 즉시 플러시하고 에디터에 머무른다(신규 노트는 `/editor/{id}`로 replace 이동 = 에디터 유지). SubNoteDialog의 Ctrl+S와 동일한 경로·의미.
- **"Save" 버튼**: `DoAutoSave`로 연결해 마우스 사용자에게도 flush-and-stay 일관성을 제공(테두리 버튼).
- **"Save & close" 버튼 신설**: 기존 `SaveNote`의 저장→`Nav.NavigateTo(BackUrl)` 동작을 `SaveAndClose`로 이름만 바꿔 유지하고, 전용 primary 버튼으로 노출.

## 완료 조건 검증
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0. `dotnet test` 157 통과 / 3 스킵(기존 PostgreSQL 전용).
- [x] **Ctrl+S를 눌러도 이탈하지 않고 저장만 됨** — Ctrl+S → `DoAutoSave`. 기존 노트는 네비게이션 없음, 신규 노트는 자기 자신의 편집 URL로 replace(에디터 유지). (코드 검토; 브라우저 확인은 아래 수동 항목)
- [x] **'Save & close' 버튼으로 저장 후 목록 이동** — `SaveAndClose` → `Nav.NavigateTo(BackUrl)`.
- [x] **Ctrl+S가 SubNoteDialog와 동일한 flush-and-stay** — 양쪽 모두 `DoAutoSave`를 호출.

## 범위 / 참고
- 범위 밖(`KeyboardShortcutService`/`keyboard-shortcuts.js` 단축키 인프라, 자동저장 디바운스/`SaveCoreAsync` 진입점)은 건드리지 않음 — 단축키 콜백 대상과 버튼만 변경.
- **테스트:** 변경 대상이 Web(Blazor) UI/네비게이션이라 기존 `Vanadium.Note.REST.Tests`(REST 전용, net10.0)로는 자동 검증 불가(CLAUDE.md의 "Web 프로젝트 테스트 없음" 한계). 완료 조건에 테스트 요구 없음 — 빌드/코드 검토로 검증하고 런타임은 아래 수동 확인.

## 수동 확인 필요 (병합 전)
- 에디터에서 Ctrl+S → 상태가 "Saving…→Saved"로 바뀌고 페이지 이동 없이 머무는지.
- "Save & close" 클릭 → 저장 후 목록(BackUrl)으로 이동하는지.
- 신규 노트에서 Ctrl+S → `/editor/{id}`로 URL만 바뀌고 에디터에 남는지.

Closes #265
