### PR TITLE
#279 멘션/슬래시/단축키 keydown에 한글 IME 조합 가드 추가

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/keyboard-shortcuts.js
+++ b/Vanadium.Note.Web/wwwroot/js/keyboard-shortcuts.js
@@ -23,6 +23,10 @@
     }
 
     function _onKeyDown(e) {
+        // Ignore keydown fired during IME composition (e.g. Hangul). The Enter
+        // that confirms a composition must not trigger a registered shortcut (#279).
+        if (e.isComposing || e.keyCode === 229) return;
+
         const key = _buildKey(e);
         if (!key || !_active.has(key)) return;
 

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/mention.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/mention.js
@@ -115,6 +115,10 @@ export function createMentionExtension(dotnetRef) {
                                 reposition(props.clientRect);
                             },
                             onKeyDown({ event }) {
+                                // Ignore keys fired during IME composition (e.g. Hangul).
+                                // The Enter that confirms a composition must not be consumed
+                                // as a menu selection (#279).
+                                if (event.isComposing || event.keyCode === 229) return false;
                                 if (event.key === 'ArrowUp') {
                                     if (!currentItems.length) return false;
                                     event.preventDefault();

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/slash-commands.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/slash-commands.js
@@ -118,6 +118,10 @@ export function createSlashCommandsExtension(dotnetRef) {
                                 reposition(props.clientRect);
                             },
                             onKeyDown({ event }) {
+                                // Ignore keys fired during IME composition (e.g. Hangul).
+                                // The Enter that confirms a composition must not be consumed
+                                // as a menu selection (#279).
+                                if (event.isComposing || event.keyCode === 229) return false;
                                 if (!currentItems.length) return false;
                                 if (event.key === 'ArrowUp') {
                                     event.preventDefault();


### PR DESCRIPTION
Closes #279

## 문제
`wwwroot/js` 전체에 IME 조합 가드(`isComposing`/`keyCode === 229`)가 없어, `@`(멘션)·`/`(슬래시) 뒤에서 한글 이름을 조합하다 조합 확정 Enter를 누르면 해당 Enter가 메뉴 항목 선택으로 오소비되어 원치 않는 멘션/슬래시 삽입과 글자 유실·중복이 발생했다.

## 변경
세 keydown 핸들러 첫 줄에 조합 가드를 추가해, 조합 중 발생한 키를 선택·단축키로 소비하지 않도록 했다.

- `tiptap/extensions/mention.js` — `onKeyDown` 첫 줄 가드
- `tiptap/extensions/slash-commands.js` — `onKeyDown` 첫 줄 가드
- `keyboard-shortcuts.js` — `_onKeyDown` 첫 줄 가드

비조합(영문 등) Enter 선택 동작은 가드가 트리거되지 않으므로 기존과 동일하게 유지된다. tiptapInterop.* 경로 및 NoteEditor.razor 호출 규약은 변경하지 않았다.

## 완료 조건 검증
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0
- [x] mention/slash `onKeyDown`이 조합 중(`isComposing`/`keyCode 229`) Enter를 소비하지 않음 — 가드가 `return false`로 조기 반환
- [ ] 한글 조합 확정 Enter로 원치 않는 멘션/슬래시 항목 삽입이 발생하지 않음 — **수동 검증 필요** (Web 프로젝트에 JS 테스트 인프라 없음)

전체 테스트: 통과 158 / 건너뜀 3 / 실패 0.