### PR TITLE
#283 로그인 비밀번호 입력 autofocus

### DIFF
--- a/Vanadium.Note.Web/Pages/Login.razor
+++ b/Vanadium.Note.Web/Pages/Login.razor
@@ -28,6 +28,7 @@
                        autocomplete="current-password"
                        class="login-input"
                        placeholder="Password"
+                       @ref="_passwordInput"
                        @bind="_model.Password"
                        @bind:event="oninput"
                        disabled="@_isLoading" />
@@ -51,6 +52,18 @@
     private readonly LoginModel _model = new();
     private bool _isLoading;
     private string? _errorMessage;
+    private ElementReference _passwordInput;
+
+    // Focus the password field on first render so a keyboard-first user can type
+    // immediately without clicking (issue #283). Native autofocus is unreliable in
+    // Blazor WASM, so use FocusAsync after the element is in the DOM.
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await _passwordInput.FocusAsync();
+        }
+    }
 
     private async Task HandleLogin()
     {


### PR DESCRIPTION
Closes #283

## 요약
로그인 페이지 진입 시 클릭 없이 비밀번호 입력란에 포커스가 자동으로 잡히도록 개선.

## 변경 내용
- `Login.razor`의 비밀번호 `<input>`에 `@ref="_passwordInput"` 부여.
- `OnAfterRenderAsync(firstRender)`에서 `FocusAsync()` 호출로 첫 렌더 후 포커스.
- Blazor WASM에서 네이티브 `autofocus` 속성은 불안정하여 `ElementReference` + `FocusAsync` 방식 사용.

## 완료 조건 검증
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0/오류 0.
- [x] `/login` 진입 시 클릭 없이 비밀번호 입력란에 포커스 자동 위치 — 첫 렌더 시 `FocusAsync` 실행.

## 범위 밖 준수
- 로그인 로직/인증 흐름 변경 없음.
- 숨겨진 username 필드 구조 변경 없음.
- `Login.razor` 단일 파일만 수정.