### PR TITLE
#266 새 노트에서 /page 무반응 수정 — 강제 저장 후 하위 페이지 생성

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -888,15 +888,58 @@
     [JSInvokable]
     public async Task<PageLinkDto?> OnSlashCommandPage()
     {
-        if (!Id.HasValue) return null;
+        // A new, not-yet-persisted note has no id to parent a sub-page under. Rather than
+        // silently swallowing the command (the /page text just disappeared, #266), force-flush
+        // the first save so the note gets a real id, then create the child under it.
+        var parentId = _currentId;
+        if (!parentId.HasValue)
+        {
+            if (_hasConflict || IsArchived || _loadFailed)
+            {
+                Snackbar.Add("Save the note before adding a sub-page.", Severity.Warning);
+                return null;
+            }
+            parentId = await ForceFlushNewNoteAsync();
+            if (!parentId.HasValue)
+            {
+                // The flush couldn't persist the note (save failed / conflict). Surface it
+                // instead of leaving the user wondering why nothing happened.
+                Snackbar.Add("Couldn't save the note, so no sub-page was created.", Severity.Warning);
+                return null;
+            }
+        }
+
         var result = await NoteService.SaveAsync(new NoteItem
         {
             Id = Guid.Empty,
             Title = "Untitled",
-            ParentNoteId = Id,
+            ParentNoteId = parentId,
         });
-        if (!result.IsSuccess) return null;
+        if (!result.IsSuccess)
+        {
+            Snackbar.Add("Couldn't create the sub-page. Please try again.", Severity.Warning);
+            return null;
+        }
         return new PageLinkDto(result.Value!.Id, result.Value!.Title);
+    }
+
+    /// <summary>Persists the current new (unsaved) note so it gains a server id, mirroring the
+    /// new-note tail of <see cref="DoAutoSave"/> (persist labels, rebind <c>_currentId</c>, and
+    /// replace-navigate to <c>/editor/{id}</c> so the next save can't create a duplicate). Returns
+    /// the new id, or <c>null</c> if the save failed. Used by the <c>/page</c> command so a sub-page
+    /// can be created straight from a brand-new note (#266). Does not reuse DoAutoSave directly to
+    /// avoid its trailing cosmetic delay blocking the command.</summary>
+    private async Task<Guid?> ForceFlushNewNoteAsync()
+    {
+        _autoSave.Cancel();
+        var saved = await SaveCoreAsync();
+        if (saved is null)
+            return null;
+        await PersistNewNoteLabelsAsync(saved.Id);
+        _currentId = saved.Id;
+        _currentParentId = null;
+        Nav.NavigateTo($"/editor/{saved.Id}", replace: true);
+        return saved.Id;
     }
 
     [JSInvokable]


### PR DESCRIPTION
## 요약
새(미저장) 노트에서 `/page` 슬래시 커맨드를 실행하면 `OnSlashCommandPage`가 `Id` 없음으로 `null`을 반환하고 `slash-commands.js`가 이를 조용히 무시해, `/page` 텍스트만 사라지고 아무 피드백도 없던 문제를 고친다. **강제 플러시 방식**을 택해, 첫 저장을 즉시 플러시해 노트에 서버 id를 부여한 뒤 그 id를 부모로 하위 페이지를 생성한다.

## 변경 내용 (`NoteEditor.razor` 단일 파일)
- **`OnSlashCommandPage`**: 부모 후보를 `_currentId`로 잡고, 미저장(`!_currentId.HasValue`)이면 `ForceFlushNewNoteAsync`로 먼저 저장. 저장 불가(충돌/아카이브/로드 실패)·저장 실패 시에는 **스낵바로 안내**하고 반환 — 어떤 경로에서도 명령이 소리 없이 사라지지 않음.
- **`ForceFlushNewNoteAsync` 신설**: `SaveCoreAsync`로 새 노트를 영속화하고, `DoAutoSave`의 신규-노트 tail(라벨 영속화 → `_currentId`/`_currentParentId` 재바인딩 → `/editor/{id}`로 replace 이동)을 미러링해 **다음 저장에서 중복 노트가 생기지 않도록** 함. `DoAutoSave`를 직접 재사용하지 않은 이유는 그 말미의 2초 장식용 지연이 커맨드 응답을 막기 때문.

## 완료 조건 검증
- [x] **미저장 노트에서 /page 실행 시 피드백 제공** — met. 성공 경로는 하위 페이지 생성, 실패 경로는 스낵바 안내.
- [x] **강제 플러시 방식: 첫 저장 후 하위 페이지 정상 생성** — met(코드 검토). `ForceFlushNewNoteAsync` 성공 시 새 id를 부모로 `NoteService.SaveAsync` 호출. 런타임 확인은 아래 수동 항목.
- [x] **빌드 클린** — met. `dotnet build Vanadium.slnx` 경고 0/오류 0, `dotnet test` 157 통과/3 스킵(기존 PostgreSQL 전용).

## 범위 / 참고
- 범위 밖(PageLink 직렬화·slash-commands 등록 구조, 자동저장 디바운스/단일 저장 진입점 구조)은 건드리지 않음 — `SaveCoreAsync`는 호출만 하고 구조 변경 없음, `slash-commands.js` 미변경.
- **테스트:** 변경 대상이 Web(Blazor) JS-interop/네비게이션이라 기존 `Vanadium.Note.REST.Tests`(REST 전용)로는 자동 검증 불가(CLAUDE.md "Web 프로젝트 테스트 없음" 한계). 완료 조건에 테스트 요구 없음 — 빌드/코드 검토로 검증.

## 수동 확인 필요 (병합 전)
- `/editor`로 새 노트를 만들고(저장 전) 본문에서 `/page` 실행 → 노트가 저장되며 URL이 `/editor/{id}`로 바뀌고, 하위 페이지 링크가 본문에 삽입되는지.
- 저장 직후 다시 저장(자동/Ctrl+S)해도 **중복 노트가 생기지 않는지**.
- 충돌(409) 상태 등 저장 불가 상황에서 `/page` 실행 시 스낵바 안내가 뜨는지.

Closes #266
