### PR TITLE
#291 락 중에도 검증 수행해 소유자 로그인 DoS 제거

### DIFF
--- a/Vanadium.Note.REST.Tests/ApiTokenAuthHandlerTests.cs
+++ b/Vanadium.Note.REST.Tests/ApiTokenAuthHandlerTests.cs
@@ -1,0 +1,101 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Vanadium.Note.REST.Auth;
+using Vanadium.Note.REST.Models;
+using Vanadium.Note.REST.Security;
+using Vanadium.Note.REST.Services;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// A valid personal access token must authenticate even while the shared PAT throttle is locked;
+/// otherwise an attacker's invalid attempts deny the owner's automations service (issue #291,
+/// mirroring the login fix). Invalid tokens are still refused and still feed the throttle.
+/// </summary>
+public class ApiTokenAuthHandlerTests
+{
+    // Minimal IOptionsMonitor so AuthenticationHandler<T> can construct without the DI stack.
+    private sealed class StubOptionsMonitor : IOptionsMonitor<AuthenticationSchemeOptions>
+    {
+        private readonly AuthenticationSchemeOptions _value = new();
+        public AuthenticationSchemeOptions CurrentValue => _value;
+        public AuthenticationSchemeOptions Get(string? name) => _value;
+        public IDisposable? OnChange(Action<AuthenticationSchemeOptions, string?> listener) => null;
+    }
+
+    private static ApiTokenThrottle LockedThrottle()
+    {
+        var throttle = new ApiTokenThrottle(
+            Options.Create(new ApiTokenThrottleOptions { FailureThreshold = 1, BaseDelaySeconds = 300, MaxDelaySeconds = 900 }),
+            TimeProvider.System,
+            NullLogger<ApiTokenThrottle>.Instance);
+        throttle.RegisterFailure(); // threshold = 1 → immediately locked
+        Assert.True(throttle.IsLocked(out _));
+        return throttle;
+    }
+
+    private static async Task<ApiTokenAuthHandler> CreateHandlerAsync(
+        TestHost h, IApiTokenThrottle throttle, string authHeaderValue)
+    {
+        var handler = new ApiTokenAuthHandler(
+            new StubOptionsMonitor(),
+            NullLoggerFactory.Instance,
+            UrlEncoder.Default,
+            h.Db,
+            throttle);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.Authorization = authHeaderValue;
+
+        await handler.InitializeAsync(
+            new AuthenticationScheme(ApiTokenAuthHandler.SchemeName, null, typeof(ApiTokenAuthHandler)),
+            httpContext);
+        return handler;
+    }
+
+    private static async Task<string> SeedValidTokenAsync(TestHost h)
+    {
+        var plaintext = ApiTokenService.TokenPrefix + "abcdefghijklmnopqrstuvwxyz012345";
+        h.Db.ApiTokens.Add(new ApiToken
+        {
+            Id = Guid.NewGuid(),
+            Name = "ci",
+            TokenHash = ApiTokenService.HashToken(plaintext),
+            TokenSuffix = plaintext[^4..],
+            CreatedAt = DateTime.UtcNow,
+        });
+        await h.Db.SaveChangesAsync();
+        return plaintext;
+    }
+
+    [Fact]
+    public async Task ValidToken_WhileLocked_Authenticates()
+    {
+        using var h = new TestHost();
+        var plaintext = await SeedValidTokenAsync(h);
+        var throttle = LockedThrottle();
+        var handler = await CreateHandlerAsync(h, throttle, $"Bearer {plaintext}");
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.True(result.Succeeded);
+        Assert.False(throttle.IsLocked(out _)); // a valid token cleared the lock
+    }
+
+    [Fact]
+    public async Task UnknownToken_WhileLocked_IsRejected()
+    {
+        using var h = new TestHost();
+        await SeedValidTokenAsync(h);
+        var throttle = LockedThrottle();
+        var handler = await CreateHandlerAsync(h, throttle, $"Bearer {ApiTokenService.TokenPrefix}not-a-real-token-value-000000000");
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.False(result.Succeeded);
+    }
+}

