### PR TITLE
#286 아카이브/휴지통 벌크 작업 병렬화 + 진행 표시

### DIFF
--- a/Vanadium.Note.Web/Pages/Archive.razor
+++ b/Vanadium.Note.Web/Pages/Archive.razor
@@ -30,7 +30,18 @@
         @if (selected.Count > 0)
         {
             <div class="bulk-bar">
-                <span class="bulk-count">@selected.Count selected</span>
+                @if (isBusy && bulkTotal > 0)
+                {
+                    <span class="bulk-count">Processing @bulkDone / @bulkTotal…</span>
+                    <div class="bulk-progress" role="progressbar"
+                         aria-valuenow="@bulkDone" aria-valuemin="0" aria-valuemax="@bulkTotal">
+                        <div class="bulk-progress-fill" style="width:@BulkProgressPercent%"></div>
+                    </div>
+                }
+                else
+                {
+                    <span class="bulk-count">@selected.Count selected</span>
+                }
                 <button class="row-btn" disabled="@isBusy" @onclick="BulkUnarchive">Unarchive</button>
                 <button class="row-btn row-btn-danger" disabled="@isBusy" @onclick="BulkDelete">Delete</button>
                 <button class="row-btn bulk-clear" disabled="@isBusy" @onclick="ClearSelection">Clear</button>
@@ -94,6 +105,15 @@
     private int currentPage = 1;
     private bool isLoading = true;
     private bool isBusy;
+
+    // Bulk actions run concurrently with a capped number of in-flight requests
+    // so a large selection finishes far faster than a sequential loop, without
+    // flooding the server. bulkTotal/bulkDone drive the progress indicator.
+    private const int MaxBulkConcurrency = 6;
+    private int bulkTotal;
+    private int bulkDone;
+
+    private int BulkProgressPercent => bulkTotal == 0 ? 0 : (int)(100.0 * bulkDone / bulkTotal);
 
     private int TotalPages => Math.Max(1, (int)Math.Ceiling((double)totalCount / PageSize));
 
@@ -200,10 +220,10 @@
         if (ids.Count == 0) return;
 
         isBusy = true;
-        var (ok, failed) = await RunBulk(ids, id => NoteService.UnarchiveAsync(id));
+        var (succeeded, failed) = await RunBulk(ids, id => NoteService.UnarchiveAsync(id));
         isBusy = false;
 
-        ReportBulk(ok, failed, "unarchived", "unarchive");
+        ReportBulk(succeeded.Count, failed, "unarchived", "unarchive");
         await ReloadAfterRemoval();
     }
 
@@ -217,14 +237,7 @@
         if (!await Confirm.ConfirmAsync("Move to Recycle Bin", message, "Move to Recycle Bin")) return;
 
         isBusy = true;
-        var deletedIds = new List<Guid>();
-        var failed = 0;
-        foreach (var id in ids)
-        {
-            var result = await NoteService.DeleteAsync(id);
-            if (result.IsSuccess) deletedIds.Add(id);
-            else failed++;
-        }
+        var (deletedIds, failed) = await RunBulk(ids, id => NoteService.DeleteAsync(id));
         isBusy = false;
 
         if (deletedIds.Count > 0)
@@ -256,17 +269,36 @@
     private List<Guid> SelectedIdsOnPage() =>
         items.Where(i => selected.Contains(i.Id)).Select(i => i.Id).ToList();
 
-    private static async Task<(int ok, int failed)> RunBulk(
+    // Runs the action for every id concurrently, capped at MaxBulkConcurrency
+    // in-flight requests, and reports progress as each one finishes. Returns the
+    // ids that succeeded (preserving input order) so callers can offer Undo, plus
+    // the failure count. Blazor WASM is single-threaded, so the shared counters
+    // are only mutated in continuations — no locking needed.
+    private async Task<(List<Guid> succeeded, int failed)> RunBulk(
         List<Guid> ids, Func<Guid, Task<ServiceResult<bool>>> action)
     {
-        int ok = 0, failed = 0;
-        foreach (var id in ids)
+        bulkTotal = ids.Count;
+        bulkDone = 0;
+        using var throttle = new SemaphoreSlim(MaxBulkConcurrency);
+
+        var results = await Task.WhenAll(ids.Select(async id =>
         {
-            var result = await action(id);
-            if (result.IsSuccess) ok++;
-            else failed++;
-        }
-        return (ok, failed);
+            await throttle.WaitAsync();
+            try
+            {
+                var result = await action(id);
+                return (id, ok: result.IsSuccess);
+            }
+            finally
+            {
+                throttle.Release();
+                bulkDone++;
+                StateHasChanged();
+            }
+        }));
+
+        var succeeded = results.Where(r => r.ok).Select(r => r.id).ToList();
+        return (succeeded, results.Length - succeeded.Count);
     }
 
     private void ReportBulk(int ok, int failed, string doneVerb, string failVerb)

