### PR TITLE
#274 공유 페이지에서 Toggle/Accordion 펼침 가능하도록 상호작용 부착

### DIFF
--- a/Vanadium.Note.Web/Pages/Share.razor
+++ b/Vanadium.Note.Web/Pages/Share.razor
@@ -108,6 +108,19 @@
             // Cosmetic fallback only — never break the note over it.
             Console.Error.WriteLine($"Failed to apply shared media placeholders: {ex.Message}");
         }
+
+        try
+        {
+            // The raw dump has no Tiptap node view, so Toggle/Accordion blocks lack
+            // the arrow + click handler and render broken. Rebuild them so collapsed
+            // bodies can be expanded and read on the anonymous page (#274).
+            await JS.InvokeVoidAsync("tiptapInterop.enableSharedToggles", _contentRef);
+        }
+        catch (JSException ex)
+        {
+            // Read-only page: a toggle-enhancement failure must not break the note.
+            Console.Error.WriteLine($"Failed to enable shared toggles: {ex.Message}");
+        }
     }
 
     // Poll the tiptapInterop.ready() gate until the module is installed (the

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -511,6 +511,19 @@ window.tiptapInterop = {
                 const willOpen = toggle.getAttribute('data-open') === 'false';
                 toggle.setAttribute('data-open', willOpen ? 'true' : 'false');
                 arrow.setAttribute('aria-expanded', String(willOpen));
+                // Accordion parity: opening a toggle inside an accordion group collapses
+                // its siblings, mirroring the editor's one-open-at-a-time behavior (#274).
+                if (willOpen) {
+                    const group = toggle.closest('[data-type="accordion-group"]');
+                    if (group) {
+                        for (const sib of group.querySelectorAll(':scope > [data-type="toggle"]')) {
+                            if (sib === toggle) continue;
+                            sib.setAttribute('data-open', 'false');
+                            const sibArrow = sib.querySelector(':scope > .toggle-arrow');
+                            if (sibArrow) sibArrow.setAttribute('aria-expanded', 'false');
+                        }
+                    }
+                }
             };
             arrow.addEventListener('click', flip);
             // A read-only page can't edit the summary, so make the whole summary a

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -467,6 +467,62 @@ window.tiptapInterop = {
         }
     },
 