--- a/Vanadium.Note.REST.Tests/AuthControllerTests.cs
+++ b/Vanadium.Note.REST.Tests/AuthControllerTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Vanadium.Note.REST.Controllers;
+using Vanadium.Note.REST.Models;
+using Vanadium.Note.REST.Security;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Login must be verified even during an active global lockout, so the owner's correct password
+/// always gets through and clears the lock; only a wrong password is refused with 429 while
+/// locked (issue #291 — the old skip-verification-while-locked path was an owner DoS).
+/// </summary>
+public class AuthControllerTests
+{
+    private const string OwnerPassword = "s3cure-owner-password";
+    // 32+ chars so GenerateJwtToken's HS256 signing key is accepted.
+    private const string JwtSecret = "auth-controller-tests-jwt-secret-0123456789";
+
+    private static AuthController CreateController(ILoginThrottle throttle)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:PasswordHash"] = PasswordHasher.Hash(OwnerPassword),
+                ["Auth:JwtSecret"] = JwtSecret,
+            })
+            .Build();
+
+        // env and passwordValidator are only used by the dev-only /hash endpoint, never by Login.
+        return new AuthController(config, env: null!, passwordValidator: null!, throttle,
+            NullLogger<AuthController>.Instance)
+        {
+            ControllerContext = CreateContext()
+        };
+    }
+
+    private static ControllerContext CreateContext()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMvcCore();
+        var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        return new ControllerContext { HttpContext = httpContext };
+    }
+
+    private static LoginThrottle LockedThrottle()
+    {
+        var throttle = new LoginThrottle(
+            Options.Create(new LoginLockoutOptions
+            {
+                FailureThreshold = 1,
+                BaseDelaySeconds = 300,
+                MaxDelaySeconds = 900,
+            }),
+            TimeProvider.System,
+            NullLogger<LoginThrottle>.Instance);
+        throttle.RegisterFailure(); // threshold = 1 → immediately locked
+        Assert.True(throttle.IsLocked(out _));
+        return throttle;
+    }
+
+    [Fact]
+    public void Login_WhileLocked_WithCorrectPassword_SucceedsAndClearsLockout()
+    {
+        var throttle = LockedThrottle();
+        var controller = CreateController(throttle);
+
+        var result = controller.Login(new LoginRequest(OwnerPassword));
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.False(throttle.IsLocked(out _)); // a correct password cleared the lock
+    }
+
+    [Fact]
+    public void Login_WhileLocked_WithWrongPassword_Returns429AndStaysLocked()
+    {
+        var throttle = LockedThrottle();
+        var controller = CreateController(throttle);
+
+        var result = controller.Login(new LoginRequest("wrong-password"));
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status429TooManyRequests, objectResult.StatusCode);
+        Assert.True(throttle.IsLocked(out _));
+    }
+
+    [Fact]
+    public void Login_NotLocked_WithWrongPassword_Returns401()
+    {
+        var throttle = new LoginThrottle(
+            Options.Create(new LoginLockoutOptions { FailureThreshold = 5, BaseDelaySeconds = 300, MaxDelaySeconds = 900 }),
+            TimeProvider.System,
+            NullLogger<LoginThrottle>.Instance);
+        var controller = CreateController(throttle);
+
+        var result = controller.Login(new LoginRequest("wrong-password"));
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status401Unauthorized, objectResult.StatusCode);
+    }
+}

