### PR TITLE
#339 Home 리스트 백그라운드 자동 갱신

### DIFF
--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -270,6 +270,15 @@
     private CancellationTokenSource? _searchCts;
     private CancellationTokenSource? _loadCts;
 
+    // Background refresh: externally-added notes (e.g. via the API) should appear without a
+    // manual full-screen reload. A periodic poll re-fetches the current page quietly and
+    // swaps the list in only when it actually changed (issue #339). Kept within the existing
+    // stack — no SignalR/real-time dependency — per the issue's constraints.
+    private PeriodicTimer? _refreshTimer;
+    private Task? _refreshLoop;
+    private string? _lastListSignature;
+    private static readonly TimeSpan BackgroundRefreshInterval = TimeSpan.FromSeconds(15);
+
     private int currentPage = 1;
     private int totalCount = 0;
     // Seeded from the user's saved settings in OnInitializedAsync; falls back to 30 if
@@ -295,6 +304,7 @@
     {
         await ApplyUserSettings();
         await LoadNotes(includeLabels: true);
+        StartBackgroundRefresh();
     }
 
     // Seed the sort column/direction and page size from the user's saved settings so the
@@ -375,9 +385,94 @@
 
         expandedNoteIds.Clear();
         childrenCache.Clear();
+        // Record the freshly-loaded list so the next background poll can tell whether
+        // anything actually changed before it re-renders.
+        _lastListSignature = ComputeListSignature(notes, totalCount);
         isLoading = false;
         StateHasChanged();
     }
+
+    // Starts the periodic background refresh loop. Called once after the initial load.
+    private void StartBackgroundRefresh()
+    {
+        _refreshTimer = new PeriodicTimer(BackgroundRefreshInterval);
+        _refreshLoop = RunBackgroundRefreshAsync(_refreshTimer);
+    }
+
+    private async Task RunBackgroundRefreshAsync(PeriodicTimer timer)
+    {
+        try
+        {
+            // WaitForNextTickAsync returns false once the timer is disposed, ending the loop.
+            while (await timer.WaitForNextTickAsync())
+                await InvokeAsync(RefreshNotesSilently);
+        }
+        catch (OperationCanceledException)
+        {
+            // Timer disposed during teardown — expected, nothing to do.
+        }
+    }
+
+    // Re-fetches the current page/filter/sort quietly and swaps the list in only when it
+    // changed. Deliberately does NOT touch isLoading (no full-screen "Loading..." indicator)
+    // and does NOT clear the existing list, so the visible notes never blank out (issue #339).
+    private async Task RefreshNotesSilently()
+    {
+        // Never fight a user-initiated load nor overwrite it with stale poll data.
+        if (isLoading)
+            return;
+
+        var page = await FetchCurrentPageAsync();
+        if (page is null)
+            return;
+
+        // An external deletion may have pushed us past the last page — clamp and refetch once
+        // so the user isn't silently stranded on an empty page.
+        var totalPages = Math.Max(1, (int)Math.Ceiling((double)page.TotalCount / pageSize));
+        if (currentPage > totalPages)
+        {
+            currentPage = totalPages;
+            page = await FetchCurrentPageAsync();
+            if (page is null)
+                return;
+        }
+
+        var signature = ComputeListSignature(page.Items, page.TotalCount);
+        if (signature == _lastListSignature)
+            return;
+
+        notes = page.Items;
+        totalCount = page.TotalCount;
+        _lastListSignature = signature;
+        StateHasChanged();
+    }
+
+    // Fetches the current page with the active search/sort/filter. Returns null when the
+    // request fails or a user-initiated load started while awaiting (so a late poll never
+    // clobbers fresher user-driven state).
+    private async Task<PagedResult<NoteSummary>?> FetchCurrentPageAsync()
+    {
+        var result = await NoteService.GetAllAsync(
+            currentPage,
+            pageSize,
+            string.IsNullOrWhiteSpace(_searchText) ? null : _searchText,
+            currentSort == SortColumn.Title ? "title" : "date",
+            sortAscending ? "asc" : "desc",
+            activeFilters.Count > 0 ? activeFilters : null,
+            includeLabels: false,
+            cancellationToken: CancellationToken.None);
+
+        if (isLoading || !result.IsSuccess || result.Value is null)
+            return null;
+
+        return result.Value;
+    }
+
+    // Lightweight change fingerprint: id + last-modified + child count per row, plus the
+    // total. Catches external adds/removes/reorders and content edits (which bump UpdatedAt)
+    // as well as sub-note count changes, so the poll skips a re-render when nothing moved.
+    private static string ComputeListSignature(List<NoteSummary> items, int total)
+        => total + "|" + string.Join(";", items.Select(n => $"{n.Id}:{n.UpdatedAt.Ticks}:{n.ChildCount}"));
 
     private async Task ToggleExpand(Guid noteId)
     {
@@ -582,6 +677,13 @@
         _searchCts?.Dispose();
         _loadCts?.Cancel();
         _loadCts?.Dispose();
+        // Stop the background poll: disposing the timer ends the loop, then await it drains.
+        _refreshTimer?.Dispose();
+        if (_refreshLoop is not null)
+        {
+            try { await _refreshLoop; }
+            catch (OperationCanceledException) { }
+        }
         await ShortcutService.UnregisterAsync("delete");
     }
 }


