### PR TITLE
#272 보드에 미분류(라벨 없음) 노트 가시화

### DIFF
--- a/Vanadium.Note.Web/Pages/Board.razor
+++ b/Vanadium.Note.Web/Pages/Board.razor
@@ -117,6 +117,65 @@
                     </div>
                 </div>
             }
+
+            @{
+                var unclassifiedNotes = GetUnclassifiedNotes();
+            }
+            @if (unclassifiedNotes.Any())
+            {
+                // "No label" virtual column: notes with none of this category's labels. It is
+                // display-only — no data-label-id (so drag-drop ignores it as a drop target) and
+                // its cards are not draggable, keeping the label-move semantics untouched (#272).
+                var unclassifiedExpanded = expandedColumns.Contains(UnclassifiedColumnKey);
+                var unclassifiedVisible = unclassifiedExpanded ? unclassifiedNotes : unclassifiedNotes.Take(CardsPerColumnLimit).ToList();
+                var unclassifiedHidden = unclassifiedNotes.Count - unclassifiedVisible.Count;
+
+                <div class="board-column board-column-unclassified">
+                    <div class="board-column-header">
+                        <span class="board-column-title">No label</span>
+                        <span class="board-column-count">@unclassifiedNotes.Count</span>
+                    </div>
+                    <div class="board-column-cards">
+                        @foreach (var note in unclassifiedVisible)
+                        {
+                            var capturedNote = note;
+                            <div class="board-card"
+                                 data-note-id="@capturedNote.Id"
+                                 @onclick="() => EditNote(capturedNote.Id)">
+                                <div class="board-card-title">
+                                    @(string.IsNullOrWhiteSpace(capturedNote.Title) ? "(No title)" : capturedNote.Title)
+                                </div>
+                                @if (capturedNote.Labels.Any())
+                                {
+                                    <div class="board-card-labels">
+                                        @foreach (var lbl in capturedNote.Labels)
+                                        {
+                                            <span class="board-card-chip @(lbl.CategoryId.HasValue ? "board-card-chip-cat" : "")">
+                                                @if (lbl.CategoryId.HasValue)
+                                                {
+                                                    <span class="board-card-chip-prefix">@lbl.CategoryName:</span>
+                                                }
+                                                @lbl.Name
+                                            </span>
+                                        }
+                                    </div>
+                                }
+                                <div class="board-card-date">
+                                    @capturedNote.UpdatedAt.ToLocalTime().ToString("MM-dd HH:mm")
+                                </div>
+                            </div>
+                        }
+                    </div>
+                    @if (unclassifiedHidden > 0)
+                    {
+                        <div class="board-column-showmore">
+                            <button class="board-showmore-btn" @onclick="() => ShowMore(UnclassifiedColumnKey)">
+                                Show @unclassifiedHidden more
+                            </button>
+                        </div>
+                    }
+                </div>
+            }
         </div>
     }
 </div>
@@ -164,6 +223,10 @@
     // does not grow the board's DOM/render cost without bound (#206). The rest
     // stay reachable behind a per-column "Show more" toggle.
     private const int CardsPerColumnLimit = 50;
+
+    // Sentinel key for the "No label" virtual column in expandedColumns. Real label ids
+    // are never Guid.Empty, so it can never collide with an actual column (#272).
+    private static readonly Guid UnclassifiedColumnKey = Guid.Empty;
 
     private IReadOnlyList<NoteSummary> notes = [];
     private List<LabelCategory> categories = [];
@@ -213,8 +276,10 @@
         }
         isLoading = true;
         StateHasChanged();
-        var labelIds = selectedCategory.Labels.Select(l => l.Id);
-        var notesResult = await NoteService.GetAllSummariesAsync(labelIds);
+        // Load every non-archived note (no label filter) so notes that carry none of this
+        // category's labels are available client-side for the "No label" virtual column (#272).
+        // Server-side label filtering would drop them entirely, making them invisible on the board.
+        var notesResult = await NoteService.GetAllSummariesAsync();
         if (!notesResult.IsSuccess)
             Snackbar.Add(notesResult.Error ?? "Failed to load notes.", Severity.Error);
         notes = notesResult.Value ?? [];
