### PR TITLE
#301 고아 파일 GC grace를 미참조 최초 관측 시점 기준으로

### DIFF
--- a/Vanadium.Note.REST.Tests/FileCleanupReferenceScanTests.cs
+++ b/Vanadium.Note.REST.Tests/FileCleanupReferenceScanTests.cs
@@ -88,6 +88,10 @@ public class FileCleanupReferenceScanTests
         var attachment = await AddAttachmentAsync(h, DateTime.UtcNow - BeyondGrace);
         await AddNoteAsync(h, "<p>no file references here</p>");
 
+        // Grace is measured from first-observed-unreferenced (issue #301): simulate an earlier
+        // scan that already saw it unreferenced beyond the grace window so this scan collects it.
+        h.OrphanTracker.ObserveUnreferenced(attachment.Id, DateTime.UtcNow - BeyondGrace);
+
         await h.FileCleanup.DeleteAllOrphansAsync();
 
         Assert.Null(await h.Db.FileAttachments.FindAsync(attachment.Id));

--- a/Vanadium.Note.REST.Tests/FileCleanupUnreferencedGraceTests.cs
+++ b/Vanadium.Note.REST.Tests/FileCleanupUnreferencedGraceTests.cs
@@ -1,0 +1,148 @@
+using Microsoft.EntityFrameworkCore;
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Tests for the first-observed-unreferenced grace window in
+/// <c>FileCleanupService.DeleteAllOrphansAsync</c> (issue #301): the grace window is
+/// measured from the first scan that saw an asset unreferenced, NOT from its upload/creation
+/// time. A draft asset that stays unsaved past the upload grace must therefore survive the
+/// scan that first observes it, and is only collected once it has stayed unreferenced for the
+/// whole grace window across scans.
+/// </summary>
+public class FileCleanupUnreferencedGraceTests
+{
+    // Pushes the tracker's "first observed unreferenced" instant for an asset far enough into
+    // the past that the next scan considers the grace window (default 60 min) elapsed.
+    private static void SeedUnreferencedLongAgo(TestHost h, Guid id) =>
+        h.OrphanTracker.ObserveUnreferenced(id, DateTime.UtcNow.AddDays(-1));
+
+    [Fact]
+    public async Task OrphanScan_AttachmentUploadedLongAgoButNeverScanned_SurvivesFirstScan()
+    {
+        using var h = new TestHost();
+
+        // Uploaded two hours ago (well past the 60-min upload grace) but never scanned before,
+        // e.g. a draft whose auto-save has been failing. Under the old upload-time grace this
+        // would be deleted; now the first scan only records it and must skip.
+        var attachment = new FileAttachment
+        {
+            OriginalName = "stuck-draft.txt",
+            ContentType = "text/plain",
+            UploadedAt = DateTime.UtcNow.AddHours(-2),
+        };
+        h.Db.FileAttachments.Add(attachment);
+        await h.Db.SaveChangesAsync();
+        var physicalPath = Path.Combine(h.ContentRoot, "uploads", $"file_{attachment.Id}");
+        await File.WriteAllTextAsync(physicalPath, "draft body");
+
+        await h.CreateNoteAsync("Unrelated", content: "<p>no references yet</p>");
+
+        await h.FileCleanup.DeleteAllOrphansAsync();
+
+        Assert.NotNull(await h.Db.FileAttachments.FindAsync(attachment.Id));
+        Assert.True(File.Exists(physicalPath));
+    }
+
+    [Fact]
+    public async Task OrphanScan_ImageCreatedLongAgoButNeverScanned_SurvivesFirstScan()
+    {
+        using var h = new TestHost();
+
+        var imageId = Guid.NewGuid();
+        var imagePath = Path.Combine(h.ContentRoot, "uploads", $"{imageId}.png");
+        await File.WriteAllTextAsync(imagePath, "png bytes");
+        File.SetCreationTimeUtc(imagePath, DateTime.UtcNow.AddHours(-2));
+        File.SetLastWriteTimeUtc(imagePath, DateTime.UtcNow.AddHours(-2));
+
+        await h.CreateNoteAsync("Unrelated", content: "<p>no references yet</p>");
+
+        await h.FileCleanup.DeleteAllOrphansAsync();
+
+        Assert.True(File.Exists(imagePath));
+    }
+
+    [Fact]
+    public async Task OrphanScan_AttachmentUnreferencedPastGrace_IsCollected()
+    {
+        using var h = new TestHost();
+
+        var attachment = new FileAttachment
+        {
+            OriginalName = "truly-orphaned.txt",
+            ContentType = "text/plain",
+            UploadedAt = DateTime.UtcNow.AddHours(-2),
+        };
+        h.Db.FileAttachments.Add(attachment);
+        await h.Db.SaveChangesAsync();
+        var physicalPath = Path.Combine(h.ContentRoot, "uploads", $"file_{attachment.Id}");
+        await File.WriteAllTextAsync(physicalPath, "orphan body");
+
+        await h.CreateNoteAsync("Unrelated", content: "<p>no references</p>");
+
+        // Simulate an earlier scan that already observed it unreferenced beyond the grace window.
+        SeedUnreferencedLongAgo(h, attachment.Id);
+
+        await h.FileCleanup.DeleteAllOrphansAsync();
+
+        Assert.Null(await h.Db.FileAttachments.FindAsync(attachment.Id));
+        Assert.False(File.Exists(physicalPath));
+    }
+
+    [Fact]
+    public async Task OrphanScan_ImageUnreferencedPastGrace_IsCollected()
+    {
+        using var h = new TestHost();
+
+        var imageId = Guid.NewGuid();
+        var imagePath = Path.Combine(h.ContentRoot, "uploads", $"{imageId}.png");
+        await File.WriteAllTextAsync(imagePath, "png bytes");
+
+        await h.CreateNoteAsync("Unrelated", content: "<p>no references</p>");
+
+        SeedUnreferencedLongAgo(h, imageId);
+
+        await h.FileCleanup.DeleteAllOrphansAsync();
+
+        Assert.False(File.Exists(imagePath));
+    }
+
+    [Fact]
+    public async Task OrphanScan_AttachmentReferencedAgainBeforeGrace_ResetsClockAndSurvives()
+    {
+        using var h = new TestHost();
+
+        var attachment = new FileAttachment
+        {
+            OriginalName = "rescued.txt",
+            ContentType = "text/plain",
+            UploadedAt = DateTime.UtcNow.AddHours(-2),
+        };
+        h.Db.FileAttachments.Add(attachment);
+        await h.Db.SaveChangesAsync();
+        var physicalPath = Path.Combine(h.ContentRoot, "uploads", $"file_{attachment.Id}");
+        await File.WriteAllTextAsync(physicalPath, "rescued body");
+
+        // The draft finally saved: a note now references the attachment.
+        await h.CreateNoteAsync("Saved",
+            content: $"<p><a href=\"/api/files/{attachment.Id}\">doc</a></p>");
+
+        // Even though a prior scan had marked it unreferenced past grace, it is referenced now.
+        SeedUnreferencedLongAgo(h, attachment.Id);
+
+        await h.FileCleanup.DeleteAllOrphansAsync();
+
+        Assert.NotNull(await h.Db.FileAttachments.FindAsync(attachment.Id));
+        Assert.True(File.Exists(physicalPath));
+
+        // The reset means a later unreferenced spell must accumulate grace afresh: a scan
+        // that observes it unreferenced for the first time again must NOT delete it.
+        await h.Db.Notes.ExecuteDeleteAsync();
+        await h.FileCleanup.DeleteAllOrphansAsync();
+
+        Assert.NotNull(await h.Db.FileAttachments.FindAsync(attachment.Id));
+        Assert.True(File.Exists(physicalPath));
+    }
+}