--- a/Vanadium.Note.REST/Auth/ApiTokenAuthHandler.cs
+++ b/Vanadium.Note.REST/Auth/ApiTokenAuthHandler.cs
@@ -36,14 +36,11 @@ public class ApiTokenAuthHandler(
         if (!plaintext.StartsWith(ApiTokenService.TokenPrefix, StringComparison.Ordinal))
             return AuthenticateResult.NoResult();
 
-        // Reject before touching the DB while a lockout is active, so a flood of invalid
-        // tokens cannot keep issuing one ApiTokens query per request.
-        if (throttle.IsLocked(out _))
-        {
-            Logger.LogWarning("Rejected API token: authentication is throttled after repeated failures.");
-            return AuthenticateResult.Fail("Too many failed API token attempts.");
-        }
-
+        // Validate EVEN during an active lockout, so a legitimate token is never rejected just
+        // because an attacker's invalid attempts armed the shared lock — the throttle otherwise
+        // becomes a denial-of-service against the owner (issue #291, mirroring the login fix).
+        // A valid token clears the lock below; only invalid/expired tokens feed RegisterFailure.
+        // The extra ApiTokens query this incurs while locked is a single indexed lookup.
         var hash = ApiTokenService.HashToken(plaintext);
 
         var record = await db.ApiTokens

--- a/Vanadium.Note.REST/Controllers/AuthController.cs
+++ b/Vanadium.Note.REST/Controllers/AuthController.cs
@@ -34,9 +34,33 @@ public class AuthController(
     {
         logger.LogInformation("Login attempt.");
 
-        // Global backoff gate: unlike the per-IP fixed-window limiter, this counter is shared
-        // across every source, so distributed IPs or forged X-Forwarded-For cannot slip past it.
-        // Attempts arriving during an active lockout are rejected without touching the password.
+        var storedHash = config["Auth:PasswordHash"];
+        if (string.IsNullOrEmpty(storedHash))
+        {
+            logger.LogError("Auth:PasswordHash is not configured — login is impossible until it is set.");
+            return Problem(
+                detail: "Server password is not configured.",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+
+        // Verify the password EVEN during an active global lockout. Skipping verification while
+        // locked let an attacker keep the owner out forever: the shared failure counter only
+        // resets on a success, so one wrong attempt right after each window expired re-armed the
+        // lock indefinitely and the owner's correct password was never checked (issue #291).
+        // Now a correct password always clears the lock and gets through; only a wrong password is
+        // rejected. The PBKDF2 cost this incurs while locked is bounded by the per-IP
+        // fixed-window limiter on this endpoint (unlike PBKDF2, the shared lock is not per-IP).
+        if (PasswordHasher.Verify(request.Password, storedHash))
+        {
+            loginThrottle.RegisterSuccess();
+            var token = GenerateJwtToken();
+            logger.LogInformation("Owner authenticated successfully.");
+            return Ok(new { token });
+        }
+
+        // Wrong password. During an active lockout, surface 429 without counting the failure
+        // (RegisterFailure already ignores locked-window attempts, so the window cannot be
+        // extended); otherwise register the failure and return 401.
         if (loginThrottle.IsLocked(out var retryAfter))
         {
             var seconds = (int)Math.Ceiling(retryAfter.TotalSeconds);
@@ -47,26 +71,9 @@ public class AuthController(
                 statusCode: StatusCodes.Status429TooManyRequests);
         }
 
-        var storedHash = config["Auth:PasswordHash"];
-        if (string.IsNullOrEmpty(storedHash))
-        {
-            logger.LogError("Auth:PasswordHash is not configured — login is impossible until it is set.");
-            return Problem(
-                detail: "Server password is not configured.",
-                statusCode: StatusCodes.Status500InternalServerError);
-        }
-
-        if (!PasswordHasher.Verify(request.Password, storedHash))
-        {
-            loginThrottle.RegisterFailure();
-            logger.LogWarning("Failed login attempt.");
-            return Problem(detail: "Invalid password.", statusCode: StatusCodes.Status401Unauthorized);
-        }
-
-        loginThrottle.RegisterSuccess();
-        var token = GenerateJwtToken();
-        logger.LogInformation("Owner authenticated successfully.");
-        return Ok(new { token });
+        loginThrottle.RegisterFailure();
+        logger.LogWarning("Failed login attempt.");
+        return Problem(detail: "Invalid password.", statusCode: StatusCodes.Status401Unauthorized);
     }
 
     /// <summary>

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -42,7 +42,9 @@ by design (single-tenant). The default JWT lifetime is 480 minutes (8h), configu
 ## Rate limiting
 
 - `POST /api/auth/login` — fixed-window **10 requests/min per client IP** (policy `login`), plus a
-  global cross-IP login-backoff lockout that returns `429` with a `Retry-After` header.
+  global cross-IP login-backoff lockout that returns `429` with a `Retry-After` header for **failed**
+  attempts. The password is still verified while locked, so the owner's correct password always
+  authenticates and clears the lockout (the per-IP limiter caps the PBKDF2 cost this incurs).
 - `GET /api/share/{token}` — fixed-window **60 requests/min per client IP** (policy `share`).
 - Rate-limit rejections return `429 Too Many Requests`.
 


### PR DESCRIPTION
## 요약
전역 로그인 락아웃이 소유자를 향한 DoS 벡터였다(#291). 락 중이면 비밀번호를 **검증하지 않고** 429를 반환했는데, 공유 실패 카운터는 성공 시에만 리셋되고 그 성공 경로가 락에 막혀 있어, 공격자가 각 락 창 만료 직후 오답 1개만 보내면 카운터가 임계값 이상으로 유지되어 즉시 재-락 → 소유자는 올바른 비밀번호로도 사실상 영구 로그인 불가였다. 이제 **락 중에도 검증을 수행**해 정답이면 락을 해제하고 통과시키며, 오답만 429로 막는다.

## 변경 사항
- `AuthController.Login`: 락 선-검사 후 미검증 429 반환하던 구조를 제거. 항상 `PasswordHasher.Verify` 수행 → 성공이면 `RegisterSuccess`(락 해제) 후 JWT 발급, 실패면서 락 상태면 `Retry-After` + 429(창 미갱신), 비락이면 `RegisterFailure` 후 401. 락 중 검증의 PBKDF2 비용은 이 엔드포인트의 per-IP fixed-window 리미터가 상한.
- `ApiTokenAuthHandler`: 락 중 DB 조회 없이 토큰을 거부하던 단락을 제거. 유효 토큰은 락 중에도 통과(성공 시 `RegisterSuccess`), 무효/만료 토큰만 `RegisterFailure` 후 거부 — 주석과 동작 일치.
- `docs/api-specification.md`: 로그인 락아웃 설명에 "실패 시에만 429, 정답은 락 중에도 인증되고 락 해제" 명시.

## 완료 조건 검증
- [x] 락 상태에서도 검증 수행, 성공 시 락 해제 + 통과 — `AuthControllerTests.Login_WhileLocked_WithCorrectPassword_SucceedsAndClearsLockout`(200 + 락 해제), `ApiTokenAuthHandlerTests.ValidToken_WhileLocked_Authenticates`(인증 성공 + 락 해제).
- [x] 검증 실패인 경우에만 429 — `Login_WhileLocked_WithWrongPassword_Returns429AndStaysLocked`(429, 창 유지) / `Login_NotLocked_WithWrongPassword_Returns401`.
- [x] `ApiTokenAuthHandler` 동일 패턴(락 중 유효 토큰 통과) — 위 PAT 테스트 + `UnknownToken_WhileLocked_IsRejected`.
- [x] 빌드 클린 — REST 경고 0 / 오류 0.

## 범위 준수
- `/api/auth/login`의 per-IP fixed-window 리미터(10 req/min) 미변경(`[EnableRateLimiting("login")]` 유지).
- PBKDF2 파라미터 미변경.
- 지수 백오프 캡(`MaxDelaySeconds`) 등 락아웃 옵션 의미 유지 — `LoginThrottle`/`ApiTokenThrottle` 구현 미변경(기존 스로틀 테스트 그대로 통과).

## 테스트
- `dotnet test Vanadium.Note.REST.Tests` → 168 통과 / 3 건너뜀(기존 PostgreSQL 전용) / 0 실패(신규 5건 포함).

Closes #291