@@ -311,6 +376,18 @@
         notes.Where(n => n.Labels.Any(l => l.Id == labelId))
              .OrderByDescending(n => n.UpdatedAt)
              .ToList();
+
+    // Notes carrying none of the selected category's labels — surfaced in the "No label"
+    // virtual column so unclassified notes are not invisible on the board (#272).
+    private List<NoteSummary> GetUnclassifiedNotes()
+    {
+        if (selectedCategory is null)
+            return [];
+        var categoryLabelIds = selectedCategory.Labels.Select(l => l.Id).ToHashSet();
+        return notes.Where(n => !n.Labels.Any(l => categoryLabelIds.Contains(l.Id)))
+                    .OrderByDescending(n => n.UpdatedAt)
+                    .ToList();
+    }
 
     private void ShowMore(Guid labelId) => expandedColumns.Add(labelId);
 

--- a/Vanadium.Note.Web/Pages/Board.razor.css
+++ b/Vanadium.Note.Web/Pages/Board.razor.css
@@ -228,6 +228,23 @@
     border-bottom-color: var(--mud-palette-primary);
 }
 
+/* "No label" virtual column (#272): notes with none of this category's labels.
+   Dashed border marks it as a non-droppable, display-only column. */
+.board-column-unclassified {
+    border-style: dashed;
+    background-color: transparent;
+}
+
+.board-column-unclassified .board-column-title {
+    opacity: 0.7;
+    font-style: italic;
+}
+
+/* Its cards are not draggable — only clickable to open the note. */
+.board-column-unclassified .board-card {
+    cursor: pointer;
+}
+
 .board-card-title {
     font-size: 0.88rem;
     font-weight: 500;


### PR DESCRIPTION
Closes #272

## 목적
선택 카테고리의 어떤 라벨도 갖지 않은 노트는 보드에서 완전히 비가시였음 — '미분류' 컬럼도 카운트 힌트도 없어 '노트가 사라졌다'로 체감. 이 노트들을 보드에서 확인할 수 있도록 함.

## 변경 사항
- **전체 노트 로드**: `Board.razor`의 `LoadNotesForCurrentCategory`가 카테고리 라벨로 서버 필터링하던 것을 제거하고 전체(비보관) 노트를 로드. 서버 라벨 필터는 미분류 노트를 아예 제외하므로 클라이언트에서 표시가 불가능했음.
- **'No label' 가상 컬럼**: 선택 카테고리의 라벨을 하나도 갖지 않은 노트를 별도 가상 컬럼으로 표시 (`GetUnclassifiedNotes`). 실제 라벨 컬럼과 동일한 `CardsPerColumnLimit` + Show more 동작 적용.
- **표시 전용 설계**: 가상 컬럼은 `data-label-id`가 없어 드롭 대상에서 제외되고, 카드도 드래그 불가. 기존 라벨 이동(드래그앤드롭) 동작은 그대로 유지 — 새로운 드래그 시맨틱을 도입하지 않음.
- **스타일**: 점선 테두리 + 이탤릭 제목으로 가상 컬럼임을 시각적으로 구분 (`Board.razor.css`).

## 범위
- 프론트 표시 계층 한정. 백엔드/`NoteService`/스키마 변경 없음.
- 미분류 노트가 없으면 가상 컬럼은 렌더링하지 않음.

## 완료 조건 검증
- **빌드 클린**: `dotnet build Vanadium.slnx` → 경고 0개, 오류 0개.
- **미분류 노트 가시화**: 선택 카테고리 라벨이 없는 노트가 'No label' 가상 컬럼(개수 배지 포함)으로 표시됨.
- **회귀 없음**: `dotnet test Vanadium.slnx` → 213 통과, 3 건너뜀(PostgreSQL 전용, 기존과 동일).

## 참고
- Web 프로젝트는 테스트 프로젝트가 없어(프로젝트 관례) 단위 테스트는 추가하지 않음. `GetUnclassifiedNotes` 로직 및 표시는 빌드/수동 확인으로 검증.