--- a/Vanadium.Note.REST.Tests/TestHost.cs
+++ b/Vanadium.Note.REST.Tests/TestHost.cs
@@ -25,6 +25,7 @@ public sealed class TestHost : IDisposable
     public LabelService Labels { get; }
     public AccountService Account { get; }
     public FileCleanupService FileCleanup { get; }
+    public OrphanReferenceTracker OrphanTracker { get; }
 
     /// <summary>Content root used by FileCleanupService ("uploads" lives below it).</summary>
     public string ContentRoot { get; }
@@ -45,8 +46,10 @@ public sealed class TestHost : IDisposable
         Directory.CreateDirectory(Path.Combine(ContentRoot, "uploads"));
 
         var configuration = new ConfigurationBuilder().Build();
+        OrphanTracker = new OrphanReferenceTracker();
         FileCleanup = new FileCleanupService(
-            Db, new TestWebHostEnvironment(ContentRoot), configuration, NullLogger<FileCleanupService>.Instance);
+            Db, new TestWebHostEnvironment(ContentRoot), configuration, OrphanTracker,
+            NullLogger<FileCleanupService>.Instance);
         Notes = new NoteService(Db, FileCleanup, new HtmlSanitizerService(), NullLogger<NoteService>.Instance);
         Labels = new LabelService(Db, NullLogger<LabelService>.Instance);
         Account = new AccountService(Db, NullLogger<AccountService>.Instance);

