### PR TITLE
#289 all-data 삭제를 JWT 전용 + 비밀번호 재확인으로 잠금

### DIFF
--- a/Vanadium.Note.REST.Tests/SettingsControllerTests.cs
+++ b/Vanadium.Note.REST.Tests/SettingsControllerTests.cs
@@ -1,0 +1,94 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Vanadium.Note.REST.Controllers;
+using Vanadium.Note.REST.Models;
+using Vanadium.Note.REST.Security;
+using Vanadium.Note.REST.Services;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Owner-password re-confirmation on the all-data purge (issue #289). The JWT-only scheme
+/// restriction is an [Authorize] attribute exercised end-to-end in
+/// <see cref="SmokeE2E.SettingsPurgeAuthE2ETests"/>; here the in-controller password gate is
+/// tested directly, mirroring <see cref="ArchiveControllerTests"/>.
+/// </summary>
+public class SettingsControllerTests
+{
+    private const string OwnerPassword = "correct horse battery staple";
+
+    private static SettingsController CreateController(TestHost h, string? passwordHash)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Auth:PasswordHash"] = passwordHash })
+            .Build();
+        var controller = new SettingsController(
+            new SettingsService(h.Db), h.Account, config, NullLogger<SettingsController>.Instance)
+        {
+            ControllerContext = CreateContext()
+        };
+        return controller;
+    }
+
+    // A minimal context with RequestServices so ControllerBase.Problem() can resolve
+    // ProblemDetailsFactory. There is no user identity in the single-user model.
+    private static ControllerContext CreateContext()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMvcCore();
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.Name, AuthController.OwnerName)], "Test")),
+            RequestServices = services.BuildServiceProvider()
+        };
+        return new ControllerContext { HttpContext = httpContext };
+    }
+
+    [Fact]
+    public async Task DeleteAllData_WithWrongPassword_Returns403AndKeepsData()
+    {
+        using var h = new TestHost();
+        await h.CreateNoteAsync("Keep me");
+        var controller = CreateController(h, PasswordHasher.Hash(OwnerPassword));
+
+        var result = await controller.DeleteAllData(new DeleteAllDataRequest("wrong password"));
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status403Forbidden, objectResult.StatusCode);
+        Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.NotEmpty(await h.Db.Notes.IgnoreQueryFilters().ToListAsync());
+    }
+
+    [Fact]
+    public async Task DeleteAllData_WithCorrectPassword_Returns204AndPurges()
+    {
+        using var h = new TestHost();
+        await h.CreateNoteAsync("Delete me");
+        var controller = CreateController(h, PasswordHasher.Hash(OwnerPassword));
+
+        var result = await controller.DeleteAllData(new DeleteAllDataRequest(OwnerPassword));
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.Empty(await h.Db.Notes.IgnoreQueryFilters().ToListAsync());
+    }
+
+    [Fact]
+    public async Task DeleteAllData_WithoutConfiguredHash_Returns500()
+    {
+        using var h = new TestHost();
+        var controller = CreateController(h, passwordHash: null);
+
+        var result = await controller.DeleteAllData(new DeleteAllDataRequest(OwnerPassword));
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
+    }
+}

