### PR TITLE
#310 input-safe 단축키 목록 단일 소스화

### DIFF
--- a/Vanadium.Note.Web/Layout/MainLayout.razor
+++ b/Vanadium.Note.Web/Layout/MainLayout.razor
@@ -104,7 +104,7 @@
                 StateHasChanged();
                 return Task.CompletedTask;
             }));
-            await ShortcutService.RegisterAsync("ctrl+k", "Quick navigation", () => InvokeAsync(ToggleQuickNav));
+            await ShortcutService.RegisterAsync("ctrl+k", "Quick navigation", () => InvokeAsync(ToggleQuickNav), inputSafe: true);
         }
     }
 

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -532,7 +532,7 @@
                 // matching SubNoteDialog's Ctrl+S (OnSaveShortcut → DoAutoSave). Leaving to the
                 // list is the separate "Save & close" button, so a habitual Ctrl+S no longer
                 // ejects keyboard users from the editor (#265).
-                await ShortcutService.RegisterAsync("ctrl+s", "Save note", () => InvokeAsync(DoAutoSave));
+                await ShortcutService.RegisterAsync("ctrl+s", "Save note", () => InvokeAsync(DoAutoSave), inputSafe: true);
             }
             catch (Exception ex)
             {

--- a/Vanadium.Note.Web/Pages/SubNoteDialog.razor
+++ b/Vanadium.Note.Web/Pages/SubNoteDialog.razor
@@ -157,7 +157,7 @@
                 // Claim Ctrl+S while the dialog is open so it saves THIS sub-note instead of the
                 // underlying page's note (which would navigate away). The prior binding is restored
                 // on dispose (#168).
-                _ctrlSOverride = await ShortcutService.OverrideAsync("ctrl+s", "Save note", OnSaveShortcut);
+                _ctrlSOverride = await ShortcutService.OverrideAsync("ctrl+s", "Save note", OnSaveShortcut, inputSafe: true);
             }
             catch (Exception ex)
             {

--- a/Vanadium.Note.Web/Services/KeyboardShortcutService.cs
+++ b/Vanadium.Note.Web/Services/KeyboardShortcutService.cs
@@ -6,7 +6,7 @@ public sealed class KeyboardShortcutService : IAsyncDisposable
 {
     public record ShortcutEntry(string Key, string Description);
 
-    private record HandlerEntry(Func<Task> Handler, string Description);
+    private record HandlerEntry(Func<Task> Handler, string Description, bool InputSafe);
 
     private readonly IJSRuntime _js;
     private readonly Dictionary<string, HandlerEntry> _handlers = new(StringComparer.OrdinalIgnoreCase);
@@ -25,10 +25,16 @@ public sealed class KeyboardShortcutService : IAsyncDisposable
         await _js.InvokeVoidAsync("keyboardShortcuts.init", _objRef);
     }
 
-    public async Task RegisterAsync(string key, string description, Func<Task> handler)
+    /// <summary>
+    /// Registers a shortcut. Set <paramref name="inputSafe"/> to keep it firing while a text field
+    /// has focus (e.g. the command palette or save) — this flag is the single source for input-safe
+    /// membership, mirrored into the JS handler at registration time (#310). Everything else is
+    /// suppressed while typing so it can't hijack the input (#214).
+    /// </summary>
+    public async Task RegisterAsync(string key, string description, Func<Task> handler, bool inputSafe = false)
     {
-        _handlers[key] = new HandlerEntry(handler, description);
-        await _js.InvokeVoidAsync("keyboardShortcuts.register", key);
+        _handlers[key] = new HandlerEntry(handler, description, inputSafe);
+        await _js.InvokeVoidAsync("keyboardShortcuts.register", key, inputSafe);
     }
 
     public async Task UnregisterAsync(string key)
@@ -49,10 +55,10 @@ public sealed class KeyboardShortcutService : IAsyncDisposable
     /// was none). Modal dialogs use this to claim Ctrl+S for their own note while open and hand it
     /// back to the underlying page on close (#168).
     /// </summary>
-    public async Task<IAsyncDisposable> OverrideAsync(string key, string description, Func<Task> handler)
+    public async Task<IAsyncDisposable> OverrideAsync(string key, string description, Func<Task> handler, bool inputSafe = false)
     {
         _handlers.TryGetValue(key, out var previous);
-        await RegisterAsync(key, description, handler);
+        await RegisterAsync(key, description, handler, inputSafe);
         return new ShortcutOverride(this, key, previous);
     }
 
@@ -64,7 +70,7 @@ public sealed class KeyboardShortcutService : IAsyncDisposable
             if (previous is not null)
             {
                 owner._handlers[key] = previous;
-                await owner._js.InvokeVoidAsync("keyboardShortcuts.register", key);
+                await owner._js.InvokeVoidAsync("keyboardShortcuts.register", key, previous.InputSafe);
             }
             else
             {

--- a/Vanadium.Note.Web/wwwroot/js/keyboard-shortcuts.js
+++ b/Vanadium.Note.Web/wwwroot/js/keyboard-shortcuts.js
@@ -5,7 +5,9 @@
     // Shortcuts that must keep working while a text field is focused (command
     // palette, save). Every other shortcut — bare keys AND modifier combos such
     // as Ctrl+N — is skipped while typing so it can't hijack the input (#214).
-    const _inputSafe = new Set(['ctrl+k', 'ctrl+s']);
+    // Membership is decided by the C# registration API (`inputSafe` flag on
+    // `register`), so this list has a single source and never drifts (#310).
+    const _inputSafe = new Set();
     let _ref = null;
 
     function _buildKey(e) {
@@ -58,7 +60,14 @@
             _ref = null;
             _active.clear();
         },
-        register(key) { _active.add(key); },
-        unregister(key) { _active.delete(key); },
+        register(key, inputSafe) {
+            _active.add(key);
+            if (inputSafe) _inputSafe.add(key);
+            else _inputSafe.delete(key);
+        },
+        unregister(key) {
+            _active.delete(key);
+            _inputSafe.delete(key);
+        },
     };
 }());


