### PR TITLE
#276 공유 뷰어 일시 장애/revoke 구분 및 Retry 버튼

### DIFF
--- a/Vanadium.Note.Web/Pages/Share.razor
+++ b/Vanadium.Note.Web/Pages/Share.razor
@@ -13,10 +13,24 @@
     }
     else if (_note is null)
     {
-        <div class="shared-note-status">
-            <h1>This note isn't available</h1>
-            <p>The link may be incorrect, or the note is no longer shared.</p>
-        </div>
+        @if (_transientFailure)
+        {
+            @* A 5xx/network failure is likely temporary — offer a retry instead of
+               presenting it as a permanently unavailable note. *@
+            <div class="shared-note-status">
+                <h1>Couldn't load this note</h1>
+                <p>Something went wrong while loading this note. This may be temporary.</p>
+                <button type="button" class="shared-note-retry" @onclick="RetryAsync" disabled="@_loading">Retry</button>
+            </div>
+        }
+        else
+        {
+            @* A 404 means the token is unknown or revoked — a permanent state. *@
+            <div class="shared-note-status">
+                <h1>This note isn't available</h1>
+                <p>The link may be incorrect, or the note is no longer shared.</p>
+            </div>
+        }
     }
     else
     {
@@ -41,6 +55,7 @@
 
     private SharedNote? _note;
     private bool _loading = true;
+    private bool _transientFailure;
     private string? _loadedToken;
     private ElementReference _contentRef;
     private bool _mermaidRendered;
@@ -52,12 +67,25 @@
     {
         if (_loadedToken == Token) return;
         _loadedToken = Token;
+        await LoadAsync();
+    }
+
+    // Re-triggered by the Retry button after a transient failure. Reloads the same
+    // token; a successful reload replaces the error screen with the note.
+    private Task RetryAsync() => LoadAsync();
+
+    private async Task LoadAsync()
+    {
         _loading = true;
         _note = null;
+        _transientFailure = false;
         _mermaidRendered = false;
 
         var result = await NoteService.GetSharedNoteAsync(Token);
         _note = result.IsSuccess ? result.Value : null;
+        // IsNotFound (404) is a permanent revoke/unknown-token state; any other
+        // failure (5xx/network) is treated as transient and offered a retry.
+        _transientFailure = !result.IsSuccess && !result.IsNotFound;
         _loading = false;
     }
 

--- a/Vanadium.Note.Web/Pages/Share.razor.css
+++ b/Vanadium.Note.Web/Pages/Share.razor.css
@@ -15,6 +15,27 @@
     color: var(--vn-text-muted, #6a6a6a);
 }
 
+.shared-note-retry {
+    margin-top: 1.25rem;
+    padding: 0.5rem 1.5rem;
+    font: inherit;
+    font-weight: 600;
+    color: var(--vn-mermaid-apply-color, #ffffff);
+    background: var(--vn-mermaid-apply-bg, #7950f2);
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.shared-note-retry:hover {
+    background: var(--vn-mermaid-apply-hover-bg, #6741d9);
+}
+
+.shared-note-retry:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
 .shared-note-card {
     background: var(--vn-editor-bg, #ffffff);
     border: 1px solid var(--vn-editor-title-border, #e0e0e0);


### PR DESCRIPTION
Closes #276

## 목적
공유 뷰어에서 5xx/네트워크 일시 장애와 revoke된(또는 미상) 토큰이 모두 동일한
'This note isn't available' 화면으로 합쳐져, 일시 장애를 영구 소멸로 오인하고
재시도 수단도 없던 문제를 해결한다.

## 변경 내용
- `NoteService.GetSharedNoteAsync`는 이미 404를 `IsNotFound`, 그 외 실패를 `Fail`로
  구분해 반환한다. UI가 이 구분값을 무시하던 것을 살려 두 상태를 분리 표시한다.
- `Share.razor`
  - `_transientFailure` 플래그 추가: `!IsSuccess && !IsNotFound`일 때만 일시 장애로 판정.
  - 404/revoke → 기존 'This note isn't available' (영구 소멸).
  - 5xx/네트워크 → 'Couldn't load this note' + **Retry** 버튼.
  - 로드 로직을 `LoadAsync()`로 추출하고 Retry 버튼이 동일 토큰 재조회를 트리거.
- `Share.razor.css`: Retry 버튼 스타일 추가(기존 primary-action 토큰 재사용, 다크 테마 대응).

## 범위
- Web `Share.razor` / `Share.razor.css`만 변경. 익명 읽기 전용 응답·토큰 처리 동작은 변경 없음(범위 밖 준수).

## 완료 조건 검증
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0/오류 0.
- [x] 404/revoke와 일시 장애가 서로 다른 메시지로 표시 — `_transientFailure` 분기.
- [x] 일시 장애 화면에 Retry 버튼이 있고 재조회 트리거 — `RetryAsync` → `LoadAsync`.
- 참고: Web 프로젝트에는 테스트 프로젝트가 없어 Razor UI 변경에 대한 자동 회귀 테스트는 추가하지 못했다(기존 REST 테스트 224건 통과 유지).