--- a/Vanadium.Note.REST.Tests/SmokeE2E/SettingsPurgeAuthE2ETests.cs
+++ b/Vanadium.Note.REST.Tests/SmokeE2E/SettingsPurgeAuthE2ETests.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests.SmokeE2E;
+
+/// <summary>
+/// Auth-scheme lockdown for the all-data purge (issue #289), driven over real HTTP through
+/// the full pipeline. A personal access token must not be able to call
+/// DELETE /api/settings/all-data (JWT-only scheme → 401), and a JWT carrying the wrong
+/// password must be refused (403). Both assertions are non-destructive — the purge never
+/// runs — so they safely share one factory/database.
+/// </summary>
+public sealed class SettingsPurgeAuthE2ETests(VanadiumWebApplicationFactory factory)
+    : IClassFixture<VanadiumWebApplicationFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private static async Task<string> LoginAsync(HttpClient client)
+    {
+        var response = await client.PostAsJsonAsync(
+            "/api/auth/login",
+            new { Password = VanadiumWebApplicationFactory.OwnerPassword });
+        response.EnsureSuccessStatusCode();
+        var login = await response.Content.ReadFromJsonAsync<LoginResponse>(JsonOptions);
+        return login!.Token;
+    }
+
+    [Fact]
+    public async Task PurgeWithPat_IsRejectedByJwtOnlyScheme()
+    {
+        var client = factory.CreateClient();
+        var jwt = await LoginAsync(client);
+
+        // Mint a personal access token using the interactive JWT.
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
+        var createResponse = await client.PostAsJsonAsync(
+            "/api/apitokens", new { Name = "ci-token", ExpiresInDays = (int?)null });
+        createResponse.EnsureSuccessStatusCode();
+        var pat = await createResponse.Content.ReadFromJsonAsync<CreateTokenResponse>(JsonOptions);
+        Assert.False(string.IsNullOrWhiteSpace(pat?.Token));
+
+        // Even with the correct password in the body, the PAT must not authenticate against
+        // the JWT-only purge endpoint — it is rejected before any deletion happens.
+        var request = new HttpRequestMessage(HttpMethod.Delete, "/api/settings/all-data")
+        {
+            Content = JsonContent.Create(new { Password = VanadiumWebApplicationFactory.OwnerPassword })
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", pat!.Token);
+        var purge = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, purge.StatusCode);
+    }
+
+    [Fact]
+    public async Task PurgeWithJwtAndWrongPassword_IsForbidden()
+    {
+        var client = factory.CreateClient();
+        var jwt = await LoginAsync(client);
+
+        var request = new HttpRequestMessage(HttpMethod.Delete, "/api/settings/all-data")
+        {
+            Content = JsonContent.Create(new { Password = "definitely-not-the-password" })
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
+        var purge = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, purge.StatusCode);
+    }
+
+    private sealed record LoginResponse(string Token);
+
+    private sealed record CreateTokenResponse(string Token);
+}

--- a/Vanadium.Note.REST/Controllers/SettingsController.cs
+++ b/Vanadium.Note.REST/Controllers/SettingsController.cs
@@ -1,6 +1,8 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Vanadium.Note.REST.Models;
+using Vanadium.Note.REST.Security;
 using Vanadium.Note.REST.Services;
 
 namespace Vanadium.Note.REST.Controllers;
