### PR TITLE
#298 제목 전파 시 참조 노트 낙관적 동시성 처리

### DIFF
--- a/Vanadium.Note.REST.Tests/TitlePropagationConcurrencyTests.cs
+++ b/Vanadium.Note.REST.Tests/TitlePropagationConcurrencyTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression coverage for issue #298: title-change propagation
+/// (<c>NoteService.UpdatePageLinkReferences</c>) must advance each referencing note's microsecond
+/// <see cref="NoteItem.UpdatedAt"/> and must not overwrite a concurrent edit to a referencing note.
+/// Before the fix, propagation neither bumped <c>UpdatedAt</c> nor tolerated a conflict — a
+/// concurrent edit surfaced as an uncaught <see cref="DbUpdateConcurrencyException"/> that failed
+/// the whole request after the title note had already been saved.
+/// </summary>
+public class TitlePropagationConcurrencyTests
+{
+    // A page-link node in note B that references note A, showing A's title. Matches the shape the
+    // editor serializes and the data-note-id="{id}" scan that WhereReferencesNote keys on.
+    private static string PageLinkTo(Guid referencedId, string title) =>
+        $"<div data-type=\"page-link\" data-note-id=\"{referencedId}\" data-title=\"{title}\" class=\"page-link-block\">" +
+        $"<span class=\"page-link-icon\">📄</span><span class=\"page-link-title\">{title}</span></div>";
+
+    private static async Task<(NoteItem? Note, bool Conflict, bool Archived)> ChangeTitleAsync(
+        TestHost h, NoteItem note, string newTitle) =>
+        await h.Notes.Update(note.Id,
+            new NoteItem { Title = newTitle, Content = note.Content, UpdatedAt = note.UpdatedAt });
+
+    [Fact]
+    public async Task TitleChange_PropagatesToReferencingNote_AndBumpsUpdatedAt()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Old Title");
+        var referrer = await h.CreateNoteAsync("Referrer", content: PageLinkTo(target.Id, "Old Title"));
+        var versionBefore = referrer.UpdatedAt;
+
+        var (_, conflict, _) = await ChangeTitleAsync(h, target, "New Title");
+        Assert.False(conflict);
+
+        var fresh = await h.FindAsync(referrer.Id);
+        Assert.Contains("New Title", fresh!.Content);       // title propagated into the page-link
+        Assert.DoesNotContain("Old Title", fresh.Content);
+        Assert.True(fresh.UpdatedAt > versionBefore);       // AC1: UpdatedAt advanced
+    }
+
+    [Fact]
+    public async Task TitleChange_ConcurrentEditOnReferencingNote_IsNotOverwritten()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Old Title");
+        var referrer = await h.CreateNoteAsync("Referrer",
+            content: PageLinkTo(target.Id, "Old Title") + "<p>original body</p>");
+
+        // Simulate a concurrent editor saving note B (the referrer) AFTER the service last read it:
+        // a raw UPDATE advances the DB row's UpdatedAt and content, bypassing the change tracker, so
+        // the still-tracked instance carries a stale concurrency token — exactly the mid-propagation
+        // race the fix must survive. The page-link is kept so the note still matches the reference scan.
+        var concurrentContent = PageLinkTo(target.Id, "Old Title") + "<p>CONCURRENT EDIT</p>";
+        var concurrentVersion = DateTime.UtcNow.AddMinutes(5);
+        await h.Db.Database.ExecuteSqlAsync(
+            $"UPDATE Notes SET Content = {concurrentContent}, UpdatedAt = {concurrentVersion} WHERE Id = {referrer.Id}");
+
+        // Changing A's title triggers propagation to B. It must not throw and must not lose the edit.
+        var (_, conflict, _) = await ChangeTitleAsync(h, target, "New Title");
+        Assert.False(conflict);
+
+        var fresh = await h.FindAsync(referrer.Id);
+        Assert.Contains("CONCURRENT EDIT", fresh!.Content);  // the concurrent edit survived (not overwritten)
+        Assert.Contains("New Title", fresh.Content);         // and the title was still layered on top
+        Assert.DoesNotContain("original body", fresh.Content);
+    }
+}

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -427,19 +427,73 @@ public class NoteService(
 
         if (referencingNotes.Count == 0) return;
 
+        // Save each referencing note on its own so one note losing an optimistic-concurrency race
+        // cannot abort propagation to the others, and so the conflict can be resolved per note
+        // (issue #298). The previous single batch save neither advanced UpdatedAt nor tolerated a
+        // conflict — a concurrent edit to any referencing note would surface as an uncaught
+        // DbUpdateConcurrencyException that failed the whole request after the title note had
+        // already been saved.
+        var propagated = 0;
         foreach (var n in referencingNotes)
         {
-            var updated = UpdatePageLinkTitleInContent(n.Content, noteId, newTitle);
-            updated = UpdateMentionTitleInContent(updated, noteId, newTitle);
-            if (updated == n.Content) continue;
-            n.Content = updated;
-            n.ContentText = StripHtml(updated);
+            if (await TryPropagateTitleToNote(n, noteId, newTitle, ct))
+                propagated++;
         }
 
-        await db.SaveChangesAsync(ct);
         logger.LogInformation(
-            "Propagated title change to '{NewTitle}' across {Count} note(s) referencing {NoteId}.",
-            newTitle, referencingNotes.Count, noteId);
+            "Propagated title change to '{NewTitle}' across {Count} of {Total} note(s) referencing {NoteId}.",
+            newTitle, propagated, referencingNotes.Count, noteId);
+    }
+
+    /// <summary>
+    /// Rewrites the page-link/mention titles that reference <paramref name="referencedId"/> inside a
+    /// single note, advances its microsecond <see cref="NoteItem.UpdatedAt"/>, and saves it on its
+    /// own. Because <c>UpdatedAt</c> is a <c>[ConcurrencyCheck]</c> token, EF pins the version we
+    /// read into the UPDATE's WHERE clause; if a concurrent editor advanced the row in between, the
+    /// save conflicts and we reload the note's current content and re-apply the title on top of that
+    /// edit instead of silently overwriting it. Returns true when the note was persisted with the new
+    /// title. Best-effort: after a bounded number of losing races the note is left untouched (its own
+    /// next save will refresh the stale title), so a hot-edited note never blocks the request.
+    /// </summary>
+    private async Task<bool> TryPropagateTitleToNote(
+        NoteItem note, Guid referencedId, string newTitle, CancellationToken ct)
+    {
+        const int maxAttempts = 3;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            var updated = UpdatePageLinkTitleInContent(note.Content, referencedId, newTitle);
+            updated = UpdateMentionTitleInContent(updated, referencedId, newTitle);
+            if (updated == note.Content) return false;
+
+            note.Content = updated;
+            note.ContentText = StripHtml(updated);
+            // Advance the version so the change is detectable by optimistic concurrency; the
+            // pre-save (original) value remains the token EF places in the UPDATE's WHERE clause.
+            note.UpdatedAt = UtcNowMicroseconds();
+
+            try
+            {
+                await db.SaveChangesAsync(ct);
+                return true;
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                // A concurrent edit advanced this note between our read and save. Reload its current
+                // state and retry so the title change layers onto that edit rather than clobbering it.
+                await db.Entry(note).ReloadAsync(ct);
+                if (db.Entry(note).State == EntityState.Detached)
+                {
+                    // The referencing note was hard-deleted mid-propagation — nothing left to update.
+                    return false;
+                }
+            }
+        }
+
+        logger.LogWarning(
+            "Skipped title propagation to note {NoteId} after {Attempts} conflicting attempts; its "
+            + "next own save will refresh the stale reference title.",
+            note.Id, maxAttempts);
+        return false;
     }
 
     private static string UpdateMentionTitleInContent(string content, Guid noteId, string newTitle)