### PR DESCRIPTION
## 요약
외부 요인(외부 API 등)으로 노트가 추가/변경되면 수동 새로고침 전까지 Home 리스트에서 확인할 수 없던 문제를 해결한다. Home 리스트에 15초 주기 백그라운드 폴링을 추가해, 전체 화면 로딩 인디케이터가 표시되는 수동 새로고침 없이 리스트가 조용히 갱신되도록 한다.

Closes #339

## 변경 내용
- `Home.razor`에 `PeriodicTimer` 기반 백그라운드 폴링(`BackgroundRefreshInterval` = 15초) 추가. 초기 로드 직후 시작하고 `DisposeAsync`에서 타이머를 정리한 뒤 루프를 드레인한다.
- `RefreshNotesSilently`: 현재 페이지/검색/정렬/필터를 그대로 재조회하되 `isLoading`을 건드리지 않고 `notes`도 비우지 않는다. 경량 시그니처(id + `UpdatedAt.Ticks` + `ChildCount` + 전체 개수)로 변경이 감지된 경우에만 목록을 교체해 불필요한 리렌더/깜빡임을 방지한다.
- 진행 중인 사용자 로드(`isLoading`)와 충돌하지 않도록 폴링을 건너뛰고, await 이후 사용자 로드가 시작됐으면 폴링 결과를 폐기해 최신 상태를 덮어쓰지 않는다.
- 외부 삭제로 현재 페이지가 마지막 페이지를 넘어가면 클램프 후 1회 재조회해 빈 페이지에 갇히지 않게 한다.

## 트리거 방식 결정
이슈에서 갱신 트리거(폴링 / 포커스 복귀 / 실시간 푸시)는 미정으로 남겨져 있었다. 제약(신규 최상위 의존성 금지 — 예: SignalR, 인증 흐름 변경 금지)을 고려해 **기존 스택 내 순수 C# `PeriodicTimer` 주기 폴링**을 선택했다. JS interop이나 신규 의존성을 추가하지 않는다.

## 완료 조건 검증
- **빌드 클린**: `dotnet build Vanadium.slnx` → 경고 0 / 오류 0.
- **테스트**: `dotnet test Vanadium.slnx` → 213 통과 / 3 건너뜀(기존 PostgreSQL 전용 스킵). Web 프로젝트는 테스트 프로젝트가 없어(CLAUDE.md) 자동 회귀 테스트는 추가하지 않았다.
- **전체 화면 로딩 미표시 / 목록 미초기화**: `RefreshNotesSilently`가 `isLoading`을 설정하지 않으므로 `@if (isLoading && !notes.Any())` 스피너 조건이 성립하지 않고, `notes`를 비우지 않아 기존 목록이 유지된다(코드 검증).
- **외부 추가 노트 반영**: 15초 주기로 현재 페이지를 재조회해 변경 시 반영. 폴링 동작의 런타임 관찰(두 프로젝트 실행 + API로 노트 추가)은 **수동 확인 필요**.

## 범위
- `Home.razor` 단일 파일만 변경. 범위 밖(인증 흐름, 신규 의존성)은 건드리지 않았다.
- `Board.razor`는 이슈에서 "확인 필요"로 남겨졌고 완료 조건은 Home만 명시하므로 이번 범위에서 제외했다(추후 동일 패턴 적용 가능).

## 알려진 트레이드오프
- 탭이 비활성/숨김 상태여도 폴링이 계속 동작한다(15초마다 요청). 단일 사용자 개인 앱 특성상 허용 가능하며, 가시성 기반 중단은 JS interop이 필요해 범위에서 제외했다.