--- a/Vanadium.Note.Web/Pages/Archive.razor.css
+++ b/Vanadium.Note.Web/Pages/Archive.razor.css
@@ -79,6 +79,21 @@
     margin-left: auto;
 }
 
+.bulk-progress {
+    flex: 1;
+    max-width: 160px;
+    height: 6px;
+    background-color: var(--mud-palette-divider);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.bulk-progress-fill {
+    height: 100%;
+    background-color: var(--mud-palette-primary);
+    transition: width 0.15s ease;
+}
+
 .note-row:last-child {
     border-bottom: none;
 }

--- a/Vanadium.Note.Web/Pages/RecycleBin.razor
+++ b/Vanadium.Note.Web/Pages/RecycleBin.razor
@@ -30,7 +30,18 @@
         @if (selected.Count > 0)
         {
             <div class="bulk-bar">
-                <span class="bulk-count">@selected.Count selected</span>
+                @if (isBusy && bulkTotal > 0)
+                {
+                    <span class="bulk-count">Processing @bulkDone / @bulkTotal…</span>
+                    <div class="bulk-progress" role="progressbar"
+                         aria-valuenow="@bulkDone" aria-valuemin="0" aria-valuemax="@bulkTotal">
+                        <div class="bulk-progress-fill" style="width:@BulkProgressPercent%"></div>
+                    </div>
+                }
+                else
+                {
+                    <span class="bulk-count">@selected.Count selected</span>
+                }
                 <button class="row-btn" disabled="@isBusy" @onclick="BulkRestore">Restore</button>
                 <button class="row-btn row-btn-danger" disabled="@isBusy" @onclick="BulkDeleteForever">Delete forever</button>
                 <button class="row-btn bulk-clear" disabled="@isBusy" @onclick="ClearSelection">Clear</button>
@@ -100,6 +111,15 @@
     private int currentPage = 1;
     private bool isLoading = true;
     private bool isBusy;
+
+    // Bulk actions run concurrently with a capped number of in-flight requests
+    // so a large selection finishes far faster than a sequential loop, without
+    // flooding the server. bulkTotal/bulkDone drive the progress indicator.
+    private const int MaxBulkConcurrency = 6;
+    private int bulkTotal;
+    private int bulkDone;
+
+    private int BulkProgressPercent => bulkTotal == 0 ? 0 : (int)(100.0 * bulkDone / bulkTotal);
 
     private int TotalPages => Math.Max(1, (int)Math.Ceiling((double)totalCount / PageSize));
 
@@ -197,10 +217,10 @@
         if (ids.Count == 0) return;
 
         isBusy = true;
-        var (ok, failed) = await RunBulk(ids, id => NoteService.RestoreAsync(id));
+        var (succeeded, failed) = await RunBulk(ids, id => NoteService.RestoreAsync(id));
         isBusy = false;
 
-        ReportBulk(ok, failed, "restored", "restore");
+        ReportBulk(succeeded.Count, failed, "restored", "restore");
         await ReloadAfterRemoval();
     }
 
@@ -213,12 +233,12 @@
         if (!await Confirm.ConfirmAsync("Delete forever", message, "Delete forever")) return;
 
         isBusy = true;
-        var (ok, failed) = await RunBulk(ids, id => NoteService.DeletePermanentAsync(id));
+        var (succeeded, failed) = await RunBulk(ids, id => NoteService.DeletePermanentAsync(id));
         isBusy = false;
 
-        if (ok > 0)
-            Logger.LogInformation("{Count} note(s) permanently deleted from recycle bin page.", ok);
-        ReportBulk(ok, failed, "permanently deleted", "delete");
+        if (succeeded.Count > 0)
+            Logger.LogInformation("{Count} note(s) permanently deleted from recycle bin page.", succeeded.Count);
+        ReportBulk(succeeded.Count, failed, "permanently deleted", "delete");
         await ReloadAfterRemoval();
     }
 
@@ -240,17 +260,36 @@
     private List<Guid> SelectedIdsOnPage() =>
         items.Where(i => selected.Contains(i.Id)).Select(i => i.Id).ToList();
 
