### PR TITLE
#299 제목 전파 replacement에서 $ 이스케이프

### DIFF
--- a/Vanadium.Note.REST.Tests/TitleDollarEscapingTests.cs
+++ b/Vanadium.Note.REST.Tests/TitleDollarEscapingTests.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression coverage for issue #299: title-change propagation rewrites page-link/mention markup
+/// with <c>Regex.Replace</c>, and <c>'$'</c> is a substitution metacharacter in the replacement
+/// string (<c>$&amp;</c>, <c>$`</c>, <c>$1</c>, ...). <c>HtmlEncode</c> leaves <c>'$'</c> alone, so a
+/// title such as "Cost is $100" or "Whole $&amp; match" corrupted every referencing note's link
+/// before the fix. The propagated title must land in the markup verbatim.
+/// </summary>
+public class TitleDollarEscapingTests
+{
+    private static string PageLinkTo(Guid referencedId, string title) =>
+        $"<div data-type=\"page-link\" data-note-id=\"{referencedId}\" data-title=\"{title}\" class=\"page-link-block\">" +
+        $"<span class=\"page-link-icon\">📄</span><span class=\"page-link-title\">{title}</span></div>";
+
+    private static string MentionTo(Guid referencedId, string title) =>
+        $"<a data-type=\"note-mention\" data-note-id=\"{referencedId}\" data-title=\"{title}\" class=\"note-mention\">@{title}</a>";
+
+    [Theory]
+    [InlineData("Cost is $100")]      // AC example: $1/$10/$100 look like group references
+    [InlineData("$1 reference")]      // leading numbered-group token
+    [InlineData("Whole $& match")]    // $& = entire match — corrupts markup pre-fix
+    [InlineData("Before $` after")]   // $` = text before match — corrupts markup pre-fix
+    [InlineData("Double $$ sign")]    // $$ = literal $ — collapses pre-fix
+    public async Task TitleWithDollar_PropagatesVerbatim_WithoutCorruption(string dollarTitle)
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Placeholder");
+        var referrer = await h.CreateNoteAsync("Referrer",
+            content: PageLinkTo(target.Id, "Placeholder") + MentionTo(target.Id, "Placeholder"));
+
+        var (_, conflict, _) = await h.Notes.Update(target.Id,
+            new NoteItem { Title = dollarTitle, Content = target.Content, UpdatedAt = target.UpdatedAt });
+        Assert.False(conflict);
+
+        var fresh = await h.FindAsync(referrer.Id);
+        var encoded = WebUtility.HtmlEncode(dollarTitle);
+
+        // page-link: both the data-title attribute and the visible text carry the exact title.
+        Assert.Contains($"data-title=\"{encoded}\"", fresh!.Content);
+        Assert.Contains($"📄 {encoded}</div>", fresh.Content);
+        // mention: visible text carries the exact title.
+        Assert.Contains($"@{encoded}</a>", fresh.Content);
+        // No substitution artifact: the pre-change title (which $& / $` would have injected) is gone,
+        // and every reference was rewritten.
+        Assert.DoesNotContain("Placeholder", fresh.Content);
+    }
+}

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -501,13 +501,18 @@ public class NoteService(
         if (string.IsNullOrEmpty(content)) return content;
         var idStr = noteId.ToString();
         var encodedTitle = WebUtility.HtmlEncode(newTitle);
+        // HtmlEncode leaves '$' untouched, and '$' is a substitution metacharacter in a
+        // Regex.Replace replacement string ($1, $&, ...). Escape it as '$$' for the inner
+        // attribute rewrite so a title like "Cost is $100" is inserted literally (issue #299).
+        // The MatchEvaluator return below is used verbatim, so it keeps the unescaped title.
+        var replacementTitle = encodedTitle.Replace("$", "$$");
 
         return Regex.Replace(
             content,
             $@"(<a\s[^>]*data-note-id=""{Regex.Escape(idStr)}""[^>]*>)@[^<]*(</a>)",
             m =>
             {
-                var openTag = Regex.Replace(m.Groups[1].Value, @"data-title=""[^""]*""", $@"data-title=""{encodedTitle}""");
+                var openTag = Regex.Replace(m.Groups[1].Value, @"data-title=""[^""]*""", $@"data-title=""{replacementTitle}""");
                 return $"{openTag}@{encodedTitle}{m.Groups[2].Value}";
             },
             RegexOptions.Singleline | RegexOptions.IgnoreCase);
@@ -529,6 +534,10 @@ public class NoteService(
         if (string.IsNullOrEmpty(content)) return content;
         var idStr = noteId.ToString();
         var encodedTitle = WebUtility.HtmlEncode(newTitle);
+        // '$' survives HtmlEncode and is a substitution metacharacter in a Regex.Replace
+        // replacement string, so escape it as '$$' before both inner rewrites — otherwise a title
+        // like "Cost is $100" would corrupt the page-link markup (issue #299).
+        var replacementTitle = encodedTitle.Replace("$", "$$");
 
         return Regex.Replace(
             content,
@@ -536,8 +545,8 @@ public class NoteService(
             m =>
             {
                 var tag = m.Value;
-                tag = Regex.Replace(tag, @"data-title=""[^""]*""", $@"data-title=""{encodedTitle}""");
-                tag = Regex.Replace(tag, @">.*?</div>$", $">📄 {encodedTitle}</div>", RegexOptions.Singleline);
+                tag = Regex.Replace(tag, @"data-title=""[^""]*""", $@"data-title=""{replacementTitle}""");
+                tag = Regex.Replace(tag, @">.*?</div>$", $">📄 {replacementTitle}</div>", RegexOptions.Singleline);
                 return tag;
             },
             RegexOptions.Singleline | RegexOptions.IgnoreCase);


### PR DESCRIPTION
Closes #299

## 문제
`UpdatePageLinkTitleInContent` / `UpdateMentionTitleInContent`가 참조 마크업을 `Regex.Replace`로 재작성하는데, 내부 replacement 문자열에 `HtmlEncode`된 제목을 그대로 넣었다. `HtmlEncode`는 `$`를 인코딩하지 않고, `$`는 `Regex.Replace` replacement의 치환 메타문자(`$&` 전체 매치, `` $` `` 앞 텍스트, `$1` 그룹 등)라, `Cost is $100`이나 `Whole $& match` 같은 제목을 참조하는 모든 노트의 링크 마크업이 손상됐다.

## 변경
`NoteService.cs`의 두 헬퍼에서 replacement에 쓰이는 제목만 `$` → `$$`로 이스케이프한 `replacementTitle`을 사용:
- 이슈 456행 → mention `data-title` 치환
- 이슈 485행 → page-link `data-title` 치환
- 이슈 486행 → page-link 표시 텍스트(`📄 {title}`) 치환

`MatchEvaluator` 반환값으로 쓰이는 mention 표시 텍스트(`@{encodedTitle}`)는 치환이 아니라 **리터럴**로 사용되므로 이스케이프하지 않고 그대로 둔다. `WebUtility.HtmlEncode` 자체와 `data-note-id` 매칭 정규식은 변경하지 않았다.

## 완료 조건 검증
- [x] **`$` 포함 제목으로 전파해도 참조 마크업이 손상되지 않는다** — `TitleDollarEscapingTests`가 `Cost is $100` / `$1 reference` / `Whole $& match` / `` Before $` after `` / `Double $$ sign`으로 전파 후 page-link의 `data-title`·표시 텍스트와 mention 표시 텍스트가 리터럴(HtmlEncode)로 정확히 갱신됨을 검증. 수정 전에는 `$&`/`` $` ``/`$$` 케이스가 실패(치환 메타문자 해석)함을 stash 후 재실행으로 확인.
- [x] **456/485/486행의 replacement가 모두 `$` 이스케이프로 처리** — 세 곳 모두 `replacementTitle` 사용.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0.
- [x] **전체 테스트** — `dotnet test Vanadium.slnx` 198 통과 / 3 스킵(PostgreSQL 전용, 기존) / 0 실패.

## 범위 준수
- `WebUtility.HtmlEncode` 유지 — `$` 이스케이프만 추가.
- `data-note-id` 매칭 정규식 등 치환 대상 선택 로직 미변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
