### PR TITLE
#278 QuickNav Shift+Enter로 전체 페이지 바로 열기

### DIFF
--- a/Vanadium.Note.Web/Components/QuickNavDialog.razor
+++ b/Vanadium.Note.Web/Components/QuickNavDialog.razor
@@ -92,7 +92,8 @@
 
             <div class="quicknav-footer">
                 <span><kbd>↑</kbd><kbd>↓</kbd> to navigate</span>
-                <span><kbd>Enter</kbd> to open</span>
+                <span><kbd>Enter</kbd> to peek</span>
+                <span><kbd>Shift</kbd><kbd>Enter</kbd> full page</span>
                 <span><kbd>Esc</kbd> to close</span>
             </div>
         </div>
@@ -238,7 +239,7 @@
                 break;
             case "Enter":
                 if (_rows.Count > 0 && _selected >= 0 && _selected < _rows.Count)
-                    await OpenRow(_rows[_selected]);
+                    await OpenRow(_rows[_selected], fullPage: e.ShiftKey);
                 break;
             case "Escape":
                 await Close();
@@ -246,13 +247,21 @@
         }
     }
 
-    private async Task OpenRow(QuickNavRow row)
+    private async Task OpenRow(QuickNavRow row, bool fullPage = false)
     {
         await Close();
 
-        // Always open the picked note in a peek dialog so the current page (and any
+        if (fullPage)
+        {
+            // Shift+Enter bypasses the peek dialog and navigates straight to the full
+            // editor page, saving the extra "Open in full page" click.
+            Nav.NavigateTo($"/editor/{row.Id}");
+            return;
+        }
+
+        // Default: open the picked note in a peek dialog so the current page (and any
         // unsaved editor work) stays in place. Full navigation is available from the
-        // dialog's "Open in full page" button.
+        // dialog's "Open in full page" button, or directly via Shift+Enter.
         var parameters = new DialogParameters<SubNoteDialog> { { x => x.NoteId, row.Id } };
         var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true, CloseOnEscapeKey = true };
         await DialogService.ShowAsync<SubNoteDialog>(string.Empty, parameters, options);


### PR DESCRIPTION
Closes #278

## 요약
QuickNav 팔레트에서 노트를 열 때 항상 peek 다이얼로그(2단계)를 거쳐야 했던 문제를, `Shift+Enter` 바이패스로 해결합니다.

## 변경 사항
- `OpenRow`에 `fullPage` 파라미터를 추가. `true`면 peek 다이얼로그 대신 `Nav.NavigateTo("/editor/{id}")`로 전체 편집 페이지로 바로 이동.
- `OnKeyDown`의 Enter 처리에서 `e.ShiftKey`를 읽어 Shift 여부를 `fullPage`로 전달.
- 푸터 힌트에 `Shift+Enter full page` 안내 추가, 기존 `Enter`는 `to peek`으로 명확화.

## 완료 조건 검증
- **빌드 클린**: `dotnet build Vanadium.slnx` → 경고 0 / 오류 0.
- **Shift+Enter로 전체 페이지 이동**: Enter 핸들러가 `fullPage: e.ShiftKey`를 전달하고, `fullPage`일 때 `/editor/{row.Id}`로 네비게이트.
- **일반 Enter는 기존 peek 유지**: `fullPage` 기본값 false → 기존 `SubNoteDialog` peek 경로 그대로.

## 범위
- 라우팅 구조 변경 없음(기존 `/editor/{id}` 라우트로 이동만 추가). `QuickNavDialog.razor` 단일 파일만 수정.
- Web 프로젝트는 테스트 프로젝트가 없어 razor 상호작용에 대한 자동 회귀 테스트는 추가하지 못함(수동 확인 필요).