### PR TITLE
#269 'New note' 단축키를 Ctrl+N → Alt+N으로 교체 (Chromium 예약키 회피)

### DIFF
--- a/Vanadium.Note.Web/Layout/MainLayout.razor
+++ b/Vanadium.Note.Web/Layout/MainLayout.razor
@@ -90,7 +90,10 @@
             await LoadThemeAsync();
             await TokenStore.InitAsync();
             await ShortcutService.InitAsync();
-            await ShortcutService.RegisterAsync("ctrl+n", "New note", () => InvokeAsync(() =>
+            // Alt+N, not Ctrl+N: Chromium-family browsers reserve Ctrl+N (new window) and never
+            // deliver it to page content, so preventDefault has no chance to run and the shortcut
+            // could never open a note. Alt+N is not browser-reserved and actually reaches us (#269).
+            await ShortcutService.RegisterAsync("alt+n", "New note", () => InvokeAsync(() =>
             {
                 Nav.NavigateTo("/editor");
                 return Task.CompletedTask;
@@ -196,6 +199,6 @@
         ThemeService.OnChanged -= OnThemeServiceChanged;
         AuthStateProvider.AuthenticationStateChanged -= OnAuthStateChanged;
         Nav.LocationChanged -= OnLocationChanged;
-        await ShortcutService.UnregisterManyAsync("ctrl+n", "ctrl+/", "ctrl+k");
+        await ShortcutService.UnregisterManyAsync("alt+n", "ctrl+/", "ctrl+k");
     }
 }


### PR DESCRIPTION
## 요약
'New note' 단축키가 `Ctrl+N`으로 등록돼 있었으나, Chromium 계열은 Ctrl+N을 새 창 단축키로 예약해 웹 콘텐츠에 전달하지 않으므로 `preventDefault`가 실행될 기회조차 없어 새 노트가 절대 열리지 않았다(도움말에는 표시돼 앱 버그로 오인). 브라우저 비예약 키인 **`Alt+N`** 으로 교체한다.

## 변경 내용 (`MainLayout.razor` 단일 파일, 2줄)
- `RegisterAsync("ctrl+n", "New note", …)` → `RegisterAsync("alt+n", …)`.
- 정리 경로 `UnregisterManyAsync("ctrl+n", …)` → `UnregisterManyAsync("alt+n", …)`.

도움말 표기는 `FormatKey`가 등록 키에서 파생(`alt` → `Alt`)하므로 자동으로 "Alt+N"으로 갱신되고, `keyboard-shortcuts.js`의 `_buildKey`는 이미 `e.altKey → 'alt'`를 처리하므로 인프라 변경이 필요 없다.

## 완료 조건 검증
- [x] **비예약 키로 교체** — met. `alt+n` 등록.
- [x] **Chromium에서 실제로 새 노트를 연다** — met(코드 검토). Alt+N은 페이지에 전달되어 `_onKeyDown`이 `preventDefault` 후 `HandleShortcut("alt+n")` → `/editor`로 이동. 런타임 확인은 아래 수동 항목.
- [x] **도움말 표시가 실제 동작 키와 일치** — met. 도움말은 등록 키를 `FormatKey`로 렌더 → "Alt+N".
- [x] **빌드 클린** — met. build 경고 0/오류 0, test 157 통과/3 스킵(기존).

## 범위 / 참고
- 범위 밖(KeyboardShortcutService/keyboard-shortcuts.js 인프라 구조, ctrl+k/s// 등 기존 단축키)은 건드리지 않음. `keyboard-shortcuts.js`의 "Ctrl+N" 언급은 수식키 조합의 일반 예시 주석이라 그대로 두었다.
- `alt+n`은 `_inputSafe`가 아니므로 기존 `ctrl+n`과 동일하게 텍스트 입력 중에는 발동하지 않는다(의도된 동작 유지).
- **테스트:** 변경 대상이 Web(Blazor) 단축키 등록/JS-interop이라 기존 `Vanadium.Note.REST.Tests`(REST 전용)로는 자동 검증 불가(CLAUDE.md "Web 프로젝트 테스트 없음" 한계). 완료 조건에 테스트 요구 없음.

## 수동 확인 필요 (병합 전)
- Chrome/Edge에서 `Alt+N` → 새 노트(`/editor`)가 열리는지(새 브라우저 창이 아니라).
- `Ctrl+/` 도움말에 'New note = Alt+N'으로 표시되는지.
- 제목/검색 입력란에 포커스가 있을 때 `Alt+N`이 발동하지 않는지(기존 동작 유지).

Closes #269
