### PR TITLE
#285 아카이브 휴지통 이동에 Undo 추가

### DIFF
--- a/Vanadium.Note.Web/Pages/Archive.razor
+++ b/Vanadium.Note.Web/Pages/Archive.razor
@@ -179,7 +179,18 @@
             return;
         }
         Logger.LogInformation("Archived note moved to recycle bin from archive page.");
-        Snackbar.Add("Note moved to the Recycle Bin.", Severity.Normal);
+        var noteId = item.Id;
+        Snackbar.Add("Note moved to the Recycle Bin.", Severity.Normal, config =>
+        {
+            config.Action = "Undo";
+            config.ActionColor = Color.Primary;
+            config.OnClick = async _ =>
+            {
+                await NoteService.RestoreAsync(noteId);
+                await ReloadAfterRemoval();
+                StateHasChanged();
+            };
+        });
         await ReloadAfterRemoval();
     }
 
@@ -206,12 +217,39 @@
         if (!await Confirm.ConfirmAsync("Move to Recycle Bin", message, "Move to Recycle Bin")) return;
 
         isBusy = true;
-        var (ok, failed) = await RunBulk(ids, id => NoteService.DeleteAsync(id));
+        var deletedIds = new List<Guid>();
+        var failed = 0;
+        foreach (var id in ids)
+        {
+            var result = await NoteService.DeleteAsync(id);
+            if (result.IsSuccess) deletedIds.Add(id);
+            else failed++;
+        }
         isBusy = false;
 
-        if (ok > 0)
-            Logger.LogInformation("{Count} archived note(s) moved to recycle bin from archive page.", ok);
-        ReportBulk(ok, failed, "moved to the Recycle Bin", "move");
+        if (deletedIds.Count > 0)
+            Logger.LogInformation("{Count} archived note(s) moved to recycle bin from archive page.", deletedIds.Count);
+
+        if (failed > 0)
+            Snackbar.Add($"Failed to move {failed} note(s).", Severity.Error);
+        if (deletedIds.Count > 0)
+        {
+            Snackbar.Add(
+                deletedIds.Count == 1 ? "Note moved to the Recycle Bin." : $"{deletedIds.Count} notes moved to the Recycle Bin.",
+                Severity.Normal,
+                config =>
+                {
+                    config.Action = "Undo";
+                    config.ActionColor = Color.Primary;
+                    config.OnClick = async _ =>
+                    {
+                        foreach (var id in deletedIds)
+                            await NoteService.RestoreAsync(id);
+                        await ReloadAfterRemoval();
+                        StateHasChanged();
+                    };
+                });
+        }
         await ReloadAfterRemoval();
     }
 


### PR DESCRIPTION
Closes #285

## 목적
아카이브 페이지에서 노트를 휴지통으로 이동할 때 Undo가 없어 Home/NoteEditor와 UX가 비일관적이었다. 동일한 방식의 Undo 스낵바를 추가해 일관성을 맞춘다.

## 변경 내용
- `Archive.razor`의 단일 삭제(`DeleteNote`)와 벌크 삭제(`BulkDelete`)에 Undo 액션 스낵바 추가.
- Undo 클릭 시 성공적으로 삭제된 노트를 `NoteService.RestoreAsync`로 휴지통에서 복원하고 아카이브 목록을 다시 로드한다.
- Home/NoteEditor의 기존 Undo 패턴(`Severity.Normal` + `config.Action = "Undo"` + `RestoreAsync`)을 그대로 미러링.

## 범위
- 백엔드/스키마 변경 없음 — 기존 restore 엔드포인트(`RestoreAsync`) 재사용.
- Home/NoteEditor 동작 미변경.

## 완료 조건 검증
- 빌드 클린: `dotnet build Vanadium.slnx` → 경고 0, 오류 0 (베이스라인 유지).
- 전체 테스트: `dotnet test Vanadium.slnx` → 213 통과 / 3 스킵(PostgreSQL 전용, 기존) / 0 실패.
- 아카이브 → 휴지통 이동 시 Undo 스낵바 노출, Undo로 삭제 이전 상태(아카이브)로 복원. (Blazor UI 변경으로 Web 프로젝트에는 테스트 프로젝트가 없어 수동 확인 대상.)