### PR TITLE
#309 link-popover의 document mousedown 리스너 미해제 누수 수정

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -557,6 +557,7 @@ window.tiptapInterop = {
             entry.blobUrlCache.clear();
             entry.editor.destroy();
             entry.bubbleMenuEl.remove();
+            document.removeEventListener('mousedown', entry.linkPopover.onDocumentMouseDown);
             entry.linkPopover.popover.remove();
             delete _editors[elementId];
             console.debug(`[tiptap] Editor destroyed: ${elementId}`);

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/ui/link-popover.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/ui/link-popover.js
@@ -57,15 +57,17 @@ export function createLinkPopover(editorId) {
         if (e.key === 'Escape') { _editors[editorId]?.editor.commands.focus(); hide(); }
     });
 
-    // Click outside → close
-    document.addEventListener('mousedown', (e) => {
+    // Click outside → close. Keep a reference to the handler so `destroy` can
+    // detach it; otherwise every editor instance leaks a live document listener.
+    const onDocumentMouseDown = (e) => {
         if (popover.style.display !== 'none' && !popover.contains(e.target)) {
             _editors[editorId]?.editor.commands.focus();
             hide();
         }
-    });
+    };
+    document.addEventListener('mousedown', onDocumentMouseDown);
 
-    return { popover, input, hide };
+    return { popover, input, hide, onDocumentMouseDown };
 }
 
 export function showLinkPopover(editorId) {


### PR DESCRIPTION
## 요약
`createLinkPopover`가 에디터 인스턴스마다 `document`에 등록하는 "클릭 아웃사이드 닫기" `mousedown` 핸들러가 익명 함수라 `destroy`에서 해제할 수 없었다. 노트 에디터를 반복해서 열고 닫으면 해제되지 않은 죽은 클로저가 `document`에 누적되어 순수 메모리 누수가 발생한다(옵셔널 체이닝 덕에 오동작은 없음).

## 변경 사항
- `link-popover.js`: 클릭 아웃사이드 핸들러를 `onDocumentMouseDown`으로 명명하고 `createLinkPopover` 반환 객체에 포함시켜 외부에서 해제할 수 있게 함.
- `interop.js`: `destroy`에서 `document.removeEventListener('mousedown', entry.linkPopover.onDocumentMouseDown)`로 해당 핸들러를 해제.

클릭 아웃사이드 닫기 동작 자체는 그대로 유지하고 리스너 생명주기만 수정했다.

## 완료 조건 검증
- [x] `createLinkPopover`가 핸들러 참조(`onDocumentMouseDown`)를 반환하고 `destroy`에서 `removeEventListener`로 해제 — 코드 확인.
- [x] 에디터를 반복 열고 닫아도 `document` `mousedown` 리스너가 누적되지 않음 — `init`이 등록한 바로 그 핸들러 참조를 `destroy`가 해제하므로 1:1로 정리됨.
- [x] 빌드 클린 — `dotnet build Vanadium.Note.Web/Vanadium.Note.Web.csproj` 경고 0 / 오류 0 (REST exe가 실행 중이라 잠겨 있어 Web 프로젝트만 빌드; 변경은 Web wwwroot JS 한정).

## 참고
순수 프론트엔드 JS 변경으로, 이 영역을 커버하는 테스트 프로젝트가 없어 자동 회귀 테스트는 추가하지 않았다(`Vanadium.Note.REST.Tests`는 서버 로직만 커버).

Closes #309
