### PR TITLE
#268 Home 목록에 Settings의 정렬·페이지 크기 설정 반영

### DIFF
--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -1,6 +1,7 @@
 @page "/"
 @attribute [Authorize]
 @inject NoteService NoteService
+@inject SettingsService SettingsService
 @inject NavigationManager Nav
 @inject ConfirmService Confirm
 @inject ILogger<Home> Logger
@@ -271,7 +272,9 @@
 
     private int currentPage = 1;
     private int totalCount = 0;
-    private const int PageSize = 30;
+    // Seeded from the user's saved settings in OnInitializedAsync; falls back to 30 if
+    // settings fail to load. Not const because it is user-configurable (issue #268).
+    private int pageSize = 30;
     private bool isLoading = false;
     private bool loadFailed = false;
 
@@ -279,7 +282,7 @@
     private SortColumn currentSort = SortColumn.Date;
     private bool sortAscending = false;
 
-    private int TotalPages => Math.Max(1, (int)Math.Ceiling((double)totalCount / PageSize));
+    private int TotalPages => Math.Max(1, (int)Math.Ceiling((double)totalCount / pageSize));
     private bool IsAllSelected => notes.Count > 0 && notes.All(n => selectedIds.Contains(n.Id));
 
     private string SortIcon(SortColumn col)
@@ -290,7 +293,24 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ApplyUserSettings();
         await LoadNotes(includeLabels: true);
+    }
+
+    // Seed the sort column/direction and page size from the user's saved settings so the
+    // Notes List section in Settings actually takes effect on Home (issue #268). Unknown
+    // or missing values fall back to the existing defaults (date desc, 30 per page).
+    private async Task ApplyUserSettings()
+    {
+        var result = await SettingsService.GetAsync();
+        if (!result.IsSuccess || result.Value is null)
+            return;
+
+        var settings = result.Value;
+        currentSort = settings.DefaultSortBy == "title" ? SortColumn.Title : SortColumn.Date;
+        sortAscending = settings.DefaultSortDir == "asc";
+        if (settings.DefaultPageSize > 0)
+            pageSize = settings.DefaultPageSize;
     }
 
     // Retry after a failed load. Reload labels too if the initial load never delivered them.
@@ -320,7 +340,7 @@
             {
                 var result = await NoteService.GetAllAsync(
                     currentPage,
-                    PageSize,
+                    pageSize,
                     string.IsNullOrWhiteSpace(_searchText) ? null : _searchText,
                     currentSort == SortColumn.Title ? "title" : "date",
                     sortAscending ? "asc" : "desc",


### PR DESCRIPTION
## 요약
Settings 화면의 **Notes List** 섹션(Default sort by / Default sort direction / Notes per page)이 편집·저장은 되지만 Home 목록 어디에도 반영되지 않던 무음 no-op(#268)을 수정한다. Home.razor가 정렬·페이지 크기를 하드코딩(`PageSize=30`, 날짜 내림차순)하고 `SettingsService`를 소비하지 않은 것이 원인이었다.

## 변경 사항
- `Home.razor`에 `SettingsService` 주입.
- `OnInitializedAsync`에서 첫 로드 전에 `ApplyUserSettings()`를 호출해 `DefaultSortBy`→정렬 컬럼, `DefaultSortDir`→정렬 방향, `DefaultPageSize`→페이지 크기 초기값으로 주입.
- const였던 `PageSize`를 사용자 설정값을 담는 mutable 필드 `pageSize`로 변경(참조 3곳 갱신).
- 설정 로드 실패 또는 알 수 없는 값은 기존 기본값(date desc, 30/page)으로 그대로 폴백.

설정값은 Home의 `LoadNotes`가 이미 사용하던 문자열 표현("title"/"date", "asc"/"desc")과 그대로 대응하므로 매핑이 1:1로 맞는다.

## 완료 조건 검증
- [x] Home 초기화 시 `SettingsService`에서 `DefaultSortBy`/`DefaultSortDir`/`DefaultPageSize`를 읽어 정렬·페이지 크기 초기값으로 반영 — `OnInitializedAsync` → `ApplyUserSettings()`(`Home.razor`)에서 확인.
- [x] Settings에서 값을 바꿔 저장하면 Home 목록의 정렬·페이지 크기가 실제로 달라짐 — Blazor가 `/`로 진입할 때마다 컴포넌트를 재생성해 `OnInitializedAsync`가 재실행되므로 저장 후 Home 재진입 시 새 설정을 다시 읽어 반영.
- [x] (대안 미채택) 실제 반영을 구현했으므로 Notes List 섹션 제거는 하지 않음.
- [x] 빌드 클린 — `dotnet build Vanadium.Note.Web/Vanadium.Note.Web.csproj` 경고 0 / 오류 0.

## 범위 준수
- `SettingsService` 저장 스키마/`UserSettings` 싱글턴 구조 변경 없음.
- MainLayout의 테마 설정 소비 경로 변경 없음.
- 변경 파일은 `Home.razor` 하나.

## 참고
Blazor WASM 컴포넌트(`Home.razor`)의 `OnInitializedAsync` 동작 변경으로, Web 프로젝트에는 테스트 프로젝트가 없어(`Vanadium.Note.REST.Tests`는 서버/EF 로직 전용) 자동 회귀 테스트는 추가하지 않았다. 실제 UI 반영은 수동 확인이 필요하다.

Closes #268