@@ -11,6 +13,7 @@ namespace Vanadium.Note.REST.Controllers;
 public class SettingsController(
     SettingsService settingsService,
     AccountService accountService,
+    IConfiguration configuration,
     ILogger<SettingsController> logger) : ControllerBase
 {
     [HttpGet]
@@ -30,9 +33,33 @@ public class SettingsController(
     /// settings, and orphaned uploads. The owner's password lives in configuration,
     /// so login remains possible afterward.
     /// </summary>
+    /// <remarks>
+    /// This is the most destructive endpoint and cannot be undone, so it is locked down
+    /// beyond the shared <c>[Authorize]</c> smart scheme (issue #289): it accepts ONLY the
+    /// interactive JWT scheme, so a leaked personal access token cannot call it, and it
+    /// re-confirms the owner password from the request body before deleting anything.
+    /// </remarks>
     [HttpDelete("all-data")]
-    public async Task<IActionResult> DeleteAllData()
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+    public async Task<IActionResult> DeleteAllData([FromBody] DeleteAllDataRequest request)
     {
+        var storedHash = configuration["Auth:PasswordHash"];
+        if (string.IsNullOrEmpty(storedHash))
+        {
+            logger.LogError("Auth:PasswordHash is not configured — the all-data purge cannot verify the owner password.");
+            return Problem(
+                detail: "Server password is not configured.",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+
+        if (!PasswordHasher.Verify(request.Password, storedHash))
+        {
+            logger.LogWarning("All-data purge rejected: owner-password re-confirmation failed.");
+            return Problem(
+                detail: "Invalid password.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
         logger.LogWarning("All-data purge requested.");
         var purged = await accountService.PurgeAllDataAsync(HttpContext.RequestAborted);
         return purged ? NoContent() : NotFound();

--- a/Vanadium.Note.REST/Models/DeleteAllDataRequest.cs
+++ b/Vanadium.Note.REST/Models/DeleteAllDataRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Vanadium.Note.REST.Models;
+
+/// <summary>
+/// Request body for the all-data purge. The owner password is re-confirmed server-side
+/// before anything is deleted, so a leaked token alone cannot wipe the account (issue #289).
+/// </summary>
+public record DeleteAllDataRequest(
+    [Required][MaxLength(256)] string Password
+);

--- a/Vanadium.Note.Web/Models/DeleteAllDataRequest.cs
+++ b/Vanadium.Note.Web/Models/DeleteAllDataRequest.cs
@@ -1,0 +1,7 @@
+namespace Vanadium.Note.Web.Models;
+
+/// <summary>
+/// Request body for the all-data purge. Mirrors the REST DTO — the owner password is
+/// re-confirmed server-side before anything is deleted (issue #289).
+/// </summary>
+public record DeleteAllDataRequest(string Password);

--- a/Vanadium.Note.Web/Pages/DeleteAllDataDialog.razor
+++ b/Vanadium.Note.Web/Pages/DeleteAllDataDialog.razor
@@ -15,7 +15,7 @@
         </MudText>
 
         <MudText Class="mb-2">
-            To confirm, type <strong>@ConfirmWord</strong> below.
+            To confirm, type <strong>@ConfirmWord</strong> and enter your account password below.
         </MudText>
 
         <MudTextField @bind-Value="_typed"
@@ -25,6 +25,14 @@
                       Placeholder="@ConfirmWord"
                       Adornment="Adornment.None"
                       AutoFocus="true" />
+
+        <MudTextField @bind-Value="_password"
+                      Immediate="true"
+                      InputType="InputType.Password"
+                      Variant="Variant.Outlined"
+                      Margin="Margin.Dense"
+                      Label="Password"
+                      Class="mt-3" />
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
@@ -45,13 +53,16 @@
     private IMudDialogInstance MudDialog { get; set; } = default!;
 
     private string _typed = string.Empty;
+    private string _password = string.Empty;
 
-    private bool CanConfirm => string.Equals(_typed.Trim(), ConfirmWord, StringComparison.Ordinal);
+    private bool CanConfirm =>
+        string.Equals(_typed.Trim(), ConfirmWord, StringComparison.Ordinal)
+        && !string.IsNullOrEmpty(_password);
 
     private void Confirm()
     {
         if (CanConfirm)
-            MudDialog.Close(DialogResult.Ok(true));
+            MudDialog.Close(DialogResult.Ok(_password));
     }
 
     private void Cancel() => MudDialog.Cancel();

--- a/Vanadium.Note.Web/Pages/Settings.razor
+++ b/Vanadium.Note.Web/Pages/Settings.razor
@@ -282,11 +282,11 @@
     {
         var dialog = await DialogService.ShowAsync<DeleteAllDataDialog>("Remove all data");
         var dialogResult = await dialog.Result;
-        if (dialogResult is null || dialogResult.Canceled)
+        if (dialogResult is null || dialogResult.Canceled || dialogResult.Data is not string password)
             return;
 
         _isPurging = true;
-        var result = await SettingsService.DeleteAllDataAsync();
+        var result = await SettingsService.DeleteAllDataAsync(password);
         if (result.IsSuccess)
         {
             Snackbar.Add("All data deleted.", Severity.Success);

--- a/Vanadium.Note.Web/Services/SettingsService.cs
+++ b/Vanadium.Note.Web/Services/SettingsService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 using Vanadium.Note.Web.Models;
 
@@ -40,14 +41,24 @@ public class SettingsService(HttpClient http, ILogger<SettingsService> logger)
         }
     }
 
-    public async Task<ServiceResult<bool>> DeleteAllDataAsync()
+    public async Task<ServiceResult<bool>> DeleteAllDataAsync(string password)
     {
         try
         {
-            var response = await http.DeleteAsync("api/settings/all-data");
-            return response.IsSuccessStatusCode
-                ? ServiceResult<bool>.Ok(true)
-                : ServiceResult<bool>.Fail("Failed to delete data.");
+            // The purge endpoint requires the owner password in the body (issue #289), so it
+            // is sent as a DELETE with a JSON body rather than a bare DeleteAsync.
+            var request = new HttpRequestMessage(HttpMethod.Delete, "api/settings/all-data")
+            {
+                Content = JsonContent.Create(new DeleteAllDataRequest(password))
+            };
+            var response = await http.SendAsync(request);
+            if (response.IsSuccessStatusCode)
+                return ServiceResult<bool>.Ok(true);
+            // A wrong password is rejected with 403; surface that distinctly so the user knows
+            // their data is intact and the password was the problem.
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+                return ServiceResult<bool>.Fail("Incorrect password. Your data was not deleted.");
+            return ServiceResult<bool>.Fail("Failed to delete data.");
         }
         catch (Exception ex)
         {

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -355,7 +355,7 @@ Route prefix `/api/settings`. **Auth: Bearer (JWT or PAT).** `UserSettings` is a
 |---|---|---|---|
 | GET | `/api/settings` | Bearer | Get user settings. |
 | PUT | `/api/settings` | Bearer | Update user settings. |
-| DELETE | `/api/settings/all-data` | Bearer | Permanently purge all content. |
+| DELETE | `/api/settings/all-data` | **JWT only** | Permanently purge all content (owner-password re-confirmation required). |
 
 ### GET `/api/settings`
 
@@ -371,7 +371,12 @@ Route prefix `/api/settings`. **Auth: Bearer (JWT or PAT).** `UserSettings` is a
 Permanently deletes all notes, labels, label categories, API tokens, settings, and orphaned
 uploads. The owner password lives in configuration, so login remains possible afterward.
 
-- **Status codes:** `204` purged · `404` nothing to purge.
+As the most destructive endpoint, it is locked down beyond the shared smart scheme: it accepts
+**only the interactive JWT scheme** (a personal access token cannot call it), and it re-confirms
+the owner password from the request body before deleting anything.
+
+- **Request body:** `{ password }` — the owner password, re-verified with `PasswordHasher.Verify`.
+- **Status codes:** `204` purged · `403` wrong password · `401` called with a PAT (or no JWT) · `500` server password not configured.
 
 ---
 


### PR DESCRIPTION
## 요약
가장 파괴적인 엔드포인트인 `DELETE /api/settings/all-data`가 Smart 스킴(JWT 또는 PAT)이라 PAT로도 재인증 없이 호출 가능해, CI 등에 심어둔 PAT 하나가 유출되면 요청 한 방으로 전 데이터가 비가역 삭제될 수 있었다(#289). `ApiTokensController` 패턴처럼 이 엔드포인트만 **JWT 스킴 전용**으로 제한하고, 요청 본문의 비밀번호를 `PasswordHasher.Verify`로 재확인하도록 잠갔다.

## 변경 사항
### 백엔드
- `SettingsController.DeleteAllData`: 메서드 레벨 `[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]` 추가(클래스 `[Authorize]` 유지 → Get/Update는 그대로 Smart 스킴). `IConfiguration` 주입, `[FromBody] DeleteAllDataRequest`의 비밀번호를 `PasswordHasher.Verify`로 검증.
  - PAT 호출 → `401`(JWT 스킴이 PAT를 인증하지 못함), 비밀번호 불일치 → `403`, `Auth:PasswordHash` 미설정 → `500`, 성공 → `204`.
- 새 DTO `DeleteAllDataRequest`(REST) + Web 미러.

### 프론트엔드
- `DeleteAllDataDialog`: "DELETE" 타이핑에 더해 **비밀번호 입력** 추가, 확인 시 비밀번호를 `DialogResult`로 반환(둘 다 충족해야 활성화).
- `Settings.razor`: 반환된 비밀번호를 `SettingsService.DeleteAllDataAsync(password)`로 전달.
- `SettingsService.DeleteAllDataAsync(string)`: DELETE에 JSON 본문을 실어 전송, `403`은 "Incorrect password. Your data was not deleted."로 구분 안내.

### 문서/테스트
- `docs/api-specification.md`의 all-data 항목 갱신(JWT 전용, 비밀번호 본문, 상태코드).
- 컨트롤러 단위 테스트(비밀번호 게이트: 오답 403 + 데이터 보존, 정답 204 + 삭제, 해시 미설정 500).
- E2E 테스트(실제 파이프라인): PAT로 호출 시 `401`, JWT + 오답 시 `403`.

## 완료 조건 검증
- [x] JWT 전용 제한(PAT 401/403) — E2E `PurgeWithPat_IsRejectedByJwtOnlyScheme`가 실제 파이프라인에서 PAT → `401` 확인.
- [x] 비밀번호 `PasswordHasher.Verify` 재확인, 불일치 시 미삭제 — 컨트롤러 테스트 `...WithWrongPassword_Returns403AndKeepsData`(403 + 노트 잔존) / E2E `...WrongPassword_IsForbidden`.
- [x] 빌드 클린 — REST/Web 경고 0 / 오류 0.
- [x] 프론트가 비밀번호 재확인 입력을 전달 — 다이얼로그 비밀번호 필드 + `DeleteAllDataAsync(password)`.

## 범위 준수
- PBKDF2 해시 파라미터/포맷 변경 없음(`PasswordHasher` 재사용).
- `DeleteAllData` 외 Settings 엔드포인트(Get/Update) 인증 방식 불변.
- 삭제 전 dump 생성은 선택 사항이라 미포함.

## 테스트
- `dotnet test Vanadium.Note.REST.Tests` → 163 통과 / 3 건너뜀(기존 PostgreSQL 전용) / 0 실패(신규 5건 포함).

Closes #289