--- a/Vanadium.Note.REST.Tests/ToggleContentTests.cs
+++ b/Vanadium.Note.REST.Tests/ToggleContentTests.cs
@@ -178,6 +178,10 @@ public class ToggleContentTests
 
         await h.CreateNoteAsync("Unrelated", content: "<p>no references here</p>");
 
+        // Grace is measured from first-observed-unreferenced (issue #301): simulate an earlier
+        // scan that already saw it unreferenced beyond the grace window so this scan removes it.
+        h.OrphanTracker.ObserveUnreferenced(orphan.Id, DateTime.UtcNow.AddHours(-2));
+
         await h.FileCleanup.DeleteAllOrphansAsync();
 
         Assert.Null(await h.Db.FileAttachments.FindAsync(orphan.Id));

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -156,6 +156,9 @@ builder.Services.AddScoped<LabelService>();
 builder.Services.AddScoped<SettingsService>();
 builder.Services.AddScoped<ApiTokenService>();
 builder.Services.AddScoped<FileCleanupService>();
+// Singleton: holds first-observed-unreferenced timestamps across periodic scans so the
+// orphan grace window is measured from first sighting, not upload time (issue #301).
+builder.Services.AddSingleton<OrphanReferenceTracker>();
 builder.Services.AddScoped<AccountService>();
 
 builder.Services.Configure<PasswordPolicyOptions>(

--- a/Vanadium.Note.REST/Services/FileCleanupService.cs
+++ b/Vanadium.Note.REST/Services/FileCleanupService.cs
@@ -13,6 +13,7 @@ public class FileCleanupService(
     NoteDbContext db,
     IWebHostEnvironment env,
     IConfiguration config,
+    OrphanReferenceTracker tracker,
     ILogger<FileCleanupService> logger)
 {
     private const int DefaultGraceMinutes = 60;
@@ -65,11 +66,19 @@ public class FileCleanupService(
     /// </summary>
     public async Task DeleteAllOrphansAsync(CancellationToken ct = default)
     {
-        // Files uploaded within the grace window are skipped: a freshly uploaded
-        // file may not yet be referenced in any note's HTML because the editor
-        // auto-save is debounced (~1500ms) and the note may still be in progress.
+        // Grace is measured from when an asset was FIRST observed unreferenced by a scan
+        // (tracked in OrphanReferenceTracker), not from its upload/creation time. A freshly
+        // uploaded asset whose note draft has not been saved yet (auto-save debounced ~1500ms,
+        // delayed, offline, or abandoned) is therefore recorded on the first scan and skipped;
+        // it is only collected once it has stayed unreferenced for the whole grace window
+        // across scans. Any scan that finds the asset referenced again clears the record and
+        // resets the clock (issue #301).
+        var now = DateTime.UtcNow;
         var graceMinutes = config.GetValue("FileCleanup:GraceMinutes", DefaultGraceMinutes);
-        var graceCutoff = DateTime.UtcNow.AddMinutes(-graceMinutes);
+        var graceCutoff = now.AddMinutes(-graceMinutes);
+
+        // GUIDs still present this scan, so the tracker can prune vanished assets afterwards.
+        var liveIds = new HashSet<Guid>();
 
         // --- File attachments (have DB records) ---
         var attachments = await db.FileAttachments.ToListAsync(ct);
@@ -82,20 +91,30 @@ public class FileCleanupService(
 
         foreach (var attachment in attachments)
         {
-            if (await IsReferencedInAnyNoteAsync(attachment.Id, ct))
-                continue;
+            liveIds.Add(attachment.Id);
 
-            // Skip recently uploaded attachments still within the grace window.
-            if (attachment.UploadedAt > graceCutoff)
+            if (await IsReferencedInAnyNoteAsync(attachment.Id, ct))
+            {
+                // Referenced again — reset any accumulated unreferenced grace.
+                tracker.Forget(attachment.Id);
+                continue;
+            }
+
+            // Skip until the asset has been unreferenced for the whole grace window,
+            // measured from the first scan that observed it unreferenced.
+            var firstUnreferenced = tracker.ObserveUnreferenced(attachment.Id, now);
+            if (firstUnreferenced > graceCutoff)
             {
                 logger.LogDebug(
-                    "Periodic scan: skipping recently uploaded attachment {FileId} (within grace window).",
+                    "Periodic scan: skipping unreferenced attachment {FileId} (within grace window since first seen unreferenced).",
                     attachment.Id);
                 continue;
             }
 
             db.FileAttachments.Remove(attachment);
             DeletePhysicalFile(Path.Combine(UploadsPath, $"file_{attachment.Id}"));
+            tracker.Forget(attachment.Id);
+            liveIds.Remove(attachment.Id);
             logger.LogDebug("Periodic scan: removed orphaned file attachment {FileId} ('{FileName}').",
                 attachment.Id, attachment.OriginalName);
             filesRemoved++;
@@ -107,6 +126,7 @@ public class FileCleanupService(
         // --- Images (disk-only, no DB record) ---
         if (!Directory.Exists(UploadsPath))
         {
+            tracker.RetainOnly(liveIds);
             logger.LogInformation(
                 "Orphan cleanup complete — {Files} file attachment(s) and 0 image(s) removed.", filesRemoved);
             return;
@@ -124,23 +144,34 @@ public class FileCleanupService(
             if (!Guid.TryParse(guidStr, out var imageId))
                 continue;
 
-            if (await IsReferencedInAnyNoteAsync(imageId, ct))
-                continue;
+            liveIds.Add(imageId);
 
-            // Disk-only images have no DB record, so fall back to the file's
-            // creation time to honor the same grace window.
-            if (file.CreationTimeUtc > graceCutoff)
+            if (await IsReferencedInAnyNoteAsync(imageId, ct))
+            {
+                tracker.Forget(imageId);
+                continue;
+            }
+
+            // Same first-unreferenced grace as attachments: disk-only images have no DB
+            // record, so the tracker (not the file's creation time) supplies the clock.
+            var firstUnreferenced = tracker.ObserveUnreferenced(imageId, now);
+            if (firstUnreferenced > graceCutoff)
             {
                 logger.LogDebug(
-                    "Periodic scan: skipping recently created image {ImageFile} (within grace window).",
+                    "Periodic scan: skipping unreferenced image {ImageFile} (within grace window since first seen unreferenced).",
                     file.Name);
                 continue;
             }
 
             DeletePhysicalFile(file.FullName);
+            tracker.Forget(imageId);
+            liveIds.Remove(imageId);
             logger.LogDebug("Periodic scan: removed orphaned image {ImageFile}.", file.Name);
             imagesRemoved++;
         }
+
+        // Forget assets that disappeared by another path so records do not accumulate.
+        tracker.RetainOnly(liveIds);
 
         logger.LogInformation(
             "Orphan cleanup complete — {Files} file attachment(s) and {Images} image(s) removed.",

--- a/Vanadium.Note.REST/Services/OrphanReferenceTracker.cs
+++ b/Vanadium.Note.REST/Services/OrphanReferenceTracker.cs
@@ -1,0 +1,53 @@
+using System.Collections.Concurrent;
+
+namespace Vanadium.Note.REST.Services;
+
+/// <summary>
+/// Tracks, per uploaded-asset GUID, the UTC instant a periodic orphan scan first
+/// observed the asset as unreferenced. The grace window before an orphan is deleted
+/// is measured from this instant — NOT from the asset's upload/creation time — so a
+/// freshly uploaded asset whose note draft has not yet been saved (auto-save delayed,
+/// offline, or abandoned) is never collected on the first scan that sees it (issue #301).
+/// An asset must be confirmed unreferenced across the whole grace window before GC; any
+/// scan that finds it referenced again clears the record and resets the clock.
+/// <para>
+/// State is in-memory by design. A process restart clears the records, which only ever
+/// DELAYS a delete (the first post-restart scan re-observes the asset and restarts its
+/// grace clock) — it can never cause a premature delete, so the data-loss edge case the
+/// grace window guards against stays fixed regardless of restart timing. The trade-off is
+/// that a genuine orphan may linger a little longer; that is the intended safe direction.
+/// </para>
+/// </summary>
+public sealed class OrphanReferenceTracker
+{
+    private readonly ConcurrentDictionary<Guid, DateTime> _firstUnreferencedUtc = new();
+
+    /// <summary>
+    /// Records <paramref name="nowUtc"/> as the first-unreferenced instant for
+    /// <paramref name="id"/> if none is stored yet, and returns the stored instant.
+    /// On the first observation this returns <paramref name="nowUtc"/> itself, so the
+    /// caller sees the asset as still within its grace window.
+    /// </summary>
+    public DateTime ObserveUnreferenced(Guid id, DateTime nowUtc) =>
+        _firstUnreferencedUtc.GetOrAdd(id, nowUtc);
+
+    /// <summary>
+    /// Forgets any first-unreferenced record for <paramref name="id"/>. Called when the
+    /// asset is found referenced again (clock reset) or after it has been deleted.
+    /// </summary>
+    public void Forget(Guid id) => _firstUnreferencedUtc.TryRemove(id, out _);
+
+    /// <summary>
+    /// Drops records for every tracked GUID that is not in <paramref name="liveIds"/>,
+    /// so assets that vanished by another path (manual delete, on-delete cleanup) do not
+    /// leak entries. Called once at the end of a full scan.
+    /// </summary>
+    public void RetainOnly(IReadOnlySet<Guid> liveIds)
+    {
+        foreach (var tracked in _firstUnreferencedUtc.Keys)
+        {
+            if (!liveIds.Contains(tracked))
+                _firstUnreferencedUtc.TryRemove(tracked, out _);
+        }
+    }
+}


### PR DESCRIPTION
Closes #301

## 문제
`OrphanFileCleanupJob`의 주기 스캔이 grace(기본 60분)를 **업로드/생성 시각** 기준으로 판정한다. 이미지를 붙여넣어 자산이 디스크에 저장된 뒤 자동저장 실패·오프라인·방치로 초안이 60분 넘게 커밋되지 않으면, 스캔이 해당 자산을 미참조 + grace 경과로 보고 삭제해 이후 저장 시 깨진 이미지가 남았다. 하필 '저장이 실패하고 있던' 최악의 순간과 겹치는 데이터 손실 버그.

## 변경
grace 판정을 업로드 시각이 아니라 **미참조로 최초 관측된 시점** 기준으로 바꿨다.

- **`OrphanReferenceTracker`** (싱글턴, 인메모리): 자산 GUID별로 스캔이 처음 미참조로 관측한 UTC 시각을 보관한다.
- `DeleteAllOrphansAsync`(첨부·이미지 양쪽):
  - 참조가 있으면 → 기록을 지워 grace 시계 리셋
  - 미참조면 → 최초 관측 시각을 기록하고, 그 시점부터 grace 전체 구간이 지난 자산만 GC
  - 즉 미참조가 **누적 확인된** 자산만 삭제된다.
- 인메모리 상태는 재시작 시 초기화되지만, 이는 삭제를 **늦출 뿐 조기 삭제를 유발하지 않는** 안전한 방향이므로 스키마/마이그레이션 없이 처리했다. (파일 참조 URL 형식, `IgnoreQueryFilters` 스캔 의미는 그대로 유지 — 범위 밖 준수)

## 완료 조건 검증
- [x] **업로드 후 60분 넘게 초안 미저장이어도 미참조 자산이 즉시 삭제되지 않는다** — `OrphanScan_AttachmentUploadedLongAgoButNeverScanned_SurvivesFirstScan`, `OrphanScan_ImageCreatedLongAgoButNeverScanned_SurvivesFirstScan` (업로드 2시간 전 자산이 최초 스캔에서 생존)
- [x] **GC는 미참조가 누적 확인된 자산에 대해서만 수행** — `OrphanScan_AttachmentUnreferencedPastGrace_IsCollected`, `OrphanScan_ImageUnreferencedPastGrace_IsCollected` (이전 스캔이 grace 넘겨 관측한 경우에만 삭제), `OrphanScan_AttachmentReferencedAgainBeforeGrace_ResetsClockAndSurvives` (재참조 시 시계 리셋)
- [x] **EF Core 마이그레이션** — 컬럼/플래그를 도입하지 않고 인메모리 트래커로 처리하므로 해당 없음 (AC의 조건부 항목)
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0, `dotnet test` 213 통과 / 3 스킵

## 참고
순수 내부 동작 변경으로 REST API 표면 변화가 없어 `docs/api-specification.md`는 수정하지 않았다.
