### PR TITLE
#300 업로드 매직바이트 검증 partial read 수정

### DIFF
--- a/Vanadium.Note.REST.Tests/MagicBytePartialReadTests.cs
+++ b/Vanadium.Note.REST.Tests/MagicBytePartialReadTests.cs
@@ -1,0 +1,87 @@
+using Vanadium.Note.REST.Controllers;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Guards against the partial-read bug in upload magic-byte validation (issue #300).
+/// A single <see cref="Stream.ReadAsync(Memory{byte}, System.Threading.CancellationToken)"/>
+/// is not guaranteed to fill the buffer — on a chunk boundary it may return fewer bytes than
+/// requested, which would wrongly reject valid files (WebP needs all 12 bytes). The validation
+/// must fill the buffer (or reach EOF) before inspecting the magic bytes.
+/// </summary>
+public class MagicBytePartialReadTests
+{
+    // A stream that hands out at most <paramref name="chunkSize"/> bytes per ReadAsync call,
+    // reproducing the chunk boundary that made valid uploads fail intermittently.
+    private sealed class ChunkedStream(byte[] data, int chunkSize) : Stream
+    {
+        private int _position;
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var remaining = data.Length - _position;
+            if (remaining <= 0) return 0;
+            var toCopy = Math.Min(Math.Min(count, chunkSize), remaining);
+            Array.Copy(data, _position, buffer, offset, toCopy);
+            _position += toCopy;
+            return toCopy;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => data.Length;
+        public override long Position { get => _position; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private static byte[] WebpBytes()
+    {
+        var buffer = new byte[12];
+        buffer[0] = 0x52; buffer[1] = 0x49; buffer[2] = 0x46; buffer[3] = 0x46; // RIFF
+        buffer[4] = 0x24; buffer[5] = 0x00; buffer[6] = 0x00; buffer[7] = 0x00; // size (arbitrary)
+        buffer[8] = 0x57; buffer[9] = 0x45; buffer[10] = 0x42; buffer[11] = 0x50; // WEBP
+        return buffer;
+    }
+
+    [Theory]
+    [InlineData(1)]  // one byte per read — the worst chunk boundary
+    [InlineData(4)]  // first read returns only 4 bytes (< the 12 WebP needs)
+    [InlineData(11)] // one byte short of the full signature
+    [InlineData(12)] // whole buffer in a single read (the already-working case)
+    public async Task Files_Webp_IsAccepted_RegardlessOfChunkBoundary(int chunkSize)
+    {
+        await using var stream = new ChunkedStream(WebpBytes(), chunkSize);
+        Assert.True(await FilesController.HasValidMagicBytesAsync(stream, "image/webp"));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(11)]
+    [InlineData(12)]
+    public async Task Images_Webp_IsDetected_RegardlessOfChunkBoundary(int chunkSize)
+    {
+        await using var stream = new ChunkedStream(WebpBytes(), chunkSize);
+        Assert.Equal("image/webp", await ImagesController.DetectImageTypeAsync(stream));
+    }
+
+    [Fact]
+    public async Task Files_TruncatedStream_IsRejected()
+    {
+        // A stream shorter than the 12-byte WebP signature must still be rejected (EOF reached).
+        await using var stream = new ChunkedStream(WebpBytes()[..8], chunkSize: 1);
+        Assert.False(await FilesController.HasValidMagicBytesAsync(stream, "image/webp"));
+    }
+
+    [Fact]
+    public async Task Images_TruncatedStream_IsRejected()
+    {
+        await using var stream = new ChunkedStream(WebpBytes()[..8], chunkSize: 1);
+        Assert.Null(await ImagesController.DetectImageTypeAsync(stream));
+    }
+}

--- a/Vanadium.Note.REST/Controllers/FilesController.cs
+++ b/Vanadium.Note.REST/Controllers/FilesController.cs
@@ -131,9 +131,17 @@ public class FilesController(IWebHostEnvironment env, NoteDbContext db, ILogger<
 
     private static async Task<bool> HasValidMagicBytesAsync(IFormFile file, string contentType)
     {
-        var buffer = new byte[12];
         await using var stream = file.OpenReadStream();
-        var read = await stream.ReadAsync(buffer);
+        return await HasValidMagicBytesAsync(stream, contentType);
+    }
+
+    internal static async Task<bool> HasValidMagicBytesAsync(Stream stream, string contentType)
+    {
+        var buffer = new byte[12];
+        // A single ReadAsync may return fewer bytes than requested on a chunk boundary,
+        // which would wrongly reject valid files (WebP needs all 12 bytes). Fill the
+        // buffer up to its length (or EOF) before validating.
+        var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: false);
 
         return HasValidMagicBytes(buffer, read, contentType);
     }

--- a/Vanadium.Note.REST/Controllers/ImagesController.cs
+++ b/Vanadium.Note.REST/Controllers/ImagesController.cs
@@ -65,9 +65,17 @@ public class ImagesController(IWebHostEnvironment env, ILogger<ImagesController>
 
     private static async Task<string?> DetectImageTypeAsync(IFormFile file)
     {
-        var buffer = new byte[12];
         await using var stream = file.OpenReadStream();
-        var read = await stream.ReadAsync(buffer);
+        return await DetectImageTypeAsync(stream);
+    }
+
+    internal static async Task<string?> DetectImageTypeAsync(Stream stream)
+    {
+        var buffer = new byte[12];
+        // A single ReadAsync may return fewer bytes than requested on a chunk boundary,
+        // which would wrongly reject valid files (WebP needs all 12 bytes). Fill the
+        // buffer up to its length (or EOF) before validating.
+        var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: false);
         if (read < 4) return null;
 
         if (buffer[0] == 0xFF && buffer[1] == 0xD8 && buffer[2] == 0xFF)


### PR DESCRIPTION
Closes #300

## 문제
업로드 매직바이트 검증이 단일 `stream.ReadAsync(buffer)`에 의존했다. `ReadAsync`는 요청한 바이트 수를 보장하지 않으므로, 청크 경계에서 첫 read가 짧게 반환되면 정상 파일(WebP는 12바이트 필요)이 간헐적으로 거부되었다.

## 변경
- `FilesController.HasValidMagicBytesAsync` / `ImagesController.DetectImageTypeAsync`가 `ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: false)`로 버퍼를 채운 뒤 매직바이트를 검증하도록 수정.
- 테스트 가능하도록 각 메서드에 `Stream`을 받는 `internal` 오버로드를 추출(기존 `IFormFile` 경로는 이 오버로드로 위임). 매직바이트 시그니처 판정 규칙(`HasValidMagicBytes`)은 변경하지 않음.
- 청크 경계 회귀 테스트 추가(`MagicBytePartialReadTests`): read당 1/4/11/12바이트를 반환하는 스트림으로 두 컨트롤러 모두 검증. `chunkSize=1`에서 기존 코드는 실패, 수정 후 통과.

## 완료 조건 검증
- **첫 read가 짧아도 12바이트까지 채운 뒤 검증** — `ReadAtLeastAsync`가 버퍼(또는 EOF)까지 채움. `chunkSize` 1/4/11 Theory 테스트로 확인.
- **WebP 등 정상 파일이 청크 경계와 무관하게 성공** — `Files_Webp_IsAccepted_RegardlessOfChunkBoundary`, `Images_Webp_IsDetected_RegardlessOfChunkBoundary` 통과. 잘린 스트림(8바이트)은 여전히 거부됨을 확인.
- **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0개. 전체 테스트 208개 통과(사전 스킵 3개는 PostgreSQL 전용).

## 범위 밖 준수
- 13종 MIME 화이트리스트·100MB 상한 등 업로드 정책 미변경.
- 매직바이트 시그니처 판정 규칙 자체 미변경(버퍼 채우기만 수정).