### PR TITLE
#287 비보안 컨텍스트 클립보드 복사 실패 처리

### DIFF
--- a/Vanadium.Note.Web/Pages/Settings.razor
+++ b/Vanadium.Note.Web/Pages/Settings.razor
@@ -274,8 +274,18 @@
 
     private async Task CopyToken(string token)
     {
-        await JS.InvokeVoidAsync("navigator.clipboard.writeText", token);
-        Snackbar.Add("Token copied to clipboard.", Severity.Info);
+        // navigator.clipboard is undefined in non-secure (http) contexts, so the interop
+        // call throws a JSException. Handle it instead of letting it surface unhandled, and
+        // point the user at the read-only token field above for manual copy (issue #287).
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", token);
+            Snackbar.Add("Token copied to clipboard.", Severity.Info);
+        }
+        catch (JSException)
+        {
+            Snackbar.Add("Couldn't copy automatically. Select the token in the field above and copy it manually.", Severity.Warning);
+        }
     }
 
     private async Task DeleteAllDataAsync()

--- a/Vanadium.Note.Web/Pages/ShareDialog.razor
+++ b/Vanadium.Note.Web/Pages/ShareDialog.razor
@@ -124,8 +124,18 @@
     private async Task CopyLink()
     {
         if (string.IsNullOrEmpty(ShareUrl)) return;
-        await JS.InvokeVoidAsync("navigator.clipboard.writeText", ShareUrl);
-        Snackbar.Add("Link copied to clipboard.", Severity.Info);
+        // navigator.clipboard is undefined in non-secure (http) contexts, so the interop
+        // call throws a JSException. Handle it instead of letting it surface unhandled, and
+        // point the user at the read-only share-link field for manual copy (issue #287).
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", ShareUrl);
+            Snackbar.Add("Link copied to clipboard.", Severity.Info);
+        }
+        catch (JSException)
+        {
+            Snackbar.Add("Couldn't copy automatically. Select the link in the field above and copy it manually.", Severity.Warning);
+        }
     }
 
     private void Close() => MudDialog.Close();


### PR DESCRIPTION
## 요약
비보안(http) 컨텍스트에서 `navigator.clipboard`가 undefined라 복사 버튼 클릭 시 미처리 JSException이 발생하던 문제(#287)를 수정한다. 두 호출부(설정의 API 토큰 복사, 공유 다이얼로그의 링크 복사)를 try/catch로 감싸 실패를 처리하고, 실패 시 경고 스낵바로 화면의 읽기 전용 필드에서 수동 복사하도록 안내한다.

## 변경 사항
- `Settings.razor`의 `CopyToken`: `JS.InvokeVoidAsync("navigator.clipboard.writeText", ...)`를 try/catch로 감싸고, `JSException` 발생 시 "Couldn't copy automatically. Select the token in the field above and copy it manually." 경고 스낵바 표시.
- `ShareDialog.razor`의 `CopyLink`: 동일 패턴 적용(공유 링크 필드 안내 문구).
- 두 경우 모두 실패 시 안내 대상인 읽기 전용 선택 가능 필드가 이미 화면에 표시되어 있어(토큰 필드 / Share link 필드) 수동 선택 폴백이 성립한다.
- 보안 컨텍스트의 정상 복사 성공 경로와 토큰/공유 링크 생성 로직은 변경하지 않음(범위 밖 준수).

## 완료 조건 검증
- [x] 비보안 컨텍스트에서 복사 버튼 클릭 시 미처리 JSException이 발생하지 않음 — 두 메서드 모두 `catch (JSException)`으로 처리(`Microsoft.JSInterop`은 `_Imports.razor`에 이미 포함).
- [x] 복사 실패 시 실패 스낵바 표시 + 수동 복사 폴백 제공 — `Severity.Warning` 스낵바가 화면의 읽기 전용 필드에서 수동 복사하도록 안내.
- [x] 빌드 클린 — `dotnet build Vanadium.Note.Web/Vanadium.Note.Web.csproj` 경고 0 / 오류 0.

## 참고
두 호출부 모두 Blazor 컴포넌트 메서드라, Web 프로젝트에 테스트 프로젝트가 없어(`Vanadium.Note.REST.Tests`는 REST 전용) 자동 회귀 테스트는 추가하지 않았다. 비보안 컨텍스트에서의 실제 스낵바/폴백 동작은 http 배포에서 수동 확인이 필요하다.

Closes #287
