### PR TITLE
#288 백링크 로드 실패와 빈 결과 상태 분리

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -208,6 +208,13 @@
             {
                 <div class="backlinks-hint">Loading…</div>
             }
+            else if (_backlinksFailed)
+            {
+                <div class="backlinks-hint backlinks-error">
+                    <span>Couldn't load backlinks.</span>
+                    <button type="button" class="btn btn-sm btn-primary" @onclick="RetryBacklinks">Retry</button>
+                </div>
+            }
             else if (backlinks.Count == 0)
             {
                 <div class="backlinks-hint">No other notes link here yet.</div>
@@ -321,6 +328,7 @@
     // Backlinks ("what links here") state
     private List<BacklinkResult> backlinks = [];
     private bool _backlinksLoading = false;
+    private bool _backlinksFailed = false;
 
     // Label state
     private List<Label> noteLabels = [];
@@ -370,6 +378,7 @@
         childCount = 0;
         noteLabels = [];
         backlinks = [];
+        _backlinksFailed = false;
         _hasConflict = false;
         // Drop any unresolved #267 draft-choice banner from the outgoing note so it can't leak
         // onto the incoming note across this reused component instance (a stale _pendingDraft
@@ -474,12 +483,24 @@
     private async Task LoadBacklinksAsync(Guid noteId)
     {
         _backlinksLoading = true;
+        _backlinksFailed = false;
         var result = await NoteService.GetBacklinksAsync(noteId);
         // Ignore a stale response if the user navigated to another note while loading.
         if (_currentId != noteId) return;
-        backlinks = result.IsSuccess ? result.Value! : [];
+        // Distinguish a load failure from a genuinely empty result so the panel does not show
+        // the "no notes link here" empty state when the request actually errored (issue #288).
+        if (result.IsSuccess)
+            backlinks = result.Value!;
+        else
+            _backlinksFailed = true;
         _backlinksLoading = false;
         StateHasChanged();
+    }
+
+    private async Task RetryBacklinks()
+    {
+        if (Id is not null)
+            await LoadBacklinksAsync(Id.Value);
     }
 
     private async Task LoadLabelsAsync()

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor.css
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor.css
@@ -673,6 +673,15 @@
     opacity: 0.5;
 }
 
+/* Load-failure state must stay legible and actionable, so it overrides the dimmed
+   empty-state hint and lays the message out beside the Retry button (issue #288). */
+.backlinks-error {
+    opacity: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
 .backlinks-list {
     list-style: none;
     margin: 0;


### PR DESCRIPTION
## 요약
백링크 로드 실패 시 빈 결과와 구분되지 않아 잘못된 빈 상태('No other notes link here yet.')가 표시되던 문제(#288)를 수정한다. `LoadBacklinksAsync`가 `result.IsSuccess ? result.Value! : []`로 실패를 빈 목록과 동일하게 처리한 것이 원인이었다.

## 변경 사항
- `_backlinksFailed` 상태 필드 추가. 로드 시작 시 false로 초기화하고, 응답이 실패면 true로 설정(성공이면 결과를 반영).
- 백링크 패널 마크업에 로딩·빈 상태와 구분되는 **오류 상태 브랜치**(빈 상태 문구 앞) 추가 — "Couldn't load backlinks." 메시지 + **Retry** 버튼.
- `RetryBacklinks` 핸들러 추가(현재 노트 Id로 재조회).
- 컴포넌트 재사용 리셋 경로에서 `_backlinksFailed = false`로 초기화해 이전 노트의 오류 상태가 새 노트로 새지 않게 함.
- 스코프 CSS `.backlinks-error` 추가: 빈 상태 힌트의 `opacity: 0.5`를 덮어 오류 메시지를 또렷하게 하고 메시지와 Retry 버튼을 가로 배치.

## 완료 조건 검증
- [x] 로드 실패 시 빈 상태 문구 대신 오류 상태(및 재시도 수단) 표시 — `_backlinksFailed` 브랜치가 `backlinks.Count == 0` 빈 상태보다 먼저 평가되어 오류 메시지 + Retry 버튼 노출.
- [x] 실제 백링크가 없을 때는 기존 빈 상태 문구 유지 — 성공 + 빈 목록이면 `_backlinksFailed`가 false라 `No other notes link here yet.` 그대로 표시.
- [x] 빌드 클린 — `dotnet build Vanadium.Note.Web/Vanadium.Note.Web.csproj` 경고 0 / 오류 0.

## 범위 준수
- 백링크 조회 API/서버 로직 변경 없음.
- stale 응답 무시 로직(`_currentId != noteId`) 그대로 유지.

## 참고
`NoteEditor.razor` 컴포넌트 상태/마크업 변경이라, Web 프로젝트에 테스트 프로젝트가 없어(`Vanadium.Note.REST.Tests`는 REST 전용) 자동 회귀 테스트는 추가하지 않았다. 실패/빈/재시도 표시는 조회 실패를 유발한 상태에서 수동 확인이 필요하다.

Closes #288