### PR DESCRIPTION
Closes #298

## 문제
`UpdatePageLinkReferences`가 참조 노트들을 로드·치환한 뒤 **UpdatedAt 갱신도 충돌 검사도 없이** 한 번의 `SaveChangesAsync`로 저장했다. `UpdatedAt`은 `[ConcurrencyCheck]` 토큰이라 EF가 UPDATE의 WHERE에 읽은 버전을 넣는데, 전파 도중 참조 노트가 동시 편집되면 그 저장이 `DbUpdateConcurrencyException`을 던지고 — **잡히지 않은 채** — 본 노트 저장이 이미 커밋된 뒤 전체 요청을 실패시켰다. 또한 UpdatedAt을 올리지 않아 전파된 변경이 낙관적 동시성에 감지되지 않았다. 본 노트 `Update` 경로의 견고한 동시성 처리와 대비됐다.

## 변경
- **`NoteService.UpdatePageLinkReferences`** — 참조 노트를 **노트별로 개별 저장**하도록 변경. 한 노트의 충돌이 나머지 전파를 막지 않는다.
- **`TryPropagateTitleToNote`(신규 private)** — 참조 노트의 page-link/mention 제목을 치환하고 **마이크로초 `UpdatedAt`을 갱신**한 뒤 저장. `[ConcurrencyCheck]`가 읽은 버전을 WHERE에 고정하므로, 동시 편집으로 충돌이 나면 노트를 `ReloadAsync`로 리로드해 **최신 콘텐츠 위에 제목을 다시 적용**(최대 3회)한다. 계속 실패하면 스킵(그 노트의 다음 자체 저장이 제목을 갱신) — 핫 편집 노트가 요청을 막지 않는다. 중간에 하드 삭제된 노트는 Detached 감지로 안전 종료.

## 완료 조건 검증
- [x] **제목 전파가 참조 노트의 UpdatedAt을 마이크로초로 갱신** — `TitleChange_PropagatesToReferencingNote_AndBumpsUpdatedAt`가 전파 후 `UpdatedAt > versionBefore`와 제목 치환을 검증.
- [x] **전파 중 충돌 시 덮어쓰지 않고 스킵/재시도** — `TitleChange_ConcurrentEditOnReferencingNote_IsNotOverwritten`가 raw SQL로 추적기를 우회해 참조 노트 행을 동시 갱신(충돌 재현)한 뒤, 전파가 예외 없이 완료되고 **동시 편집(CONCURRENT EDIT)이 보존된 채 새 제목이 위에 적용**됨을 검증.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0.
- [x] **전체 테스트** — `dotnet test Vanadium.slnx` 193 통과 / 3 스킵(PostgreSQL 전용, 기존) / 0 실패.

## 범위 준수
- 본 노트 `Update` 경로의 clientVersion 기반 낙관적 동시성 로직은 변경하지 않음.
- `IgnoreQueryFilters`로 soft-deleted 참조 노트까지 제목을 갱신하는 동작 유지.
- 참조 정규화 테이블(#141)은 범위 밖으로 손대지 않음 — 본 PR은 기존 콘텐츠 재작성 경로를 동시성-안전하게 만드는 데 한정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
