### PR TITLE
#267 드래프트 복원 타임스탬프 비교 — 최신 서버본 덮어쓰기 방지 + 선택 배너

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -75,6 +75,17 @@
     </div>
 }
 
+@if (_pendingDraft is not null)
+{
+    <div class="conflict-banner">
+        <span>⚠ This note changed on the server after your unsaved draft was stashed. Keep which version?</span>
+        <div class="conflict-banner-actions">
+            <button class="btn btn-sm btn-primary" @onclick="KeepDraft">Keep my draft</button>
+            <button class="btn btn-sm btn-outline-secondary" @onclick="DiscardDraft">Use server version</button>
+        </div>
+    </div>
+}
+
 @if (_loadFailed)
 {
     <div class="load-error-banner">
@@ -297,6 +308,9 @@
     private bool _loadFailed = false;
     private bool _editorInitFailed = false;
     private DateTime _serverUpdatedAt;
+    // A draft that was NOT auto-restored because the server copy is newer than the draft's
+    // stash time (#267). Non-null drives the "keep my draft vs use server version" banner.
+    private EditorDraft? _pendingDraft;
     // One-shot flag: the user pressed "Force Save" in the conflict banner, so the
     // next save must send the explicit force opt-in (#221). Consumed and reset by
     // the save entry point — a default/zero version alone no longer force-saves.
@@ -420,10 +434,24 @@
             var draft = await DraftStore.GetAsync(Id);
             if (draft is not null)
             {
-                title = draft.Title;
-                content = draft.Content;
-                HasPendingChanges = true;
-                Snackbar.Add("Restored your unsaved changes.", Severity.Info);
+                // Multi-device guard (#267): if the server copy was updated AFTER this draft was
+                // stashed, another device saved in the meantime. Auto-restoring would let the stale
+                // draft's next autosave — riding the freshly-GET'd _serverUpdatedAt — pass the
+                // concurrency check and silently clobber the newer server copy. Offer a choice
+                // banner instead, keeping the just-loaded server content on screen until the user
+                // decides. New notes (no server version) and the single-device case (server not
+                // newer) fall through to the unconditional restore below, unchanged.
+                if (Id is not null && AsUtc(_serverUpdatedAt) > AsUtc(draft.StashedAt))
+                {
+                    _pendingDraft = draft;
+                }
+                else
+                {
+                    title = draft.Title;
+                    content = draft.Content;
+                    HasPendingChanges = true;
+                    Snackbar.Add("Restored your unsaved changes.", Severity.Info);
+                }
             }
         }
 
@@ -779,6 +807,40 @@
         await JS.InvokeVoidAsync("tiptapInterop.setContent", _editorId, content);
         StateHasChanged();
     }
