### PR TITLE
#340 노트 내부 링크 클릭 시 새 탭으로 열기

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -191,6 +191,26 @@ window.tiptapInterop = {
             document.body.removeChild(a);
         });
 
+        // Plain link click — the Link extension runs with openOnClick:false so that
+        // clicking a link's text in edit mode positions the caret instead of
+        // navigating, but that leaves ProseMirror swallowing the click entirely so
+        // the link never opens (issue #340). Open it manually: in read-only mode a
+        // plain click navigates; in edit mode only Ctrl/Cmd+click navigates, so a
+        // plain click keeps placing the caret for editing (behavior unchanged).
+        // File attachments have their own handler above and are excluded here.
+        editor.view.dom.addEventListener('click', (e) => {
+            const link = e.target.closest('a[href]');
+            if (!link || link.classList.contains('file-attachment')) return;
+            if (editor.isEditable && !(e.ctrlKey || e.metaKey)) return;
+            const href = link.getAttribute('href');
+            if (!href) return;
+            e.preventDefault();
+            e.stopPropagation();
+            // 'noopener,noreferrer' mirrors the rendered <a rel="noopener noreferrer">
+            // so the opened tab cannot reach back through window.opener.
+            window.open(href, '_blank', 'noopener,noreferrer');
+        });
+
         // Callout emoji click — prevent cursor move, open emoji picker
         editor.view.dom.addEventListener('mousedown', (e) => {
             if (e.target.classList.contains('callout-emoji')) e.preventDefault();


### PR DESCRIPTION
Closes #340

## 문제
노트 편집기의 일반 링크를 클릭해도 아무 반응이 없었다. `Link` 익스텐션이 `openOnClick: false`로 설정되어 있어 ProseMirror가 클릭을 가로채고, `file-attachment`/`page-link`와 달리 일반 `<a>` 링크에는 클릭 핸들러가 없었기 때문이다.

## 변경 내용
`wwwroot/js/tiptap/interop.js`의 에디터 `init`에 일반 링크 클릭 핸들러를 추가했다.
- **읽기 전용 모드**(보관/공유 등): 링크를 클릭하면 새 탭으로 열린다.
- **편집 모드**: `Ctrl/Cmd + 클릭`으로 새 탭에서 열린다. 일반 클릭은 기존과 동일하게 커서 이동으로 동작한다.
- `window.open(href, '_blank', 'noopener,noreferrer')`로 열어 렌더링된 `<a target="_blank" rel="noopener noreferrer">`와 동일한 보안 속성을 유지한다.
- `a.file-attachment`는 명시적으로 제외, `note-mention`(href 없는 `<a>`)·`page-link`(`<div>`)는 선택자(`a[href]`)에 해당하지 않아 자동 제외되어 기존 특수 노드 동작은 그대로 유지된다.

## 완료 조건 검증
- [x] 일반 링크 클릭(읽기 전용) / Ctrl·Cmd+클릭(편집) 시 새 탭으로 열림 — `window.open` 경로로 구현
- [x] `target=_blank`, `rel=noopener noreferrer` — `window.open`의 `noopener,noreferrer` 옵션 + 렌더링된 `<a>` 속성
- [x] 편집 중 커서 이동/텍스트 수정 동작 유지 — 편집 모드의 일반 클릭은 조기 반환하여 `preventDefault` 미호출, ProseMirror 기본 커서 배치 그대로
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0개, `dotnet test` 213 통과

## 범위
`interop.js` 한 파일만 변경. 특수 노드 클릭 동작 미변경. interop은 `tiptapInterop.*` 내부에서만 처리(`NoteEditor.razor` 호출 규약 유지).

> JS 인터롭 변경이라 백엔드 테스트로 커버되지 않음(Web 프로젝트는 테스트 없음). 빌드/기존 테스트 회귀 없음 확인.