+    // Make Toggle / Accordion blocks interactive in a read-only shared view. The
+    // shared content is a raw HTML dump, so the Tiptap node view never runs: toggles
+    // have no arrow, no `.toggle-inner` wrapper (which the folding CSS keys off of),
+    // and no click handler, leaving a collapsed body broken and unreadable (issue
+    // #274). Rebuild the exact node-view DOM structure so the existing app.css rules
+    // apply (arrow rotation + `[data-open="false"] > .toggle-inner >
+    // [data-type="toggle-content"] { display:none }`) and wire a click to flip
+    // data-open. Accordions are just groups of toggle blocks, so they are covered
+    // too; the editor-only "one open at a time" constraint is intentionally not
+    // enforced on this read-only page. Pass a CSS selector string or a DOM element.
+    enableSharedToggles(root) {
+        const el = typeof root === 'string' ? document.querySelector(root) : root;
+        if (!el) return;
+
+        for (const toggle of el.querySelectorAll('[data-type="toggle"]')) {
+            // Defensive: skip anything already rebuilt (e.g. a double invocation).
+            if (toggle.querySelector(':scope > .toggle-inner')) continue;
+
+            const summary = toggle.querySelector(':scope > [data-type="toggle-summary"]');
+            const content = toggle.querySelector(':scope > [data-type="toggle-content"]');
+            if (!summary || !content) continue;
+
+            const open = toggle.getAttribute('data-open') !== 'false';
+            toggle.setAttribute('data-open', open ? 'true' : 'false');
+
+            const arrow = document.createElement('button');
+            arrow.type = 'button';
+            arrow.className = 'toggle-arrow';
+            arrow.setAttribute('aria-expanded', String(open));
+            arrow.setAttribute('aria-label', 'Toggle section');
+            arrow.textContent = '▸'; // ▸
+
+            // Wrap summary + content in `.toggle-inner` and prepend the arrow,
+            // matching the editor node view so the existing CSS layout/folding works.
+            const inner = document.createElement('div');
+            inner.className = 'toggle-inner';
+            inner.append(summary, content);
+            toggle.prepend(arrow);
+            toggle.append(inner);
+
+            const flip = () => {
+                const willOpen = toggle.getAttribute('data-open') === 'false';
+                toggle.setAttribute('data-open', willOpen ? 'true' : 'false');
+                arrow.setAttribute('aria-expanded', String(willOpen));
+            };
+            arrow.addEventListener('click', flip);
+            // A read-only page can't edit the summary, so make the whole summary a
+            // click target too (except real links inside it) for an easier hit area.
+            summary.style.cursor = 'pointer';
+            summary.addEventListener('click', e => {
+                if (e.target.closest('a')) return;
+                flip();
+            });
+        }
+    },
+
     destroy(elementId) {
         const entry = _editors[elementId];
         if (entry) {

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -481,6 +481,14 @@ window.tiptapInterop = {
         const el = typeof root === 'string' ? document.querySelector(root) : root;
         if (!el) return;
 
+        // The server sanitizer strips the `class` attribute from stored content, so the
+        // shared dump keeps `data-type`/`data-open` but loses `toggle-block`, `toggle-summary`,
+        // `toggle-content`, `accordion-group` — the exact classes app.css keys its folding,
+        // flex layout and arrow rotation on. Restore them here (data-* survives, so we can
+        // re-derive every class) so the existing CSS applies without touching the sanitizer (#274).
+        for (const group of el.querySelectorAll('[data-type="accordion-group"]'))
+            group.classList.add('accordion-group');
+
         for (const toggle of el.querySelectorAll('[data-type="toggle"]')) {
             // Defensive: skip anything already rebuilt (e.g. a double invocation).
             if (toggle.querySelector(':scope > .toggle-inner')) continue;
@@ -491,6 +499,11 @@ window.tiptapInterop = {
 
             const open = toggle.getAttribute('data-open') !== 'false';
             toggle.setAttribute('data-open', open ? 'true' : 'false');
+
+            // Restore the sanitizer-stripped classes the folding/layout CSS depends on.
+            toggle.classList.add('toggle-block');
+            summary.classList.add('toggle-summary');
+            content.classList.add('toggle-content');
 
             const arrow = document.createElement('button');
             arrow.type = 'button';


### PR DESCRIPTION
## 요약
익명 공유 페이지(`/share/{token}`)에서 접힌 Toggle/Accordion을 **읽고 접기/펼치기**할 수 있게 한다. 공유 콘텐츠는 `(MarkupString)` 원시 HTML 덤프라 Tiptap 노드뷰가 실행되지 않아, 화살표·클릭·폴딩이 전혀 없었다. 공유 전용 JS로 상호작용을 부착하고, **sanitizer가 제거한 CSS 클래스까지 복원**해 기존 app.css 폴딩 규칙이 그대로 걸리도록 한다.

## 근본 원인 (조사로 확정)
1. **노드뷰 미실행:** 공유 페이지는 원시 HTML을 덤프하므로 편집기 노드뷰가 만드는 화살표 버튼/`.toggle-inner` 래퍼/클릭 핸들러가 없다.
2. **sanitizer의 `class` 제거(핵심):** `HtmlSanitizerService`는 `data-*`만 명시적으로 보존하고 **`class` 속성은 제거**한다. 그 결과 공유 HTML에는 `data-type`/`data-open`은 남지만 `toggle-block` 등 클래스가 사라져, 폴딩·플렉스 레이아웃·화살표 회전 CSS(전부 클래스 기반)가 매칭되지 않는다. (편집기는 Tiptap이 `data-type`로 재파싱하며 클래스를 다시 붙이므로 무관 — 공유 raw dump에서만 발생.)

## 변경 내용 (공유 페이지 한정, 서버 sanitizer 미변경)
| 커밋 | 내용 |
|---|---|
| `08783aa` | `tiptapInterop.enableSharedToggles` 신설 — `[data-type="toggle"]`의 summary/content를 `.toggle-inner`로 감싸고 `.toggle-arrow`를 prepend해 노드뷰 DOM 구조 재구성 + 클릭으로 `data-open` 토글. `Share.razor`에서 호출(mermaid/placeholder와 동일 패턴). |
| `2800321` | 아코디언 배타 동작 — 같은 `accordion-group` 안의 토글을 펼치면 형제가 접힘(편집기의 one-open-at-a-time 일치). |
| `5735e80` | **sanitizer가 벗겨낸 클래스 복원** — `toggle-block`/`toggle-summary`/`toggle-content`/`accordion-group`를 클라이언트에서 재도출해 기존 폴딩/레이아웃 CSS가 적용되게 함. |

## 완료 조건 검증
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0/오류 0, `dotnet test` 158 통과/3 스킵.
- [x] **공유 페이지에서 접힌 Toggle/Accordion 본문을 읽고 접기/펼치기** — 실제 브라우저에서 동작 확인(작성자 검증 완료). 브라우저 진단으로 근본 원인(class 제거) 확인 후 클래스 복원으로 해결.

## 범위 / 참고
- 범위 밖 준수: **SharedNote 필드 불변**(HTML만 처리), **에디터 tiptapInterop 경로/NoteEditor 미변경**(신규 헬퍼는 Share.razor에서만 호출), **서버 sanitizer 미변경**(class 허용으로 넓히지 않고 공유 페이지에서만 복원 — 저장 전반의 보안 표면을 넓히지 않기 위함).
- 임베드 이미지/첨부의 익명 렌더 한계는 별도 이슈.
- 접힘 헤딩(Collapsible heading)은 본 이슈 범위(Toggle/Accordion) 밖이며, 숨김이 런타임 데코레이션이라 공유 HTML엔 없어 이미 전부 보임.
- **테스트:** 변경 대상이 Web(Blazor)/JS-interop이라 REST 테스트 하네스로 자동 검증 불가(CLAUDE.md "Web 프로젝트 테스트 없음"). 빌드/`node --check`/jsdom 재현/브라우저 검증으로 확인.

Closes #274