+
+    /// <summary>Resolves the #267 draft-choice banner by keeping the local draft: applies the
+    /// stashed title/content over the server copy on screen and marks it pending so the next save
+    /// (a deliberate overwrite the user chose) persists it. Mirrors <see cref="ReloadNote"/>'s
+    /// setContent push into the mounted editor.</summary>
+    private async Task KeepDraft()
+    {
+        if (_pendingDraft is null) return;
+        title = _pendingDraft.Title;
+        content = _pendingDraft.Content;
+        _pendingDraft = null;
+        HasPendingChanges = true;
+        if (_editorMounted)
+            await JS.InvokeVoidAsync("tiptapInterop.setContent", _editorId, content);
+        StateHasChanged();
+    }
+
+    /// <summary>Resolves the #267 draft-choice banner by discarding the local draft: keeps the
+    /// already-loaded server copy on screen and clears the stale draft so it won't prompt again.</summary>
+    private async Task DiscardDraft()
+    {
+        if (_pendingDraft is null) return;
+        _pendingDraft = null;
+        await DraftStore.ClearAsync(Id);
+        StateHasChanged();
+    }
+
+    // Normalizes a DateTime to UTC for ordering. Server UpdatedAt and the draft's StashedAt are
+    // both UTC by construction; an Unspecified-kind value (e.g. from JSON without an offset) is
+    // treated as already-UTC rather than shifted through the local zone (#267).
+    private static DateTime AsUtc(DateTime value) =>
+        value.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            : value.ToUniversalTime();
 
     private async Task DeleteNote()
     {

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -371,6 +371,10 @@
         noteLabels = [];
         backlinks = [];
         _hasConflict = false;
+        // Drop any unresolved #267 draft-choice banner from the outgoing note so it can't leak
+        // onto the incoming note across this reused component instance (a stale _pendingDraft
+        // would show the wrong banner and Keep-my-draft would apply the wrong note's draft).
+        _pendingDraft = null;
         _loadFailed = false;
         _saveInFlight = null;
         _serverUpdatedAt = default;

--- a/Vanadium.Note.Web/Services/DraftStore.cs
+++ b/Vanadium.Note.Web/Services/DraftStore.cs
@@ -25,7 +25,9 @@ public class DraftStore(IJSRuntime js, ILogger<DraftStore> logger)
     {
         try
         {
-            var json = JsonSerializer.Serialize(new EditorDraft(noteId, title, content));
+            // Stamp the stash time (UTC) so the editor can compare it against the server's
+            // UpdatedAt on restore and avoid clobbering a newer server copy (issue #267).
+            var json = JsonSerializer.Serialize(new EditorDraft(noteId, title, content, DateTime.UtcNow));
             await js.InvokeVoidAsync("sessionStorage.setItem", StorageKey(noteId), json);
         }
         catch (Exception ex)

--- a/Vanadium.Note.Web/Services/EditorDraft.cs
+++ b/Vanadium.Note.Web/Services/EditorDraft.cs
@@ -5,6 +5,9 @@ namespace Vanadium.Note.Web.Services;
 /// <c>sessionStorage</c> when a save fails mid-session (e.g. an auth-expiry 401),
 /// so the unsaved work can be restored when the same note is reopened after
 /// re-login (issue #117). <see cref="NoteId"/> is <c>null</c> for a new,
-/// not-yet-persisted note.
+/// not-yet-persisted note. <see cref="StashedAt"/> is the UTC instant the draft was
+/// stashed; the editor compares it against the server's <c>UpdatedAt</c> on restore so
+/// a stale draft from another device does not silently overwrite a newer server copy
+/// (issue #267).
 /// </summary>
-public record EditorDraft(Guid? NoteId, string Title, string Content);
+public record EditorDraft(Guid? NoteId, string Title, string Content, DateTime StashedAt);


### PR DESCRIPTION
## 요약
드래프트 복원이 타임스탬프 비교 없이 무조건 적용돼, 다기기 사용 시 구본 드래프트가 최신 서버본을 덮을 수 있던 문제를 고친다. 드래프트에 **스태시 시각(UTC)** 을 저장하고, 복원 시 서버 `UpdatedAt`이 그보다 최신이면 자동 복원하지 않고 **선택 배너**(내 드래프트 유지 / 서버본 사용)를 제공한다.

## 변경 내용 (Web 3개 파일)
- **`EditorDraft.cs`**: 레코드에 `DateTime StashedAt` 추가.
- **`DraftStore.cs`**: `SaveAsync`에서 `StashedAt = DateTime.UtcNow` 스탬프(호출부 시그니처 불변 — 모든 스태시 경로가 자동으로 시각 기록).
- **`NoteEditor.razor`**:
  - 복원 블록: `Id is not null && AsUtc(_serverUpdatedAt) > AsUtc(draft.StashedAt)` 이면 `_pendingDraft`에 담고 배너 표시(방금 GET한 서버 내용을 화면에 유지). 아니면 기존과 동일하게 무조건 복원.
  - 선택 배너 UI(기존 conflict-banner 스타일 재사용) + `KeepDraft`(드래프트 적용 후 `setContent`)/`DiscardDraft`(서버본 유지 + `ClearAsync`) 핸들러.
  - `AsUtc` 헬퍼: 서버/드래프트 시각을 UTC로 정규화해 비교(Unspecified는 로컬 변환 없이 UTC로 간주).

## 완료 조건 검증
- [x] **드래프트에 스태시 시각 저장** — met. `EditorDraft.StashedAt`, `SaveAsync`에서 UTC 스탬프.
- [x] **서버 UpdatedAt이 스태시 시각보다 최신이면 선택지 배너 제공** — met. 조건 충족 시 `_pendingDraft` → 배너, 무조건 덮어쓰기 안 함.
- [x] **단일 기기(서버본이 더 최신 아님)에서는 기존과 동일 복원** — met. `else` 분기가 기존 로직 그대로. 신규 노트(`Id` null)도 배너 없이 복원.
- [x] **빌드 클린** — met. build 경고 0/오류 0, test 157 통과/3 스킵(기존).

## 범위 / 참고
- 범위 밖(서버측 낙관적 동시성(409) 판정, sessionStorage 저장 매체 자체)은 건드리지 않음 — 매체는 그대로 sessionStorage이고 페이로드에 시각 필드만 추가.
- **설계 메모(비차단):** 이슈 사양대로 **스태시 시각** 기준으로 비교한다. 드래프트가 기반한 로드 시점 서버 버전 기준이 아니라 스태시 시각 기준이므로, "A 로드 후 · A 스태시 전"에 B가 저장한 극히 드문 구간은 감지하지 않는다(이슈가 명시한 비교 기준). 하위 심각도이며 완료 조건과 일치.
- 하위호환: 이전 스킴(시각 없음)으로 저장된 드래프트는 `StashedAt`이 기본값(MinValue)이라 서버본이 항상 최신으로 판정 → 배너 노출(보수적·안전). sessionStorage는 세션 한정이라 영향 미미.
- **테스트:** 변경 대상이 Web(Blazor) UI/JS-interop이라 기존 `Vanadium.Note.REST.Tests`(REST 전용)로는 자동 검증 불가(CLAUDE.md "Web 프로젝트 테스트 없음" 한계). 완료 조건에 테스트 요구 없음.

## 수동 확인 필요 (병합 전)
- 다기기 재현: 기기 A에서 편집 중 스태시 → 기기 B에서 같은 노트 저장 → A에서 재오픈 시 **배너**가 뜨고, 서버 내용이 화면에 유지되는지.
- '내 드래프트 유지' → 드래프트 내용이 에디터에 반영되고 이후 저장으로 반영되는지 / '서버본 사용' → 서버 내용 유지 + 드래프트가 지워져 재오픈 시 다시 묻지 않는지.
- 단일 기기(중간에 다른 기기 저장 없음) 스태시 → 재오픈 시 배너 없이 기존처럼 복원되는지.

Closes #267