-    private static async Task<(int ok, int failed)> RunBulk(
+    // Runs the action for every id concurrently, capped at MaxBulkConcurrency
+    // in-flight requests, and reports progress as each one finishes. Returns the
+    // ids that succeeded (preserving input order) plus the failure count. Blazor
+    // WASM is single-threaded, so the shared counters are only mutated in
+    // continuations — no locking needed.
+    private async Task<(List<Guid> succeeded, int failed)> RunBulk(
         List<Guid> ids, Func<Guid, Task<ServiceResult<bool>>> action)
     {
-        int ok = 0, failed = 0;
-        foreach (var id in ids)
+        bulkTotal = ids.Count;
+        bulkDone = 0;
+        using var throttle = new SemaphoreSlim(MaxBulkConcurrency);
+
+        var results = await Task.WhenAll(ids.Select(async id =>
         {
-            var result = await action(id);
-            if (result.IsSuccess) ok++;
-            else failed++;
-        }
-        return (ok, failed);
+            await throttle.WaitAsync();
+            try
+            {
+                var result = await action(id);
+                return (id, ok: result.IsSuccess);
+            }
+            finally
+            {
+                throttle.Release();
+                bulkDone++;
+                StateHasChanged();
+            }
+        }));
+
+        var succeeded = results.Where(r => r.ok).Select(r => r.id).ToList();
+        return (succeeded, results.Length - succeeded.Count);
     }
 
     private void ReportBulk(int ok, int failed, string doneVerb, string failVerb)

--- a/Vanadium.Note.Web/Pages/RecycleBin.razor.css
+++ b/Vanadium.Note.Web/Pages/RecycleBin.razor.css
@@ -79,6 +79,21 @@
     margin-left: auto;
 }
 
+.bulk-progress {
+    flex: 1;
+    max-width: 160px;
+    height: 6px;
+    background-color: var(--mud-palette-divider);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.bulk-progress-fill {
+    height: 100%;
+    background-color: var(--mud-palette-primary);
+    transition: width 0.15s ease;
+}
+
 .note-row:last-child {
     border-bottom: none;
 }


### PR DESCRIPTION
Closes #286

## 요약
아카이브/휴지통의 다중 선택 벌크 작업(복원/삭제/영구삭제/해제)이 순차 HTTP 루프(`foreach await`)라 항목이 많으면 느리고 진행 표시가 없던 문제를 개선한다.

## 변경 내용
- **병렬화**: `RunBulk`를 `SemaphoreSlim`(동시 최대 6개)으로 제한한 `Task.WhenAll` 병렬 처리로 교체. N개 항목이 순차 N회 왕복 대신 약 ⌈N/6⌉ 왕복으로 완료된다. 서버 부하를 막기 위해 동시 요청 수를 6개로 제한.
- **진행 표시**: 벌크 바에 `Processing X / N…` 텍스트와 진행 막대(`role="progressbar"`, `aria-valuenow/min/max`)를 추가. 각 요청이 끝날 때 `StateHasChanged`로 갱신.
- `RunBulk`가 성공한 id 목록(입력 순서 유지)을 반환하도록 하여, 아카이브 벌크 삭제의 Undo 스낵바 로직을 그대로 유지.

## 설계 판단
이슈의 "병렬화 **또는** 서버 벌크 엔드포인트" 중 **클라이언트 병렬화** 경로를 선택했다. 새 엔드포인트/DTO/스키마 변경 없이 목적을 달성하며, 기존 소프트삭제/복원 의미와 `IgnoreQueryFilters()` 규칙에 영향을 주지 않는다. 따라서 "서버 엔드포인트 추가 시 DTO 미러" 완료 조건은 해당 없음.

## 완료 조건 검증
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` → 경고 0 / 오류 0
- [x] 다수 항목 벌크가 순차 대비 빠름 — 동시 6개 병렬 처리
- [x] 진행 상태 노출 — 벌크 바 `Processing X / N…` + 진행 막대
- [x] 성공/실패 집계(`ReportBulk`)·스낵바 형식·Undo 동작 유지

## 범위
프론트엔드 4개 파일만 변경: `Archive.razor(.css)`, `RecycleBin.razor(.css)`. 스키마/서버 변경 없음.

## 참고
- Web 프로젝트에는 테스트 프로젝트가 없어 자동 회귀 테스트는 추가하지 못했다(REST 테스트 213개 통과 확인). 병렬 처리/진행 표시는 수동 확인 필요.
- Blazor WASM은 단일 스레드라 공유 카운터를 continuation에서만 변경 — 별도 락 불필요.