### PR TITLE
#297 JWT payload base64url 디코드 및 만료 토큰 거부

### DIFF
--- a/Vanadium.Note.REST.Tests/JwtClaimParserTests.cs
+++ b/Vanadium.Note.REST.Tests/JwtClaimParserTests.cs
@@ -1,0 +1,121 @@
+using System.Buffers.Text;
+using System.Security.Claims;
+using System.Text.Json;
+using Vanadium.Note.Web.Auth;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression coverage for issue #297: the client parses a JWT payload as <c>base64url</c>, so a
+/// token whose payload contains <c>-</c>/<c>_</c> must still yield its claims (the old
+/// <c>Convert.FromBase64String</c> path threw and produced an authenticated-but-nameless user,
+/// which made the Settings/Logout buttons vanish). Also pins the new <c>exp</c> expiry check.
+/// </summary>
+public class JwtClaimParserTests
+{
+    // Builds a real 3-segment JWT (header.payload.signature) with the given payload object,
+    // payload encoded as base64url exactly like a server-issued token.
+    private static string BuildJwt(object payload)
+    {
+        static string Segment(ReadOnlySpan<byte> bytes) => Base64Url.EncodeToString(bytes);
+        var header = Segment("{\"alg\":\"HS256\",\"typ\":\"JWT\"}"u8);
+        var body = Segment(JsonSerializer.SerializeToUtf8Bytes(payload));
+        return $"{header}.{body}.{Segment("signature"u8)}";
+    }
+
+    private static long Unix(DateTimeOffset when) => when.ToUnixTimeSeconds();
+
+    // A base64url payload contains '-' (index 62) / '_' (index 63) only where a specific byte lands
+    // on a 3-byte-group boundary: '~'(0x7E)&63 = 62 -> '-', '>'(0x3E) = 62 -> '-', '?'(0x3F) = 63 ->
+    // '_'. A run of three identical such chars covers all three offsets mod 3, so one is guaranteed
+    // to hit the boundary regardless of the marker's position — giving a deterministic base64url
+    // payload that the old Convert.FromBase64String path rejected.
+    [Theory]
+    [InlineData('-', "~~~")]
+    [InlineData('_', "???")]
+    public void ParseClaims_PayloadWithBase64UrlChar_ParsesUsername(char urlChar, string marker)
+    {
+        var jwt = BuildJwt(new { unique_name = "owner", marker });
+        var body = jwt.Split('.')[1];
+        Assert.Contains(urlChar, body); // sanity: this token genuinely exercises base64url
+
+        var claims = JwtClaimParser.ParseClaims(jwt);
+
+        Assert.Equal("owner", claims.FirstOrDefault(c => c.Type == "unique_name")?.Value);
+    }
+
+    [Theory]
+    [InlineData("~~~")]
+    [InlineData("???")]
+    public void ParseClaims_PayloadStandardBase64WouldReject_StillDecodes(string marker)
+    {
+        // Prove the regression: the old path (Convert.FromBase64String after the previous code's
+        // %4 padding) throws on exactly these base64url payloads, yet the new parser still decodes.
+        var jwt = BuildJwt(new { unique_name = "owner", marker });
+        var body = jwt.Split('.')[1];
+        var padded = (body.Length % 4) switch { 2 => body + "==", 3 => body + "=", _ => body };
+        Assert.Throws<FormatException>(() => Convert.FromBase64String(padded));
+
+        var claims = JwtClaimParser.ParseClaims(jwt);
+
+        Assert.Equal("owner", claims.FirstOrDefault(c => c.Type == "unique_name")?.Value);
+    }
+
+    [Fact]
+    public void ParseClaims_ValidToken_ReturnsAllClaims()
+    {
+        var jwt = BuildJwt(new { unique_name = "owner", exp = Unix(DateTimeOffset.UtcNow.AddHours(1)) });
+
+        var claims = JwtClaimParser.ParseClaims(jwt);
+
+        Assert.Contains(claims, c => c.Type == "unique_name" && c.Value == "owner");
+        Assert.Contains(claims, c => c.Type == "exp");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-jwt")]        // no dot, single segment
+    [InlineData("header.only")]      // payload is "only" — invalid base64url/JSON
+    [InlineData("a..c")]             // empty payload segment
+    public void ParseClaims_MalformedToken_ReturnsEmpty(string? jwt)
+    {
+        Assert.Empty(JwtClaimParser.ParseClaims(jwt));
+    }
+
+    [Fact]
+    public void IsExpired_ExpInPast_ReturnsTrue()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var claims = new[] { new Claim("exp", Unix(now.AddMinutes(-1)).ToString()) };
+
+        Assert.True(JwtClaimParser.IsExpired(claims, now));
+    }
+
+    [Fact]
+    public void IsExpired_ExpInFuture_ReturnsFalse()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var claims = new[] { new Claim("exp", Unix(now.AddMinutes(1)).ToString()) };
+
+        Assert.False(JwtClaimParser.IsExpired(claims, now));
+    }
+
+    [Fact]
+    public void IsExpired_NoExpClaim_ReturnsFalse()
+    {
+        var claims = new[] { new Claim("unique_name", "owner") };
+
+        Assert.False(JwtClaimParser.IsExpired(claims, DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void IsExpired_UnparseableExp_ReturnsFalse()
+    {
+        var claims = new[] { new Claim("exp", "not-a-number") };
+
+        Assert.False(JwtClaimParser.IsExpired(claims, DateTimeOffset.UtcNow));
+    }
+}

--- a/Vanadium.Note.REST.Tests/Vanadium.Note.REST.Tests.csproj
+++ b/Vanadium.Note.REST.Tests/Vanadium.Note.REST.Tests.csproj
@@ -35,6 +35,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Vanadium.Note.REST\Vanadium.Note.REST.csproj" />
+    <!-- Referenced only to unit-test the dependency-free Vanadium.Note.Web.Auth.JwtClaimParser
+         (issue #297); the Web project is Blazor WASM but JwtClaimParser has no Blazor/JS deps. -->
+    <ProjectReference Include="..\Vanadium.Note.Web\Vanadium.Note.Web.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Vanadium.Note.Web/Auth/JwtAuthenticationStateProvider.cs
+++ b/Vanadium.Note.Web/Auth/JwtAuthenticationStateProvider.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Components.Authorization;
 using System.Security.Claims;
-using System.Text.Json;
 
 namespace Vanadium.Note.Web.Auth;
 
@@ -31,7 +30,21 @@ public class JwtAuthenticationStateProvider : AuthenticationStateProvider
         if (string.IsNullOrWhiteSpace(token))
             return Anonymous;
 
-        var claims = ParseClaimsFromJwt(token);
+        var claims = JwtClaimParser.ParseClaims(token);
+        if (claims.Count == 0)
+        {
+            logger.LogWarning("JWT produced no claims — token may be malformed or corrupted.");
+            return Anonymous;
+        }
+
+        // An expired token must not present as authenticated, otherwise a stale JWT flashes a
+        // logged-in shell before the first API 401 forces re-login (issue #297).
+        if (JwtClaimParser.IsExpired(claims, DateTimeOffset.UtcNow))
+        {
+            logger.LogInformation("JWT is expired — treating as anonymous.");
+            return Anonymous;
+        }
+
         var identity = new ClaimsIdentity(claims, "jwt");
         return new AuthenticationState(new ClaimsPrincipal(identity));
     }
@@ -39,34 +52,5 @@ public class JwtAuthenticationStateProvider : AuthenticationStateProvider
     public void NotifyAuthStateChanged()
     {
         NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
-    }
-
-    private IEnumerable<Claim> ParseClaimsFromJwt(string jwt)
-    {
-        var payload = jwt.Split('.').ElementAtOrDefault(1);
-        if (payload is null)
-        {
-            logger.LogWarning("JWT is malformed — missing payload segment.");
-            return [];
-        }
-
-        var padded = (payload.Length % 4) switch
-        {
-            2 => payload + "==",
-            3 => payload + "=",
-            _ => payload,
-        };
-
-        try
-        {
-            var jsonBytes = Convert.FromBase64String(padded);
-            var pairs = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(jsonBytes);
-            return pairs?.Select(p => new Claim(p.Key, p.Value.ToString())) ?? [];
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to parse JWT claims — token may be malformed or corrupted.");
-            return [];
-        }
     }
 }

--- a/Vanadium.Note.Web/Auth/JwtClaimParser.cs
+++ b/Vanadium.Note.Web/Auth/JwtClaimParser.cs
@@ -1,0 +1,64 @@
+using System.Buffers.Text;
+using System.Security.Claims;
+using System.Text.Json;
+
+namespace Vanadium.Note.Web.Auth;
+
+/// <summary>
+/// Pure, dependency-free parsing of a JWT's payload segment into claims (issue #297).
+///
+/// <para>
+/// A JWT payload is <c>base64url</c>-encoded (RFC 7515 §2: <c>-</c>/<c>_</c> instead of
+/// <c>+</c>/<c>/</c>, padding stripped), NOT standard base64. Decoding it with
+/// <c>Convert.FromBase64String</c> throws <c>FormatException</c> whenever the encoded
+/// <c>exp</c>/<c>iat</c> bytes happen to produce a <c>-</c> or <c>_</c>, which previously left the
+/// user authenticated but nameless and made the Settings/Logout buttons vanish intermittently.
+/// <see cref="System.Buffers.Text.Base64Url"/> decodes base64url directly, including the missing
+/// padding, so any valid token parses.
+/// </para>
+///
+/// <para>
+/// This type is deliberately free of Blazor/JS-interop dependencies so it can be unit-tested.
+/// </para>
+/// </summary>
+public static class JwtClaimParser
+{
+    /// <summary>
+    /// Parses the claims out of <paramref name="jwt"/>'s payload segment. Returns an empty list if
+    /// the token is malformed, the payload segment is missing, or the payload is not valid JSON.
+    /// </summary>
+    public static IReadOnlyList<Claim> ParseClaims(string? jwt)
+    {
+        if (string.IsNullOrWhiteSpace(jwt)) return [];
+
+        var segments = jwt.Split('.');
+        if (segments.Length < 2) return [];
+
+        var payload = segments[1];
+        if (payload.Length == 0) return [];
+
+        try
+        {
+            var jsonBytes = Base64Url.DecodeFromChars(payload);
+            var pairs = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(jsonBytes);
+            if (pairs is null) return [];
+            return pairs.Select(p => new Claim(p.Key, p.Value.ToString())).ToList();
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="claims"/> carry an <c>exp</c> claim (Unix seconds) whose
+    /// instant is at or before <paramref name="now"/>. A token without a parseable <c>exp</c> is
+    /// treated as not-expired, so this never rejects a token on the basis of a missing claim.
+    /// </summary>
+    public static bool IsExpired(IEnumerable<Claim> claims, DateTimeOffset now)
+    {
+        var exp = claims.FirstOrDefault(c => c.Type == "exp")?.Value;
+        if (exp is null || !long.TryParse(exp, out var seconds)) return false;
+        return DateTimeOffset.FromUnixTimeSeconds(seconds) <= now;
+    }
+}


### PR DESCRIPTION
Closes #297

## 문제
클라이언트가 JWT payload를 `Convert.FromBase64String`(표준 base64)로 디코드했다. JWT payload는 **base64url**(`-`/`_`)이라, `exp`/`iat` 인코딩 결과에 `-`/`_`가 섞이면 `FormatException`으로 클레임이 비어버린다. 인증 타입은 살아 있어 로그인은 되지만 `unique_name`이 null → NavMenu의 `_username`이 null → **Settings/Logout 버튼이 간헐적으로 사라지는** 재현 불가 버그였다.

## 변경
- **`JwtClaimParser`(신규)** — Blazor/JS 의존성이 없는 순수 정적 클래스. `System.Buffers.Text.Base64Url.DecodeFromChars`로 base64url payload를 직접 디코드(패딩 없이). `exp` 클레임(Unix seconds)을 읽어 만료 여부를 판정하는 `IsExpired`도 제공.
- **`JwtAuthenticationStateProvider`** — 인라인 파싱을 `JwtClaimParser`로 교체. 클레임이 비면 익명 처리하고, `exp`가 지난 토큰은 익명으로 취급해 만료 토큰의 플래시 로그인을 제거.
- **테스트** — `JwtClaimParserTests`(REST.Tests). 순수 클래스 검증을 위해 테스트 프로젝트에서 Web 프로젝트를 `ProjectReference`로 참조(패키지 의존성 추가 아님).

## 완료 조건 검증
- [x] **payload에 `-`/`_`가 포함된 JWT도 클레임 정상 파싱(username 비어있지 않음)** — `ParseClaims_PayloadWithBase64UrlChar_ParsesUsername`(`-`/`_` 각각), `ParseClaims_PayloadStandardBase64WouldReject_StillDecodes`가 옛 표준 base64 경로는 `FormatException`을 던지지만 새 파서는 `unique_name=owner`를 반환함을 검증.
- [x] **만료된(exp 지난) 토큰은 인증 상태로 취급되지 않음** — `IsExpired_ExpInPast_ReturnsTrue`/`ExpInFuture_ReturnsFalse`/`NoExpClaim`/`UnparseableExp`로 판정 로직 검증, 프로바이더가 만료 시 `Anonymous` 반환.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0.
- [x] **전체 테스트** — `dotnet test Vanadium.slnx` 191 통과 / 3 스킵(PostgreSQL 전용, 기존) / 0 실패.

## 범위 준수
- 서버 측 JWT 검증(issuer/audience 미검사, 단일 테넌트)은 변경하지 않음 — 클라이언트 파싱만 수정.
- 리프레시 토큰을 도입하지 않음 — 만료 시 재로그인 방침 유지(만료 토큰을 익명 처리할 뿐).

## 참고
- 프론트엔드(Blazor WASM) 버그라 실제 버튼 표시는 브라우저에서의 수동 확인이 필요할 수 있으나, 파싱·만료 로직은 위 단위 테스트로 검증됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
