### PR TITLE
#273 보드 카드 터치 이동 메뉴 추가

### DIFF
--- a/Vanadium.Note.Web/Pages/Board.razor
+++ b/Vanadium.Note.Web/Pages/Board.razor
@@ -75,8 +75,21 @@
                                  data-note-id="@capturedNote.Id"
                                  data-label-id="@columnLabel.Id"
                                  @onclick="() => EditNote(capturedNote.Id)">
-                                <div class="board-card-title">
-                                    @(string.IsNullOrWhiteSpace(capturedNote.Title) ? "(No title)" : capturedNote.Title)
+                                <div class="board-card-header">
+                                    <div class="board-card-title">
+                                        @(string.IsNullOrWhiteSpace(capturedNote.Title) ? "(No title)" : capturedNote.Title)
+                                    </div>
+                                    @* Touch fallback for HTML5 drag-drop (#273): a menu button that opens the
+                                       "move to column" sheet, since dragstart/drop never fire on touch. *@
+                                    <button class="board-card-move"
+                                            type="button"
+                                            draggable="false"
+                                            title="Move to another column"
+                                            aria-label="Move to another column"
+                                            @onclick="() => OpenMoveSheet(capturedNote, columnLabel.Id)"
+                                            @onclick:stopPropagation="true">
+                                        &#8942;
+                                    </button>
                                 </div>
                                 @{
                                     var otherLabels = capturedNote.Labels.Where(l => l.Id != columnLabel.Id).ToList();
@@ -218,6 +231,41 @@
     </div>
 }
 
+@* Move sheet: touch-friendly fallback (#273) to change a card's column when HTML5
+   drag-drop is unavailable. Lists the current category's labels; tapping one moves
+   the note via the same persistence path as a desktop drop. *@
+@if (showMoveSheet)
+{
+    <div class="board-dialog-overlay" @onclick="CloseMoveSheet">
+        <div class="board-dialog board-move-sheet"
+             role="dialog"
+             aria-modal="true"
+             aria-label="Move note to another column"
+             @onclick:stopPropagation="true">
+            <div class="board-dialog-header">
+                <h4>Move &ldquo;<strong>@moveNoteTitle</strong>&rdquo; to</h4>
+                <button class="board-dialog-close" @onclick="CloseMoveSheet">×</button>
+            </div>
+            <div class="board-move-options">
+                @foreach (var lbl in moveSheetLabels)
+                {
+                    var targetId = lbl.Id;
+                    var isCurrent = targetId == moveFromLabelId;
+                    <button class="board-move-option @(isCurrent ? "current" : "")"
+                            disabled="@isCurrent"
+                            @onclick="() => MoveViaSheet(targetId)">
+                        <span class="board-move-option-name">@lbl.Name</span>
+                        @if (isCurrent)
+                        {
+                            <span class="board-move-option-badge">Current</span>
+                        }
+                    </button>
+                }
+            </div>
+        </div>
+    </div>
+}
+
 @code {
     // Cap the cards initially rendered per column so a category with many notes
     // does not grow the board's DOM/render cost without bound (#206). The rest
@@ -245,6 +293,13 @@
     private ElementReference _dialogRef;
     private ElementReference _dialogInput;
     private bool _trapQueued;
+
+    // ── Move sheet state (touch fallback for HTML5 drag-drop, #273) ───────────
+    private bool showMoveSheet = false;
+    private Guid moveNoteId;
+    private Guid moveFromLabelId;
+    private string moveNoteTitle = "";
+    private IReadOnlyList<Label> moveSheetLabels = [];
 
     private LabelCategory? selectedCategory =>
         categories.FirstOrDefault(c => c.Id == selectedCategoryId);
@@ -310,7 +365,13 @@
         if (!Guid.TryParse(noteIdStr, out var noteId)) return;
         if (!Guid.TryParse(fromLabelIdStr, out var fromLabelId)) return;
         if (!Guid.TryParse(toLabelIdStr, out var toLabelId)) return;
+        await MoveNoteToLabelAsync(noteId, fromLabelId, toLabelId);
+    }
 
+    // Shared move logic used by both the desktop HTML5 drop (OnDropFromJs) and the
+    // touch move sheet (MoveViaSheet) so both paths persist identically (#273).
+    private async Task MoveNoteToLabelAsync(Guid noteId, Guid fromLabelId, Guid toLabelId)
+    {
         // Resolve target label object from current category
         var targetLabel = selectedCategory?.Labels.FirstOrDefault(l => l.Id == toLabelId);
         if (targetLabel is null)
@@ -399,6 +460,32 @@
 
     private void EditNote(Guid id) =>
         Nav.NavigateTo($"/editor/{id}?returnUrl=/board");
+
+    // ── Move sheet (touch fallback for HTML5 drag-drop, #273) ─────────────────
+
+    private void OpenMoveSheet(NoteSummary note, Guid fromLabelId)
+    {
+        moveNoteId = note.Id;
+        moveFromLabelId = fromLabelId;
+        moveNoteTitle = string.IsNullOrWhiteSpace(note.Title) ? "(No title)" : note.Title;
+        moveSheetLabels = selectedCategory?.Labels.OrderBy(l => l.Name).ToList() ?? [];
+        showMoveSheet = true;
+    }
+
+    private void CloseMoveSheet()
+    {
+        showMoveSheet = false;
+        moveSheetLabels = [];
+    }
+
+    private async Task MoveViaSheet(Guid toLabelId)
+    {
+        var noteId = moveNoteId;
+        var fromLabelId = moveFromLabelId;
+        CloseMoveSheet();
+        if (toLabelId == fromLabelId) return;
+        await MoveNoteToLabelAsync(noteId, fromLabelId, toLabelId);
+    }
 
     // ── Add note dialog ───────────────────────────────────────────────────────
 

--- a/Vanadium.Note.Web/Pages/Board.razor.css
+++ b/Vanadium.Note.Web/Pages/Board.razor.css
@@ -245,12 +245,64 @@
     cursor: pointer;
 }
 
+.board-card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.35rem;
+}
+
 .board-card-title {
     font-size: 0.88rem;
     font-weight: 500;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
+/* Touch fallback (#273): kebab button that opens the "move to column" sheet. */
+.board-card-move {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.6rem;
+    min-height: 1.6rem;
+    padding: 0;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: inherit;
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.5;
+    transition: opacity 0.15s, background-color 0.15s;
+}
+
+.board-card-move:hover {
+    opacity: 1;
+    background-color: var(--vn-note-hover-bg);
+}
+
+/* On pointer devices keep cards clean: the kebab appears only on card hover or
+   keyboard focus. On touch devices (hover: none) it stays visible so the move
+   menu is always reachable — the whole point of this fallback. */
+@media (hover: hover) {
+    .board-card-move {
+        opacity: 0;
+    }
+
+    .board-card:hover .board-card-move,
+    .board-card-move:focus-visible {
+        opacity: 0.5;
+    }
+
+    .board-card:hover .board-card-move:hover {
+        opacity: 1;
+    }
 }
 
 .board-card-labels {
@@ -370,6 +422,59 @@
     display: flex;
     justify-content: flex-end;
     gap: 0.5rem;
+}
+
+/* ── Move sheet (touch fallback, #273) ───────────────────────────────────── */
+
+.board-move-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    max-height: 50vh;
+    overflow-y: auto;
+}
+
+.board-move-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: 1px solid var(--mud-palette-divider);
+    border-radius: 6px;
+    padding: 0.55rem 0.7rem;
+    font-size: 0.9rem;
+    color: inherit;
+    cursor: pointer;
+    transition: background-color 0.15s, border-color 0.15s;
+}
+
+.board-move-option-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.board-move-option:hover:not(:disabled) {
+    background-color: var(--vn-note-hover-bg);
+    border-color: var(--mud-palette-primary);
+}
+
+.board-move-option:disabled,
+.board-move-option.current {
+    cursor: default;
+    opacity: 0.55;
+}
+
+.board-move-option-badge {
+    flex-shrink: 0;
+    font-size: 0.68rem;
+    opacity: 0.7;
+    border: 1px solid var(--mud-palette-divider);
+    border-radius: 999px;
+    padding: 0.05rem 0.4rem;
 }
 
 /* ── Responsive (narrow / mobile) ───────────────────────────────────────────


### PR DESCRIPTION
Closes #273

## 배경
보드는 HTML5 `dragstart`/`dragover`/`drop`만 등록되어 있어 터치 환경에서는 카드 이동이 발동하지 않았다. 그 결과 모바일에서 보드가 사실상 읽기 전용이 되었다.

## 변경 사항
터치 DnD 라이브러리를 도입하는 대신(범위 밖/제약 준수), 저비용 컨텍스트 메뉴 폴백을 추가했다.

- 각 컬럼 카드에 케밥(⋮) 버튼 추가 → 탭하면 **이동 시트**가 열림
- 이동 시트는 현재 카테고리의 컬럼(라벨) 목록을 보여주고, 현재 컬럼은 `Current` 배지와 함께 비활성화
- 컬럼 선택 시 데스크톱 드롭과 **동일한 지속화 경로**로 이동
  - `OnDropFromJs`의 이동 로직을 `MoveNoteToLabelAsync`로 추출해 드롭/시트가 공유(낙관적 업데이트 + 실패 시 롤백 포함)
- 케밥 버튼 노출 규칙: `@media (hover: hover)` 기기에서는 카드 hover/포커스 시에만, 터치 기기(`hover: none`)에서는 항상 노출
- `board-drag-drop.js`는 **전혀 손대지 않음** → 데스크톱 DnD 회귀 없음
- `No label` 가상 컬럼(#272)은 드래그 불가 정책을 유지하기 위해 이동 메뉴를 붙이지 않음

## 완료 조건 검증
- **빌드 클린**: `dotnet build Vanadium.slnx` → 경고 0, 오류 0
- **터치 환경에서 라벨(컬럼) 변경 경로 제공**: 카드 케밥 버튼 → 이동 시트에서 컬럼 선택 (터치 기기에서 버튼 상시 노출)
- **데스크톱 HTML5 DnD 회귀 없음**: DnD 관련 JS 미변경, 이동 로직은 동일 본문을 그대로 추출만 함. `dotnet test Vanadium.slnx` → 213 통과 / 3 스킵(Postgres 전용)

## 테스트 노트
프런트엔드(Blazor Board 컴포넌트) 단독 변경이며 Web 프로젝트에는 테스트 프로젝트가 없어 자동화 테스트는 추가하지 않았다. 백엔드 회귀는 기존 테스트 스위트로 확인.