### PR DESCRIPTION
Closes #310

### 변경 내용
input-safe 단축키(텍스트 필드 포커스 중에도 동작해야 하는 단축키) 목록이 JS(`keyboard-shortcuts.js`)에 하드코딩(`Set(['ctrl+k','ctrl+s'])`)되어 있어, C# `KeyboardShortcutService`에서 새 input-safe 단축키를 추가할 때 JS 수정을 잊기 쉬운 이중 소스 문제를 제거한다.

- `keyboard-shortcuts.js`: 하드코딩 `_inputSafe` 목록을 빈 Set으로 바꾸고, `register(key, inputSafe)`에서 플래그에 따라 추가/제거하도록 변경. `unregister`도 `_inputSafe`에서 함께 제거.
- `KeyboardShortcutService.cs`: `HandlerEntry`에 `InputSafe` 추가, `RegisterAsync`/`OverrideAsync`에 `bool inputSafe = false` 파라미터 추가, override 복원 시 이전 항목의 `InputSafe` 값으로 재등록.
- 호출부: `ctrl+k`(MainLayout, Quick nav), `ctrl+s`(NoteEditor 저장 / SubNoteDialog override)에서 `inputSafe: true` 전달. 나머지 단축키(alt+n, ctrl+/, delete)는 기본값 false로 기존 동작 유지.

### 완료 조건 검증
- **빌드 클린**: `dotnet build Vanadium.slnx` → 경고 0, 오류 0.
- **단일 소스화**: JS 하드코딩 Set 제거 완료. input-safe 여부는 C# `RegisterAsync`/`OverrideAsync`의 `inputSafe` 인자로만 결정되어 JS로 전달됨.
- **회귀 없음(ctrl+k/ctrl+s)**: 두 단축키 등록부에서 `inputSafe: true`를 전달하므로 텍스트 필드 포커스 중에도 기존과 동일하게 동작. `_buildKey`의 metaKey→ctrl 매핑과 #214 입력 중 억제 로직은 변경하지 않음.

### 테스트
`dotnet test Vanadium.slnx` → 221 통과, 3 스킵(PostgreSQL 전용, 기존 스킵). Web 프로젝트는 테스트 프로젝트가 없고 본 변경은 Blazor JS interop 동작이라 REST 테스트 범위 밖 — 자동 회귀 테스트는 추가하지 않았으며 ctrl+k/ctrl+s 동작 유지는 수동 확인 필요.