### PR TITLE
#296 운영 환경 비밀번호 회전용 --hash-password 기동 플래그

### DIFF
--- a/Vanadium.Note.REST.Tests/PasswordHashCliTests.cs
+++ b/Vanadium.Note.REST.Tests/PasswordHashCliTests.cs
@@ -1,0 +1,85 @@
+using Vanadium.Note.REST.Security;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// The server-local <c>--hash-password</c> path (issue #296): it must produce a hash that
+/// <see cref="PasswordHasher.Verify"/> accepts, reject weak passwords using the same policy as
+/// the API, and never emit anything but the hash on stdout.
+/// </summary>
+public class PasswordHashCliTests
+{
+    private sealed class StubValidator(PasswordValidationResult result) : IPasswordValidator
+    {
+        public string? LastPassword { get; private set; }
+
+        public Task<PasswordValidationResult> ValidateAsync(
+            string password, CancellationToken cancellationToken = default)
+        {
+            LastPassword = password;
+            return Task.FromResult(result);
+        }
+    }
+
+    [Theory]
+    [InlineData(new[] { "--hash-password" }, true)]
+    [InlineData(new[] { "run", "--hash-password", "extra" }, true)]
+    [InlineData(new[] { "--Hash-Password" }, false)] // case-sensitive: not the flag
+    [InlineData(new string[0], false)]
+    [InlineData(new[] { "--urls", "http://+:8080" }, false)]
+    public void IsInvocation_DetectsFlagExactly(string[] args, bool expected)
+    {
+        Assert.Equal(expected, PasswordHashCli.IsInvocation(args));
+    }
+
+    [Fact]
+    public async Task RunAsync_ValidPassword_PrintsVerifiableHashAndReturnsZero()
+    {
+        const string password = "correct horse battery staple";
+        var validator = new StubValidator(PasswordValidationResult.Success);
+        using var input = new StringReader(password + "\n");
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exitCode = await PasswordHashCli.RunAsync(validator, input, output, error);
+
+        Assert.Equal(0, exitCode);
+        var hash = output.ToString().Trim();
+        // stdout carries ONLY the hash, nothing else — so `> hash.txt` captures a clean value.
+        Assert.Equal(hash, output.ToString().TrimEnd('\r', '\n'));
+        Assert.True(PasswordHasher.Verify(password, hash));
+        Assert.Equal(password, validator.LastPassword); // validated verbatim, no trimming
+    }
+
+    [Fact]
+    public async Task RunAsync_WeakPassword_PrintsErrorsAndReturnsOneWithNoHash()
+    {
+        var validator = new StubValidator(
+            PasswordValidationResult.Failed(["Password must be at least 15 characters long."]));
+        using var input = new StringReader("short\n");
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exitCode = await PasswordHashCli.RunAsync(validator, input, output, error);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(string.Empty, output.ToString()); // no hash leaked to stdout on rejection
+        Assert.Contains("at least 15 characters", error.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_EmptyStdin_ReturnsOneWithoutCallingValidator()
+    {
+        var validator = new StubValidator(PasswordValidationResult.Success);
+        using var input = new StringReader(string.Empty);
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exitCode = await PasswordHashCli.RunAsync(validator, input, output, error);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(string.Empty, output.ToString());
+        Assert.Null(validator.LastPassword); // short-circuited before validation
+    }
+}

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -16,6 +16,19 @@ using Vanadium.Note.REST.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Server-local password-hash generation (issue #296): the `--hash-password` startup flag prints a
+// storage hash and exits (handled right after Build below). Silence routine logging first so stdout
+// carries ONLY the hash — the Serilog console sink writes to stdout, and the breach-check HttpClient
+// would otherwise emit Information logs there and corrupt a `> hash.txt` capture.
+var hashPasswordCli = PasswordHashCli.IsInvocation(args);
+if (hashPasswordCli)
+{
+    builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+    {
+        ["Serilog:MinimumLevel:Default"] = "Fatal",
+    });
+}
+
 builder.Host.UseSerilog((context, services, config) =>
 {
     config
@@ -213,6 +226,20 @@ builder.Services.AddSwaggerGen(options =>
 
 var app = builder.Build();
 
+// Server-local password-hash generation (issue #296): the `--hash-password` startup flag reads a
+// new password from stdin, validates it against the API's password policy, prints its PBKDF2
+// storage hash, and exits WITHOUT starting the web host or touching the database. This is the
+// production-safe rotation path — `/api/auth/hash` stays Development-only, and requiring shell
+// access to the running server is itself the authorization control. Reusing the DI-built
+// IPasswordValidator keeps the CLI's policy identical to the endpoint's.
+if (hashPasswordCli)
+{
+    using var cliScope = app.Services.CreateScope();
+    var passwordValidator = cliScope.ServiceProvider.GetRequiredService<IPasswordValidator>();
+    return await PasswordHashCli.RunAsync(
+        passwordValidator, Console.In, Console.Out, Console.Error);
+}
+
 var seqConfigUrl = app.Configuration["Seq:ServerUrl"];
 var seqConfigKey = app.Configuration["Seq:ApiKey"];
 if (!string.IsNullOrWhiteSpace(seqConfigUrl) && string.IsNullOrWhiteSpace(seqConfigKey))
@@ -302,6 +329,11 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+
+// app.Run() blocks until shutdown; on graceful exit the process returns 0. An explicit return is
+// required because the `--hash-password` branch above returns an int, making this entry point
+// int-typed on every path.
+return 0;
 
 // Exposes the implicit top-level Program class to the test assembly so the smoke
 // E2E WebApplicationFactory<Program> can bootstrap the real application pipeline.

--- a/Vanadium.Note.REST/Security/PasswordHashCli.cs
+++ b/Vanadium.Note.REST/Security/PasswordHashCli.cs
@@ -1,0 +1,63 @@
+namespace Vanadium.Note.REST.Security;
+
+/// <summary>
+/// Server-local password-hash generation path (issue #296).
+///
+/// Invoked with the <c>--hash-password</c> startup flag, it reads a candidate password from
+/// standard input, validates it against the very same password policy the API enforces, prints
+/// the PBKDF2 storage hash to standard output, and returns an exit code — the web host is never
+/// started and the database is never touched.
+///
+/// This gives an owner who only runs the production instance an official way to rotate
+/// <c>Auth:PasswordHash</c>: the <c>/api/auth/hash</c> endpoint deliberately stays
+/// Development-only. Requiring shell access to the running server IS the authorization control,
+/// and — like the endpoint — nothing is persisted. The password is read from stdin (not from a
+/// command-line argument) so it never lands in the shell history or the process argument list.
+/// </summary>
+public static class PasswordHashCli
+{
+    /// <summary>Startup flag that switches the process into hash-generation mode.</summary>
+    public const string Flag = "--hash-password";
+
+    /// <summary>True when <paramref name="args"/> requests hash-generation mode.</summary>
+    public static bool IsInvocation(string[] args) =>
+        args.Any(a => string.Equals(a, Flag, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Reads a password from <paramref name="input"/>, validates it, and writes its storage hash
+    /// to <paramref name="output"/> (only the hash — prompts and errors go to <paramref name="error"/>,
+    /// so <c>&gt; hash.txt</c> captures a clean value). Returns <c>0</c> on success, <c>1</c> when no
+    /// password was supplied or it fails the security policy.
+    /// </summary>
+    public static async Task<int> RunAsync(
+        IPasswordValidator validator,
+        TextReader input,
+        TextWriter output,
+        TextWriter error,
+        CancellationToken cancellationToken = default)
+    {
+        error.WriteLine("Enter the new password (read from stdin), then press Enter:");
+
+        // ReadLine strips the trailing newline; the password is otherwise used verbatim (no trim)
+        // so it hashes identically to what /api/auth/login later verifies.
+        var password = await input.ReadLineAsync(cancellationToken);
+
+        if (string.IsNullOrEmpty(password))
+        {
+            error.WriteLine("No password was provided on stdin.");
+            return 1;
+        }
+
+        var validation = await validator.ValidateAsync(password, cancellationToken);
+        if (!validation.IsValid)
+        {
+            error.WriteLine("Password does not meet the security policy:");
+            foreach (var message in validation.Errors)
+                error.WriteLine($"  - {message}");
+            return 1;
+        }
+
+        output.WriteLine(PasswordHasher.Hash(password));
+        return 0;
+    }
+}

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -74,6 +74,14 @@ into `Auth:PasswordHash`. Persists nothing. Returns `404` outside the Developmen
 - **Status codes:** `200` success · `400` password fails the security policy (`ValidationProblemDetails`)
   · `404` not in Development.
 
+> **Production password rotation.** Because this endpoint is `404` outside Development, an owner who
+> only runs the production instance rotates the password with the server-local `--hash-password`
+> startup flag instead: `dotnet Vanadium.Note.REST.dll --hash-password` (or `dotnet run -- --hash-password`)
+> reads the new password from **stdin**, applies the same password policy, prints the PBKDF2 storage
+> hash to stdout, and exits without starting the web host or touching the database. Requiring shell
+> access to the running server is the authorization control. Nothing is persisted — paste the printed
+> hash into `Auth:PasswordHash` (config/env) and restart.
+
 ---
 
 ## Personal access tokens — `ApiTokensController`


### PR DESCRIPTION
Closes #296

## 배경
`/api/auth/hash`가 dev 전용(운영은 404)이라, 운영 인스턴스만 굴리는 소유자는 새 비밀번호의 저장 해시를 만들 공식 경로가 없어 비밀번호 회전을 미루게 되는 문제를 해결한다.

## 변경 사항
- **`--hash-password` 서버 로컬 기동 플래그 추가** (`PasswordHashCli` + `Program.cs`)
  - stdin으로 새 비밀번호를 받아, 기존 `IPasswordValidator`(엔드포인트와 동일한 정책)로 검증한 뒤, PBKDF2 저장 해시를 stdout에 출력하고 종료한다.
  - 웹 호스트를 시작하지 않고 DB도 건드리지 않으며, 어떤 것도 영구 저장하지 않는다.
  - 비밀번호는 CLI 인자가 아닌 stdin으로 받아 셸 히스토리/프로세스 목록에 남지 않는다.
  - CLI 모드에서는 Serilog 콘솔 로깅을 억제해 stdout이 해시만 담도록 한다(`> hash.txt` 클린 캡처 보장).
  - `/api/auth/hash`는 dev 전용으로 그대로 유지.
- 단위 테스트 추가(`PasswordHashCliTests`).
- API 문서에 운영 회전 절차 명시.

## 사용법
```bash
dotnet Vanadium.Note.REST.dll --hash-password
# (또는 개발 시) dotnet run -- --hash-password
# 프롬프트 후 새 비밀번호 입력 → 출력된 해시를 Auth:PasswordHash(config/env)에 붙여넣고 재시작
```

## 완료 조건 검증
- **빌드 클린**: `dotnet build Vanadium.slnx` → 경고 0 / 오류 0.
- **운영에서 저장 해시 획득 경로 존재**: `echo <pw> | dotnet run -- --hash-password` 실행으로 `salt:hash:600000` 형식 해시 출력 확인, `dotnet test`의 `RunAsync_ValidPassword_PrintsVerifiableHashAndReturnsZero`가 출력 해시를 `PasswordHasher.Verify`로 검증.
- **무단 사용 방지**: 서버 셸 접근이 있어야만 실행 가능한 서버 로컬 경로(HTTP 노출 없음).

## 범위 밖(유지)
- 약한 비밀번호 400/거부: 동일 `PasswordValidator` 재사용으로 유지(약한 비밀번호는 exit 1, 해시 미출력).
- PBKDF2-SHA256 600k: `PasswordHasher.Hash` 그대로 사용(출력 해시에 `:600000` 확인).
- DB 영구 저장 없음: 실행 시 마이그레이션/호스트 시작 이전에 종료, 출력만 수행.

## 테스트
- `dotnet test Vanadium.slnx` → 221 통과 / 3 스킵(기존 Postgres 전용) / 0 실패.