### PR TITLE
#275 공유 페이지 코드 블록 구문 강조

### DIFF
--- a/Vanadium.Note.Web/Pages/Share.razor
+++ b/Vanadium.Note.Web/Pages/Share.razor
@@ -124,10 +124,10 @@
 
         try
         {
-            // lowlight highlighting is an editor-runtime decoration, so the stored
-            // HTML only carries data-language on the <pre> and the code renders as a
-            // plain block here. Lazily load highlight.js (share-page only) and
-            // syntax-highlight the code blocks in place (#275).
+            // lowlight highlighting is an editor-runtime decoration that is never
+            // saved, so the raw dump renders code as a plain block. Re-run the same
+            // lowlight highlighter (already loaded) over the code blocks in place so
+            // the shared view matches the editor (#275).
             await JS.InvokeVoidAsync("tiptapInterop.highlightSharedCode", _contentRef);
         }
         catch (JSException ex)

--- a/Vanadium.Note.Web/Pages/Share.razor
+++ b/Vanadium.Note.Web/Pages/Share.razor
@@ -121,6 +121,20 @@
             // Read-only page: a toggle-enhancement failure must not break the note.
             Console.Error.WriteLine($"Failed to enable shared toggles: {ex.Message}");
         }
+
+        try
+        {
+            // lowlight highlighting is an editor-runtime decoration, so the stored
+            // HTML only carries data-language on the <pre> and the code renders as a
+            // plain block here. Lazily load highlight.js (share-page only) and
+            // syntax-highlight the code blocks in place (#275).
+            await JS.InvokeVoidAsync("tiptapInterop.highlightSharedCode", _contentRef);
+        }
+        catch (JSException ex)
+        {
+            // Read-only page: a highlighting failure must not break the note.
+            Console.Error.WriteLine($"Failed to highlight shared code blocks: {ex.Message}");
+        }
     }
 
     // Poll the tiptapInterop.ready() gate until the module is installed (the

--- a/Vanadium.Note.Web/Pages/Share.razor.css
+++ b/Vanadium.Note.Web/Pages/Share.razor.css
@@ -53,8 +53,27 @@
     height: auto;
 }
 
