### PR TITLE
#271 보드 카드 이동을 AddLabelToNoteAsync 단일 호출로 원자화

### DIFF
--- a/Vanadium.Note.REST.Tests/LabelMutualExclusionTests.cs
+++ b/Vanadium.Note.REST.Tests/LabelMutualExclusionTests.cs
@@ -1,0 +1,39 @@
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Issue #271: the Board card-move persists a move with a SINGLE AddLabelToNoteAsync call
+/// (no separate remove), relying on the server enforcing category mutual exclusion — adding a
+/// category label removes any existing sibling label in the same category, atomically in one
+/// SaveChanges. This characterizes that invariant so the client's single-call move stays correct:
+/// the old column label is dropped, the new one added, and labels in other categories are kept.
+/// </summary>
+public class LabelMutualExclusionTests
+{
+    [Fact]
+    public async Task AddLabel_SameCategorySibling_RemovesOldKeepsOtherCategories()
+    {
+        using var h = new TestHost();
+
+        var status = await h.Labels.CreateCategoryAsync("Status");
+        var todo = await h.Labels.CreateLabelAsync("Todo", status.Id);
+        var done = await h.Labels.CreateLabelAsync("Done", status.Id);
+        var general = await h.Labels.CreateLabelAsync("pinned", null);
+
+        var note = await h.CreateNoteAsync();
+        await h.Labels.AddLabelToNoteAsync(note.Id, todo.Id);
+        await h.Labels.AddLabelToNoteAsync(note.Id, general.Id);
+
+        // The Board move: add the sibling label in the same category with NO prior remove call.
+        await h.Labels.AddLabelToNoteAsync(note.Id, done.Id);
+
+        var loaded = await h.Notes.Get(note.Id);
+        Assert.NotNull(loaded);
+        var labelIds = loaded!.Labels.Select(l => l.Id).ToHashSet();
+
+        Assert.Contains(done.Id, labelIds);        // moved-to column label is present
+        Assert.DoesNotContain(todo.Id, labelIds);  // moved-from label auto-removed (mutual exclusion)
+        Assert.Contains(general.Id, labelIds);      // an unrelated general label is untouched
+    }
+}

--- a/Vanadium.Note.Web/Pages/Board.razor
+++ b/Vanadium.Note.Web/Pages/Board.razor
@@ -278,13 +278,15 @@
         Logger.LogInformation("Moving note {NoteId}: label {FromLabel} → {ToLabel}.",
             noteId, fromLabelId, toLabelId);
 
-        // Persist to server
-        var removeResult = await LabelService.RemoveLabelFromNoteAsync(noteId, fromLabelId);
-        var addResult = removeResult.IsSuccess
-            ? await LabelService.AddLabelToNoteAsync(noteId, toLabelId)
-            : ServiceResult<bool>.Fail("Remove failed");
+        // Persist to server with a SINGLE add. Board columns are labels of one category, so the
+        // server's category mutual-exclusion (adding a label removes any sibling in the same
+        // category, atomically in one SaveChanges) both drops the old label and adds the new one.
+        // A separate remove call would leave a window where a mid-move failure strips the note's
+        // label and drops it from every column; the single add has no such partial-failure mode —
+        // on failure the server is unchanged and the note keeps its original label (#271).
+        var addResult = await LabelService.AddLabelToNoteAsync(noteId, toLabelId);
 
-        if (!removeResult.IsSuccess || !addResult.IsSuccess)
+        if (!addResult.IsSuccess)
         {
             Logger.LogError(
                 "Failed to persist label move for note {NoteId} ({FromLabel} → {ToLabel}).",


### PR DESCRIPTION
## 요약
보드 카드 이동이 `RemoveLabelFromNoteAsync` → `AddLabelToNoteAsync` **2단계**로 이뤄져, remove 성공 후 add 실패 시 노트가 라벨을 잃고 어느 컬럼에서도 사라지던 문제를 고친다. 서버가 카테고리 내 상호배제를 **단일 `SaveChanges`** 로 강제하므로, `AddLabelToNoteAsync` **한 번**이면 이전 라벨 제거 + 새 라벨 추가가 원자적으로 끝난다.

## 변경 내용
- **`Board.razor` (`OnDropFromJs`)**: 영속화 로직을 `RemoveLabelFromNoteAsync` + `AddLabelToNoteAsync` 2단계에서 `AddLabelToNoteAsync` **단일 호출**로 교체. 실패 시 기존 낙관적 롤백 + `LoadNotesForCurrentCategory` 재동기화는 그대로 유지.
- **`LabelMutualExclusionTests.cs` (신규)**: 서버 불변식(같은 카테고리 라벨을 add하면 형제 라벨이 원자적으로 제거되고 다른 카테고리 라벨은 보존)을 고정하는 특성 테스트.

## 완료 조건 검증
- [x] **AddLabelToNoteAsync 단일 호출, 별도 remove 없음** — met. `OnDropFromJs`가 add 한 번만 호출.
- [x] **이동 후 목적 컬럼에만 나타나고 원본 카테고리 라벨은 서버 상호배제로 자동 제거** — met. `LabelService.AddLabelToNoteAsync`가 같은 `CategoryId` 라벨을 `RemoveRange` 후 add를 한 `SaveChanges`로 처리(서버 측 121–140행). 신규 테스트로 검증.
- [x] **단일 호출 실패 시에도 노트가 기존 라벨/컬럼을 잃지 않음** — met. 실패 시 서버는 불변(부분 상태 없음)이며, 클라이언트는 `originalLabels`로 롤백 후 재동기화.
- [x] **빌드 클린** — met. build 경고 0/오류 0, test **158 통과**/3 스킵(신규 1건 포함).

## 범위 / 참고
- 범위 밖(서버측 상호배제 강제 로직, 보드 DnD UI 인터랙션 구조)은 건드리지 않음 — 클라이언트 영속화 호출만 축소, 서버 로직은 **의존**하되 변경하지 않음.
- **테스트 메모:** 실제 변경 지점(`Board.razor`)은 Web(Blazor)이라 REST 테스트 하네스로 직접 단위 테스트 불가(CLAUDE.md "Web 프로젝트 테스트 없음"). 대신 이 수정의 정확성이 전적으로 의존하는 **서버 불변식**(AC #2)이 그동안 미검증 상태였기에, 이를 고정하는 특성 테스트를 `Vanadium.Note.REST.Tests`에 추가했다(내 클라이언트 변경 전에도 통과하는 성격 — fail-before 회귀가 아니라 의존 불변식 잠금).

## 수동 확인 필요 (병합 전)
- 보드에서 같은 카테고리 컬럼 간 카드 드래그 → 목적 컬럼에만 나타나고 원본 컬럼에서 사라지는지.
- 이동 중 네트워크 오류(예: 오프라인)로 add 실패 시 → 스낵바 안내와 함께 카드가 **원본 컬럼/라벨을 유지**하는지(어디에서도 사라지지 않는지).

Closes #271
