### PR TITLE
#292 공유 응답에서 page-link/mention 참조 마크업 치환

### DIFF
--- a/Vanadium.Note.REST.Tests/ShareContentRedactorTests.cs
+++ b/Vanadium.Note.REST.Tests/ShareContentRedactorTests.cs
@@ -1,0 +1,101 @@
+using Vanadium.Note.REST.Services;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Unit contract for <see cref="ShareContentRedactor"/> (issue #292): page-link and note-mention
+/// nodes must be replaced with a reference-free placeholder so a shared note never leaks the
+/// GUIDs/titles of the notes it links to, while ordinary formatting HTML is left untouched.
+/// </summary>
+public class ShareContentRedactorTests
+{
+    private const string SecretId = "11111111-2222-3333-4444-555555555555";
+    private const string SecretTitle = "Top Secret Roadmap";
+
+    private static string PageLink() =>
+        $"<div data-type=\"page-link\" data-note-id=\"{SecretId}\" data-title=\"{SecretTitle}\" class=\"page-link-block\">" +
+        $"<span class=\"page-link-icon\">📄</span><span class=\"page-link-title\">{SecretTitle}</span></div>";
+
+    private static string Mention() =>
+        $"<a data-type=\"note-mention\" data-note-id=\"{SecretId}\" data-title=\"{SecretTitle}\" class=\"note-mention\">@{SecretTitle}</a>";
+
+    [Fact]
+    public void Redact_PageLink_RemovesIdAndTitle()
+    {
+        var result = ShareContentRedactor.Redact($"<p>See </p>{PageLink()}");
+
+        Assert.DoesNotContain(SecretId, result);
+        Assert.DoesNotContain(SecretTitle, result);
+        Assert.DoesNotContain("data-note-id", result);
+        Assert.DoesNotContain("data-title", result);
+        Assert.Contains("🔒 private page", result);
+        Assert.Contains("<p>See </p>", result); // surrounding content preserved
+    }
+
+    [Fact]
+    public void Redact_Mention_RemovesIdAndTitle()
+    {
+        var result = ShareContentRedactor.Redact($"<p>ping {Mention()} now</p>");
+
+        Assert.DoesNotContain(SecretId, result);
+        Assert.DoesNotContain(SecretTitle, result);
+        Assert.DoesNotContain("data-note-id", result);
+        Assert.DoesNotContain("data-title", result);
+        Assert.Contains("🔒 private page", result);
+        Assert.Contains("now</p>", result); // surrounding content preserved
+    }
+
+    [Fact]
+    public void Redact_MultipleNodes_RedactsEach()
+    {
+        var result = ShareContentRedactor.Redact($"{PageLink()}<p>x</p>{Mention()}{PageLink()}");
+
+        Assert.DoesNotContain(SecretId, result);
+        Assert.DoesNotContain(SecretTitle, result);
+        Assert.Equal(3, CountOccurrences(result, "🔒 private page"));
+    }
+
+    [Fact]
+    public void Redact_AttributeOrderVariation_StillRedacts()
+    {
+        // class first, data-type not leading — mirrors possible attribute reordering.
+        var reordered =
+            $"<div class=\"page-link-block\" data-note-id=\"{SecretId}\" data-title=\"{SecretTitle}\" data-type=\"page-link\">" +
+            $"<span>{SecretTitle}</span></div>";
+
+        var result = ShareContentRedactor.Redact(reordered);
+
+        Assert.DoesNotContain(SecretId, result);
+        Assert.DoesNotContain(SecretTitle, result);
+        Assert.Contains("🔒 private page", result);
+    }
+
+    [Fact]
+    public void Redact_OrdinaryContent_Unchanged()
+    {
+        const string html = "<h1>Title</h1><p>Just <strong>text</strong> and a <a href=\"https://x.test\">link</a>.</p>";
+
+        Assert.Equal(html, ShareContentRedactor.Redact(html));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Redact_NullOrEmpty_ReturnedUnchanged(string? html)
+    {
+        Assert.Equal(html, ShareContentRedactor.Redact(html!));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, System.StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+}

--- a/Vanadium.Note.REST.Tests/ShareControllerTests.cs
+++ b/Vanadium.Note.REST.Tests/ShareControllerTests.cs
@@ -39,6 +39,33 @@ public class ShareControllerTests
     }
 
     [Fact]
+    public async Task Get_NoteWithReferences_RedactsIdsAndTitles()
+    {
+        using var h = new TestHost();
+        const string secretId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        const string secretTitle = "Private Referenced Note";
+        var content =
+            $"<p>intro</p>" +
+            $"<div data-type=\"page-link\" data-note-id=\"{secretId}\" data-title=\"{secretTitle}\" class=\"page-link-block\">" +
+            $"<span class=\"page-link-icon\">📄</span><span class=\"page-link-title\">{secretTitle}</span></div>" +
+            $"<p>see <a data-type=\"note-mention\" data-note-id=\"{secretId}\" data-title=\"{secretTitle}\" class=\"note-mention\">@{secretTitle}</a></p>";
+        var note = await h.CreateNoteAsync("Shared", content: content);
+        var info = await h.Notes.SetShare(note.Id, ShareMode.Public);
+        var controller = CreateController(h);
+
+        var result = await controller.Get(info!.Token!, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var shared = Assert.IsType<SharedNote>(ok.Value);
+        Assert.DoesNotContain(secretId, shared.Content);
+        Assert.DoesNotContain(secretTitle, shared.Content);
+        Assert.DoesNotContain("data-note-id", shared.Content);
+        Assert.DoesNotContain("data-title", shared.Content);
+        Assert.Contains("🔒 private page", shared.Content);
+        Assert.Contains("<p>intro</p>", shared.Content); // ordinary content survives
+    }
+
+    [Fact]
     public async Task Get_UnknownToken_ReturnsNotFound()
     {
         using var h = new TestHost();

--- a/Vanadium.Note.REST.Tests/SmokeE2E/VanadiumWebApplicationFactory.cs
+++ b/Vanadium.Note.REST.Tests/SmokeE2E/VanadiumWebApplicationFactory.cs
@@ -37,15 +37,21 @@ public sealed class VanadiumWebApplicationFactory : WebApplicationFactory<Progra
     // while at least one connection to it is open.
     private readonly SqliteConnection _connection = new("DataSource=:memory:");
 
-    public VanadiumWebApplicationFactory()
+    // Program validates Auth:JwtSecret eagerly during WebApplication.CreateBuilder,
+    // before the host is built — earlier than any ConfigureAppConfiguration source takes
+    // effect. Environment variables are read at that point (the default builder calls
+    // AddEnvironmentVariables), so the auth config must be supplied this way.
+    //
+    // Environment variables are process-global, so this is done ONCE in a static
+    // constructor and never torn down. Every E2E factory (there is one per test class,
+    // and xUnit runs test classes in parallel) then observes the same valid config while
+    // building its host. Setting them per-instance and nulling them in Dispose instead
+    // raced across parallel factories: one factory's Dispose could null Auth:JwtSecret
+    // while another was still building its host, making that host fail to start
+    // ("Auth:JwtSecret is not configured") and flaking a smoke test on CI.
+    // "__" maps to the ":" configuration separator.
+    static VanadiumWebApplicationFactory()
     {
-        _connection.Open();
-
-        // Program validates Auth:JwtSecret eagerly during WebApplication.CreateBuilder,
-        // before the host is built — earlier than any ConfigureAppConfiguration source
-        // takes effect. Environment variables are read at that point (the default builder
-        // calls AddEnvironmentVariables), so the auth config is supplied this way.
-        // "__" maps to the ":" configuration separator.
         Environment.SetEnvironmentVariable("Auth__JwtSecret", JwtSecret);
         Environment.SetEnvironmentVariable("Auth__PasswordHash", PasswordHasher.Hash(OwnerPassword));
         // Never used (the provider is replaced below) but present so the Npgsql option
@@ -53,6 +59,11 @@ public sealed class VanadiumWebApplicationFactory : WebApplicationFactory<Progra
         Environment.SetEnvironmentVariable(
             "ConnectionStrings__DefaultConnection",
             "Host=localhost;Database=vanadium_test;Username=test;Password=test");
+    }
+
+    public VanadiumWebApplicationFactory()
+    {
+        _connection.Open();
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -92,9 +103,11 @@ public sealed class VanadiumWebApplicationFactory : WebApplicationFactory<Progra
         if (!disposing)
             return;
 
+        // Only the per-factory SQLite connection is torn down here. The auth/config
+        // environment variables are process-global and set once in the static
+        // constructor; they are deliberately NOT nulled, so disposing one factory can
+        // never pull valid config out from under another factory that is still building
+        // its host on a parallel test thread.
         _connection.Dispose();
-        Environment.SetEnvironmentVariable("Auth__JwtSecret", null);
-        Environment.SetEnvironmentVariable("Auth__PasswordHash", null);
-        Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", null);
     }
 }

--- a/Vanadium.Note.REST/Controllers/ShareController.cs
+++ b/Vanadium.Note.REST/Controllers/ShareController.cs
@@ -37,7 +37,9 @@ public class ShareController(NoteService noteService, ILogger<ShareController> l
         {
             Id = note.Id,
             Title = note.Title,
-            Content = note.Content,
+            // Strip cross-note reference markup so a shared note never leaks the GUIDs/titles of
+            // the (possibly non-shared) notes it links to (issue #292).
+            Content = ShareContentRedactor.Redact(note.Content),
             UpdatedAt = note.UpdatedAt
         });
     }

--- a/Vanadium.Note.REST/Services/ShareContentRedactor.cs
+++ b/Vanadium.Note.REST/Services/ShareContentRedactor.cs
@@ -1,0 +1,55 @@
+using System.Text.RegularExpressions;
+
+namespace Vanadium.Note.REST.Services;
+
+/// <summary>
+/// Redacts cross-note reference markup from a note's HTML before it is served on the
+/// anonymous share path (issue #292).
+///
+/// <para>
+/// Page-link (<c>&lt;div data-type="page-link"&gt;</c>) and note-mention
+/// (<c>&lt;a data-type="note-mention"&gt;</c>) nodes embed the referenced note's
+/// <c>data-note-id</c> (internal GUID) and <c>data-title</c> (its title, which also appears
+/// as the node's visible text). Sharing one note would otherwise leak the titles and GUIDs of
+/// every private note it links to. Each such node is replaced with a static
+/// <c>🔒 private page</c> placeholder that carries no id/title, so an anonymous viewer learns
+/// nothing about the referenced note beyond that a reference existed.
+/// </para>
+///
+/// <para>
+/// This runs only on the share response assembly (<c>ShareController</c>); the stored content
+/// and the owner-facing editor rendering are untouched. The regex targets are the same
+/// <c>data-type</c>-anchored shapes the editor serializes (mirroring the id-scoped rewrites in
+/// <c>NoteService</c>): both nodes are atoms whose only inner content is spans / text, so the
+/// first matching close tag is always the node's own.
+/// </para>
+/// </summary>
+public static class ShareContentRedactor
+{
+    private const string Placeholder = "🔒 private page";
+
+    // Page-link renders as a block <div data-type="page-link" ...> with two inner <span>s and no
+    // nested <div>, so a non-greedy match to the first </div> captures exactly the node.
+    private static readonly Regex PageLinkRegex = new(
+        @"<div\b[^>]*\bdata-type=""page-link""[^>]*>.*?</div>",
+        RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // Note-mention renders as an inline <a data-type="note-mention" ...>@title</a> with text-only
+    // content and no nested <a>, so a non-greedy match to the first </a> captures exactly the node.
+    private static readonly Regex MentionRegex = new(
+        @"<a\b[^>]*\bdata-type=""note-mention""[^>]*>.*?</a>",
+        RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns <paramref name="html"/> with every page-link and note-mention node replaced by a
+    /// reference-free placeholder. Null/empty input is returned unchanged.
+    /// </summary>
+    public static string Redact(string html)
+    {
+        if (string.IsNullOrEmpty(html)) return html;
+
+        var result = PageLinkRegex.Replace(html, $"<div class=\"private-page-ref\">{Placeholder}</div>");
+        result = MentionRegex.Replace(result, $"<span class=\"private-page-ref\">{Placeholder}</span>");
+        return result;
+    }
+}

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -395,8 +395,10 @@ This is the only content endpoint reachable without authentication.
 
 - **Path:** `token` — the unguessable share token.
 - **Response `200`:** `SharedNote` — `{ id, title, content, updatedAt }`. Lean, read-only; never exposes
-  the token, structure, labels, or lifecycle fields. For `Link` mode, an `X-Robots-Tag: noindex, nofollow`
-  header is added; `Public` mode omits it.
+  the token, structure, labels, or lifecycle fields. Cross-note reference markup (page-link / note-mention)
+  is redacted from `content` — each node is replaced with a `🔒 private page` placeholder so a referenced
+  (possibly non-shared) note's GUID and title are never disclosed. For `Link` mode, an
+  `X-Robots-Tag: noindex, nofollow` header is added; `Public` mode omits it.
 - **Status codes:** `200` · `404` unknown, revoked, or soft-deleted note.
 
 ---


### PR DESCRIPTION
Closes #292

## 문제
공유 노트(`GET /api/share/{token}`) 응답에 page-link(`<div data-type="page-link">`)와 mention(`<a data-type="note-mention">`) 마크업이 그대로 포함되어, 참조된 **비공유** 노트의 내부 GUID(`data-note-id`)와 제목(`data-title`, 표시 텍스트에도 등장)이 익명 뷰어에게 유출되었다.

## 변경
- `ShareContentRedactor`(신규): page-link/mention 노드를 `🔒 private page` 자리표시자로 치환하는 순수 정적 헬퍼. 기존 `NoteService`의 id 기반 재작성과 동일한 `data-type` 앵커 정규식 패턴을 사용한다.
- `ShareController.Get`: 응답 조립 시 `note.Content`에 리댁션을 적용. **공유 응답 경로에만** 적용하며 저장 콘텐츠·소유자 에디터 렌더링은 건드리지 않는다.
- `docs/api-specification.md`: 공유 응답의 참조 마크업 리댁션 동작 명시.

## 완료 조건 검증
- [x] 공유 응답 HTML에 `data-note-id`(GUID) 미노출 — `ShareContentRedactorTests`, `ShareControllerTests.Get_NoteWithReferences_RedactsIdsAndTitles`가 `Assert.DoesNotContain` 으로 검증
- [x] 공유 응답 HTML에 `data-title`(제목) 미노출 — 위 동일 테스트에서 제목 문자열·속성 부재 검증
- [x] page-link/mention이 `🔒 private page`로 치환 — 위 테스트에서 자리표시자 존재 검증
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0 / 오류 0
- [x] 전체 테스트 통과 — `dotnet test Vanadium.slnx` 176 통과 / 3 스킵(PostgreSQL 전용, 기존)

## 범위 준수
- `SharedNote`는 여전히 `{ id, title, content, updatedAt }`만 반환하며 `ShareToken`을 절대 노출하지 않는다 (lean read-only 계약 유지).
- 소유자 에디터에서의 page-link/mention 렌더링은 변경하지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