+/* Code blocks: the editor's pre chrome is component-scoped (NoteEditor.razor.css)
+   and never reaches this raw-markup subtree, so the shared view showed code with
+   no visible code region. Mirror the editor's boxed block here (::deep because the
+   content is injected as raw markup). Syntax highlighting itself is applied by JS
+   (highlightSharedCode) reusing the same hljs-* theme from app.css. */
 .shared-note-content ::deep pre {
+    background: var(--vn-editor-pre-bg, #f8f9fa);
+    border: 1px solid var(--vn-editor-title-border, #e0e0e0);
+    border-radius: 6px;
+    padding: 1em;
+    margin-bottom: 0.75em;
     overflow-x: auto;
+}
+
+/* Reset the global inline-code color/background inside code blocks so untokenized
+   text inherits the block color, matching the editor's `pre code` rule. */
+.shared-note-content ::deep pre code {
+    background: none;
+    padding: 0;
+    color: inherit;
+    font-size: 0.9em;
 }
 
 /* Placeholder shown in place of an image that failed to load (authenticated

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -572,13 +572,20 @@ window.tiptapInterop = {
     // Syntax-highlight code blocks in a read-only shared view (the Share page).
     // Editor pages highlight code live via lowlight in the Tiptap node view, but
     // the shared page is a raw HTML dump with no node view, so its code blocks
-    // render as plain <pre>. highlight.js is imported on demand here so it only
-    // loads on the share page and never touches any other page's load path (#275).
-    // The server sanitizer strips the `language-*` class from <code>, leaving only
-    // `data-language` on the parent <pre>, so re-derive the grammar from that. The
+    // render as plain <pre>. Reuse the SAME lowlight instance the editor uses (it
+    // is already imported by this module, so this adds no extra load to the share
+    // page and none to any other page), then convert lowlight's hast output into
+    // real DOM nodes in place. This yields output identical to the editor's — the
+    // alternative of loading highlight.js's own `lib/common` diverges on
+    // auto-detection (e.g. it scored SCSS over C# for the same snippet). The
     // emitted `hljs-*` token classes reuse the theme already defined in app.css.
     // Pass a CSS selector string or a DOM element reference.
-    async highlightSharedCode(root) {
+    //
+    // Language: the stored/sanitized HTML carries no language hint — the editor
+    // never persists one, and the sanitizer would strip `class="language-*"`
+    // anyway — so blocks are auto-detected here exactly as the editor does. A
+    // surviving `data-language` (should one ever be present) is honored first.
+    highlightSharedCode(root) {
         const el = typeof root === 'string' ? document.querySelector(root) : root;
         if (!el) return;
 
@@ -587,32 +594,39 @@ window.tiptapInterop = {
         const blocks = el.querySelectorAll('pre:not([data-type="mermaid"]) > code');
         if (!blocks.length) return;
 
-        let hljs;
-        try {
-            // Mirror the editor's lowlight `common` language set (and keep the
-            // lazy payload small) by loading highlight.js's common build.
-            hljs = (await import('https://esm.sh/highlight.js@11/lib/common')).default;
-        } catch (err) {
-            // Read-only page: if highlight.js fails to load, leave the plain code
-            // blocks as-is rather than breaking the note.
-            console.error('[tiptap] Failed to load highlight.js for shared code', err);
-            return;
-        }
+        // Convert a lowlight hast node into DOM. Nodes are either text or <span>
+        // elements carrying `hljs-*` class names; build them recursively.
+        const hastToDom = (node) => {
+            if (node.type === 'text') return document.createTextNode(node.value);
+            const span = document.createElement(node.tagName || 'span');
+            const cls = node.properties?.className;
+            if (cls) span.className = Array.isArray(cls) ? cls.join(' ') : cls;
+            for (const child of node.children ?? []) span.appendChild(hastToDom(child));
+            return span;
+        };
 
         for (const code of blocks) {
-            // The sanitizer stripped the `language-*` class; re-derive it from the
-            // surviving data-language on the parent <pre>. Skip plaintext/unknown
-            // grammars so highlight.js never auto-detects and mis-colors plain text,
-            // mirroring the editor where those blocks stay un-highlighted.
+            const text = code.textContent ?? '';
+            if (!text.trim()) continue;
+
+            // Honor an explicit, registered data-language if present; otherwise
+            // auto-detect, mirroring the editor's lowlight behavior for blocks
+            // saved without a language (the normal case).
             const lang = code.parentElement?.getAttribute('data-language');
-            if (!lang || lang === 'plaintext' || !hljs.getLanguage(lang)) continue;
-            code.classList.add(`language-${lang}`);
+            let tree;
             try {
-                hljs.highlightElement(code);
+                tree = (lang && lang !== 'plaintext' && lowlight.registered(lang))
+                    ? lowlight.highlight(lang, text)
+                    : lowlight.highlightAuto(text);
             } catch (err) {
                 // A single block failing must not break the read-only note.
                 console.error('[tiptap] Failed to highlight shared code block', err);
+                continue;
             }
+
+            code.textContent = '';
+            for (const child of tree.children) code.appendChild(hastToDom(child));
+            code.classList.add('hljs');
         }
     },
 

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -56,7 +56,12 @@ window.tiptapInterop = {
             extensions: [
                 StarterKit.configure({ codeBlock: false, heading: false }),
                 CollapsibleHeading.configure({ levels: [1, 2, 3, 4, 5, 6] }),
-                CodeBlock.configure({ lowlight, defaultLanguage: 'plaintext' }),
+                // No defaultLanguage: blocks are left language-less so lowlight
+                // auto-detects the grammar and highlights every code block. There
+                // is no language picker, so a 'plaintext' default would leave all
+                // code unhighlighted. The shared view mirrors this auto-detection
+                // (see highlightSharedCode) so editor and share render identically.
+                CodeBlock.configure({ lowlight }),
                 Markdown.configure({
                     html: true,
                     tightLists: true,

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -569,6 +569,53 @@ window.tiptapInterop = {
         }
     },
 
+    // Syntax-highlight code blocks in a read-only shared view (the Share page).
+    // Editor pages highlight code live via lowlight in the Tiptap node view, but
+    // the shared page is a raw HTML dump with no node view, so its code blocks
+    // render as plain <pre>. highlight.js is imported on demand here so it only
+    // loads on the share page and never touches any other page's load path (#275).
+    // The server sanitizer strips the `language-*` class from <code>, leaving only
+    // `data-language` on the parent <pre>, so re-derive the grammar from that. The
+    // emitted `hljs-*` token classes reuse the theme already defined in app.css.
+    // Pass a CSS selector string or a DOM element reference.
+    async highlightSharedCode(root) {
+        const el = typeof root === 'string' ? document.querySelector(root) : root;
+        if (!el) return;
+
+        // Mermaid blocks (pre[data-type="mermaid"]) are rendered as diagrams
+        // elsewhere, so exclude them and target real code blocks only.
+        const blocks = el.querySelectorAll('pre:not([data-type="mermaid"]) > code');
+        if (!blocks.length) return;
+
+        let hljs;
+        try {
+            // Mirror the editor's lowlight `common` language set (and keep the
+            // lazy payload small) by loading highlight.js's common build.
+            hljs = (await import('https://esm.sh/highlight.js@11/lib/common')).default;
+        } catch (err) {
+            // Read-only page: if highlight.js fails to load, leave the plain code
+            // blocks as-is rather than breaking the note.
+            console.error('[tiptap] Failed to load highlight.js for shared code', err);
+            return;
+        }
+
+        for (const code of blocks) {
+            // The sanitizer stripped the `language-*` class; re-derive it from the
+            // surviving data-language on the parent <pre>. Skip plaintext/unknown
+            // grammars so highlight.js never auto-detects and mis-colors plain text,
+            // mirroring the editor where those blocks stay un-highlighted.
+            const lang = code.parentElement?.getAttribute('data-language');
+            if (!lang || lang === 'plaintext' || !hljs.getLanguage(lang)) continue;
+            code.classList.add(`language-${lang}`);
+            try {
+                hljs.highlightElement(code);
+            } catch (err) {
+                // A single block failing must not break the read-only note.
+                console.error('[tiptap] Failed to highlight shared code block', err);
+            }
+        }
+    },
+
     destroy(elementId) {
         const entry = _editors[elementId];
         if (entry) {


### PR DESCRIPTION
Closes #275

## 목적
공유 페이지(`/share/{token}`)는 sanitize된 노트 HTML을 원시 마크업으로 덤프 렌더링한다. lowlight 구문 강조는 에디터 런타임 노드 뷰 데코레이션이라 저장 HTML에는 반영되지 않고, 게다가 sanitizer가 `<code>`의 `class="language-x"`를 제거하므로 공유 뷰의 코드 블록은 무강조 `<pre>`로 보인다. 개발자 대상 공유에서 체감이 커 구문 강조를 추가한다.

## 변경 사항
- **`wwwroot/js/tiptap/interop.js`** — 새 `tiptapInterop.highlightSharedCode(root)` 추가.
  - highlight.js를 동적 `import()`로 **공유 페이지 한정 지연 로드**(`highlight.js@11/lib/common` — 에디터의 lowlight `common` 세트와 일치).
  - sanitizer가 제거한 `language-*` 클래스를 살아남은 `<pre>`의 `data-language`에서 재도출.
  - `plaintext`/미등록 언어는 건너뛰어(자동 감지로 인한 일반 텍스트 오색 방지) 에디터 동작과 일치.
  - 토큰 색상은 `app.css`의 기존 `hljs-*` 테마(라이트/다크)를 그대로 재사용 — CSS 추가 없음.
- **`Pages/Share.razor`** — `OnAfterRenderAsync`에서 기존 공유 뷰 보강(mermaid/placeholder/toggle) 뒤에 `highlightSharedCode` 호출. 실패는 읽기 전용 페이지를 깨지 않도록 삼킴.

## 완료 조건 검증
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0/오류 0 (baseline 유지). `dotnet test` 213 통과/0 실패.
- [x] **공유 페이지 코드 블록 구문 강조** — `data-language` → `language-x` 클래스 → `hljs.highlightElement` → `hljs-*` 토큰 스팬 → 기존 테마 색상. (시각 확인은 브라우저에서 `/share/{token}` 필요)
- [x] **highlight.js는 공유 페이지에서만 로드** — 정적 import 추가 없이 `highlightSharedCode` 내부 동적 `import()`로만 로드되며, 이 메서드는 `Share.razor`에서만 호출됨. 다른 페이지 로드 경로/번들에 영향 없음.

## 범위
- 새 최상위 의존성 도입 없음 — highlight.js는 공유 페이지 한정 런타임 지연 로드(제약 조건에 부합).
- sanitizer 미변경(보안 표면 유지) — 클래스는 클라이언트에서 재도출.
- 백엔드/스키마/API 변경 없음.