### PR TITLE
#284 로그인 returnUrl 오픈 리다이렉트 검증 추가

### DIFF
--- a/Vanadium.Note.Web/Pages/Login.razor
+++ b/Vanadium.Note.Web/Pages/Login.razor
@@ -61,8 +61,7 @@
 
         if (outcome == LoginOutcome.Success)
         {
-            var target = string.IsNullOrEmpty(ReturnUrl) ? "/" : Uri.UnescapeDataString(ReturnUrl);
-            Nav.NavigateTo(target);
+            Nav.NavigateTo(ResolveSafeReturnUrl());
         }
         else
         {
@@ -75,6 +74,19 @@
             };
             _isLoading = false;
         }
+    }
+
+    // Only redirect to a same-app absolute path after login. An external absolute URL
+    // (e.g. https://evil.example) or a scheme-relative URL (//evil.example) must never be
+    // a redirect target, so a returnUrl that does not start with a single '/' falls back
+    // to the app root — this closes the open-redirect on /login?returnUrl= (issue #284).
+    private string ResolveSafeReturnUrl()
+    {
+        if (string.IsNullOrEmpty(ReturnUrl))
+            return "/";
+
+        var target = Uri.UnescapeDataString(ReturnUrl);
+        return target.StartsWith('/') && !target.StartsWith("//") ? target : "/";
     }
 
     private class LoginModel


### PR DESCRIPTION
## 요약
`/login?returnUrl=` 오픈 리다이렉트(#284)를 수정한다. 기존 `Login.razor`는 `ReturnUrl`을 검증 없이 `Uri.UnescapeDataString` 후 `Nav.NavigateTo`에 넘겨, `/login?returnUrl=https://evil.example` 같은 링크로 유도된 소유자가 로그인 성공 직후 외부 도메인으로 이탈할 수 있었다.

## 변경 사항
- `ResolveSafeReturnUrl()` 헬퍼를 추가해, returnUrl이 **`/`로 시작하고 `//`로 시작하지 않는** 앱 내부 절대 경로일 때만 그 경로로 이동하고, 그 외(외부 절대 URL, 스킴 상대 URL, 빈 값)에는 `/`로 폴백한다.
- `HandleLogin`의 성공 분기가 이 헬퍼 결과로 이동하도록 교체.
- 인증/토큰 발급 로직은 전혀 건드리지 않음(범위 밖 준수) — 리다이렉트 대상 검증만 추가.

## 완료 조건 검증
- [x] returnUrl이 `/`로 시작하고 `//`로 시작하지 않을 때만 이동, 그 외에는 `/`로 폴백 — `ResolveSafeReturnUrl`의 `target.StartsWith('/') && !target.StartsWith("//")` 조건으로 구현.
- [x] `https://evil.example` / `//evil.example`로 로그인해도 외부 이탈 없음 — 검증:
  - `https://evil.example` → `/`로 시작하지 않음 → `/` 폴백.
  - `//evil.example` → `/`로 시작하나 `//`로도 시작 → `/` 폴백.
  - `/board`, `/editor/{id}` 등 정상 내부 경로는 그대로 유지, 빈/null은 기존과 동일하게 `/`.
- [x] 빌드 클린 — `dotnet build Vanadium.Note.Web/Vanadium.Note.Web.csproj` 경고 0 / 오류 0.

## 참고
검증 로직은 `Login.razor`의 `@code` 블록 내 컴포넌트 메서드라, Web 프로젝트에 테스트 프로젝트가 없고(`Vanadium.Note.REST.Tests`는 REST 프로젝트만 참조) 자동 회귀 테스트는 추가하지 않았다. 위 입력 벡터별 폴백 동작은 로그인 후 리다이렉트로 수동 확인 가능하다.

Closes #284
