### PR TITLE
#350 Tiptap 에디터 ProseMirror 중복 로드 초기화 예외 수정

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/mention.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/mention.js
@@ -1,5 +1,5 @@
 import { Extension } from 'https://esm.sh/@tiptap/core@2'
-import { PluginKey, Plugin } from 'https://esm.sh/prosemirror-state@1.4.4'
+import { PluginKey, Plugin } from 'https://esm.sh/@tiptap/pm@2/state'
 import Suggestion from 'https://esm.sh/@tiptap/suggestion@2'
 
 // ── Mention extension (@) ────────────────────────────────────────────────────

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/slash-commands.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/slash-commands.js
@@ -1,5 +1,5 @@
 import { Extension } from 'https://esm.sh/@tiptap/core@2'
-import { PluginKey } from 'https://esm.sh/prosemirror-state@1.4.4'
+import { PluginKey } from 'https://esm.sh/@tiptap/pm@2/state'
 import Suggestion from 'https://esm.sh/@tiptap/suggestion@2'
 
 // ── Slash commands ───────────────────────────────────────────────────────────

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/toggle-keymap.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/toggle-keymap.js
@@ -1,5 +1,5 @@
 import { Extension } from 'https://esm.sh/@tiptap/core@2'
-import { Selection, TextSelection } from 'https://esm.sh/prosemirror-state@1.4.4'
+import { Selection, TextSelection } from 'https://esm.sh/@tiptap/pm@2/state'
 import { findAncestorOfType, toggleOpenAt } from '../nodes/toggle.js'
 import { collectFoldedHeadingSpans } from '../nodes/collapsible-heading.js'
 

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/nodes/accordion.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/nodes/accordion.js
@@ -1,5 +1,5 @@
 import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@2'
-import { PluginKey, Plugin } from 'https://esm.sh/prosemirror-state@1.4.4'
+import { PluginKey, Plugin } from 'https://esm.sh/@tiptap/pm@2/state'
 
 // ── Accordion group ──────────────────────────────────────────────────────────
 //

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/nodes/collapsible-heading.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/nodes/collapsible-heading.js
@@ -1,5 +1,5 @@
-import { PluginKey, Plugin, Selection } from 'https://esm.sh/prosemirror-state@1.4.4'
-import { Decoration, DecorationSet } from 'https://esm.sh/prosemirror-view@1.42.1'
+import { PluginKey, Plugin, Selection } from 'https://esm.sh/@tiptap/pm@2/state'
+import { Decoration, DecorationSet } from 'https://esm.sh/@tiptap/pm@2/view'
 import Heading from 'https://esm.sh/@tiptap/extension-heading@2'
 import { toggleOpenAt } from './toggle.js'
 


### PR DESCRIPTION
Closes #350

## 문제 (현재 동작)
노트 에디터(`/editor/{id}`) 진입 시 Tiptap 초기화에서 `JSException`이 발생했다.
- 초기화: `Cannot read properties of undefined (reading 'localsInner')`
- 포커스: `Cannot read properties of undefined (reading 'eq')`

두 오류 모두 `prosemirror-view`의 Decoration/plugin state 처리 지점에서 났고, `NoteEditor.razor`의 catch 블록이 이를 잡아 `_editorInitFailed` 배너로 표시하지만 에디터가 뜨지 않아 편집이 불가능했다.

## 근본 원인
`@tiptap/core@2`는 내부적으로 peer 의존성인 `@tiptap/pm`을 통해 ProseMirror(현재 `prosemirror-view@1.42.2`)를 로드한다. 그런데 커스텀 노드/익스텐션들은 esm.sh에서 `prosemirror-state@1.4.4`, `prosemirror-view@1.42.1`을 **직접** import 하고 있었다.

esm.sh 기준 이 둘은 서로 다른 모듈 URL이라 **prosemirror-view/-state의 복사본이 2벌 로드**된다. `CollapsibleHeading` 플러그인이 한쪽(1.42.1) 복사본으로 만든 `DecorationSet`을 에디터의 다른쪽(1.42.2) `EditorView`가 소비하면서, prosemirror-view의 `locals`/`matchesNode` 내부에서 `undefined.localsInner` / `undefined.eq`를 읽어 예외가 났다.

## 수정
모든 ProseMirror import를 `@tiptap/core`와 동일한 peer 의존성인 `@tiptap/pm@2/*` 경유로 변경 (Tiptap 2 권장 방식):
- `prosemirror-state@1.4.4` → `@tiptap/pm@2/state`
- `prosemirror-view@1.42.1` → `@tiptap/pm@2/view`

대상 파일: `extensions/{mention,slash-commands,toggle-keymap}.js`, `nodes/{accordion,collapsible-heading}.js`

esm.sh에서 `@tiptap/pm@2/view`는 `@tiptap/core@2.27.2`가 내부적으로 쓰는 것과 **동일한 모듈 URL**(`/@tiptap/pm@2.27.2/es2022/view.mjs` → `prosemirror-view@^1.37.0`)로 해석되므로, 브라우저 모듈 그래프에서 단일 복사본으로 dedupe 되어 근본 원인이 제거된다. 버전 범위도 tiptap의 이동을 자동으로 따라가 재발을 방지한다.

## 완료 조건 검증
- [x] `localsInner` 예외 미발생 — 중복 prosemirror-view 복사본 제거로 원인 해소
- [x] `eq` 예외 미발생 — 동일 원인 해소
- [x] 새/기존/아카이브 에디터 모두 동일 `tiptapInterop.init` 경로를 쓰므로 함께 해결
- [x] catch 배너로 숨기지 않고 근본 원인(중복 로드)을 수정 — `_editorInitFailed` 배너 로직은 그대로 유지
- [x] 빌드 클린 (`dotnet build Vanadium.slnx` — 경고 0, 오류 0)

## 참고
프론트엔드 JS(런타임 esm.sh CDN 로드) 수정이라 Web 프로젝트에 테스트 하네스가 없어 자동 회귀 테스트는 추가하지 못했다. REST 테스트 213건은 전부 통과(회귀 없음). 브라우저에서 에디터 진입/포커스로 수동 확인이 필요하다.

## 범위
JS import 라인 6곳만 변경. 인터롭 호출 규약(`tiptapInterop.*`), 노드 직렬화 규칙, `_editorInitFailed` 재시도 배너 UX 모두 미변경.