### PR TITLE
#302 Archive/RecycleBin 그룹 판정을 타임스탬프 대신 전용 GroupId로

### DIFF
--- a/Vanadium.Note.REST.Tests/ArchiveServiceTests.cs
+++ b/Vanadium.Note.REST.Tests/ArchiveServiceTests.cs
@@ -430,4 +430,78 @@ public class ArchiveServiceTests
         Assert.Null(c!.DeletedAt);
         Assert.Null(c.ParentNoteId); // would otherwise resurrect under a read-only parent
     }
+
+    // ── #302: group membership is decided by a dedicated group id, never by ──
+    //         DeletedAt/ArchivedAt timestamp equality ──────────────────────────
+
+    [Fact]
+    public async Task Archive_AssignsSharedGroupId_DistinctPerOperation()
+    {
+        using var h = new TestHost();
+        var rootA = await h.CreateNoteAsync("Root A");
+        var childA = await h.CreateNoteAsync("Child A", rootA.Id);
+        var rootB = await h.CreateNoteAsync("Root B");
+
+        await h.Notes.Archive(rootA.Id);
+        await h.Notes.Archive(rootB.Id);
+
+        var groupA = (await h.FindAsync(rootA.Id))!.ArchiveGroupId;
+        Assert.NotNull(groupA);
+        Assert.Equal(groupA, (await h.FindAsync(childA.Id))!.ArchiveGroupId);      // shared within the group
+        Assert.NotEqual(groupA, (await h.FindAsync(rootB.Id))!.ArchiveGroupId);     // distinct per operation
+    }
+
+    [Fact]
+    public async Task Unarchive_TimestampCollisionBetweenGroups_UnarchivesOnlyOwnGroup()
+    {
+        using var h = new TestHost();
+        var rootA = await h.CreateNoteAsync("Root A");
+        var childA = await h.CreateNoteAsync("Child A", rootA.Id);
+        var rootB = await h.CreateNoteAsync("Root B");
+        var childB = await h.CreateNoteAsync("Child B", rootB.Id);
+
+        await h.Notes.Archive(rootA.Id);
+        await h.Notes.Archive(rootB.Id);
+
+        // Force a microsecond timestamp collision across the two independent archive
+        // groups. Under the old ArchivedAt-equality grouping this would fuse them;
+        // group-id identity must keep them apart.
+        var sharedTimestamp = (await h.FindAsync(rootA.Id))!.ArchivedAt;
+        await h.Db.Notes.IgnoreQueryFilters()
+            .Where(n => n.ArchivedAt != null)
+            .ExecuteUpdateAsync(s => s.SetProperty(n => n.ArchivedAt, sharedTimestamp));
+
+        Assert.True(await h.Notes.Unarchive(rootA.Id));
+
+        Assert.Null((await h.FindAsync(rootA.Id))!.ArchivedAt);
+        Assert.Null((await h.FindAsync(childA.Id))!.ArchivedAt);
+        Assert.NotNull((await h.FindAsync(rootB.Id))!.ArchivedAt);   // untouched despite same timestamp
+        Assert.NotNull((await h.FindAsync(childB.Id))!.ArchivedAt);
+    }
+
+    [Fact]
+    public async Task Restore_TimestampCollisionBetweenGroups_RestoresOnlyOwnGroup()
+    {
+        using var h = new TestHost();
+        var rootA = await h.CreateNoteAsync("Root A");
+        var childA = await h.CreateNoteAsync("Child A", rootA.Id);
+        var rootB = await h.CreateNoteAsync("Root B");
+        var childB = await h.CreateNoteAsync("Child B", rootB.Id);
+
+        await h.Notes.Delete(rootA.Id);
+        await h.Notes.Delete(rootB.Id);
+
+        // Same microsecond-collision scenario for the recycle-bin deletion group.
+        var sharedTimestamp = (await h.FindAsync(rootA.Id))!.DeletedAt;
+        await h.Db.Notes.IgnoreQueryFilters()
+            .Where(n => n.DeletedAt != null)
+            .ExecuteUpdateAsync(s => s.SetProperty(n => n.DeletedAt, sharedTimestamp));
+
+        Assert.True(await h.Notes.Restore(rootA.Id));
+
+        Assert.Null((await h.FindAsync(rootA.Id))!.DeletedAt);
+        Assert.Null((await h.FindAsync(childA.Id))!.DeletedAt);
+        Assert.NotNull((await h.FindAsync(rootB.Id))!.DeletedAt);   // untouched despite same timestamp
+        Assert.NotNull((await h.FindAsync(childB.Id))!.DeletedAt);
+    }
 }

--- a/Vanadium.Note.REST/Migrations/20260727022606_AddNoteGroupId.Designer.cs
+++ b/Vanadium.Note.REST/Migrations/20260727022606_AddNoteGroupId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Vanadium.Note.REST.Data;
@@ -11,9 +12,11 @@ using Vanadium.Note.REST.Data;
 namespace Vanadium.Note.REST.Migrations
 {
     [DbContext(typeof(NoteDbContext))]
-    partial class NoteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727022606_AddNoteGroupId")]
+    partial class AddNoteGroupId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Vanadium.Note.REST/Migrations/20260727022606_AddNoteGroupId.cs
+++ b/Vanadium.Note.REST/Migrations/20260727022606_AddNoteGroupId.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Vanadium.Note.REST.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNoteGroupId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ArchiveGroupId",
+                table: "Notes",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "DeletionGroupId",
+                table: "Notes",
+                type: "uuid",
+                nullable: true);
+
+            // Backfill existing groups so the switch from timestamp-equality to group-id
+            // equality is lossless: every note already in a group gets a group id, and all
+            // notes that previously grouped by a shared timestamp keep grouping together.
+            // One fresh uuid is assigned per distinct DeletedAt / ArchivedAt value
+            // (gen_random_uuid() is evaluated once per GROUP BY row). Active notes keep NULL.
+            migrationBuilder.Sql(@"
+                UPDATE ""Notes"" AS n
+                SET ""DeletionGroupId"" = sub.gid
+                FROM (
+                    SELECT ""DeletedAt"" AS ts, gen_random_uuid() AS gid
+                    FROM ""Notes""
+                    WHERE ""DeletedAt"" IS NOT NULL
+                    GROUP BY ""DeletedAt""
+                ) AS sub
+                WHERE n.""DeletedAt"" = sub.ts;");
+
+            migrationBuilder.Sql(@"
+                UPDATE ""Notes"" AS n
+                SET ""ArchiveGroupId"" = sub.gid
+                FROM (
+                    SELECT ""ArchivedAt"" AS ts, gen_random_uuid() AS gid
+                    FROM ""Notes""
+                    WHERE ""ArchivedAt"" IS NOT NULL
+                    GROUP BY ""ArchivedAt""
+                ) AS sub
+                WHERE n.""ArchivedAt"" = sub.ts;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ArchiveGroupId",
+                table: "Notes");
+
+            migrationBuilder.DropColumn(
+                name: "DeletionGroupId",
+                table: "Notes");
+        }
+    }
+}

--- a/Vanadium.Note.REST/Models/NoteItem.cs
+++ b/Vanadium.Note.REST/Models/NoteItem.cs
@@ -28,6 +28,14 @@ public class NoteItem
     [JsonIgnore]
     public bool IsDeletionRoot { get; set; }
 
+    /// <summary>Identifies the recycle-bin restore group: the directly-deleted note plus the
+    /// descendants swept in with it share one value, assigned fresh per delete operation.
+    /// Group membership is decided by this id, never by <see cref="DeletedAt"/> equality
+    /// (a microsecond timestamp collision must never merge two independent groups).
+    /// Null when the note is not in the recycle bin.</summary>
+    [JsonIgnore]
+    public Guid? DeletionGroupId { get; set; }
+
     /// <summary>Null = not archived. Non-null marks the note archived (read-only).
     /// Notes archived in the same operation share the same value (restore group).
     /// Serialized on purpose: the frontend editor uses it to switch to read-only mode.</summary>
@@ -37,6 +45,14 @@ public class NoteItem
     /// Sub-notes swept into the archive keep this false.</summary>
     [JsonIgnore]
     public bool IsArchiveRoot { get; set; }
+
+    /// <summary>Identifies the archive restore group: notes archived in one operation share one
+    /// value, assigned fresh per archive operation. Group membership is decided by this id, never
+    /// by <see cref="ArchivedAt"/> equality. Independent of <see cref="DeletionGroupId"/> so an
+    /// archived note that is later soft-deleted keeps its archive group for a lossless restore.
+    /// Null when the note is not archived.</summary>
+    [JsonIgnore]
+    public Guid? ArchiveGroupId { get; set; }
 
     /// <summary>Unguessable token that grants anonymous read access when the note is shared.
     /// Null when the note is not shared. Cleared on unshare, which immediately invalidates any

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -315,8 +315,10 @@ public class NoteService(
         // by the soft-delete filter (and silently purged) or born archived.
         note.DeletedAt = null;
         note.IsDeletionRoot = false;
+        note.DeletionGroupId = null;
         note.ArchivedAt = null;
         note.IsArchiveRoot = false;
+        note.ArchiveGroupId = null;
         // Sharing is off at birth and can only be turned on through the dedicated share
         // endpoints — a client must never be able to mint a share token via create/update.
         note.ShareToken = null;
@@ -700,16 +702,19 @@ public class NoteService(
         if (note is null) return false;
 
         var deletedAt = UtcNowMicroseconds();
+        var groupId = Guid.NewGuid();
         note.DeletedAt = deletedAt;
         note.IsDeletionRoot = true;
+        note.DeletionGroupId = groupId;
 
-        // Active descendants are swept into the same recycle bin group (same timestamp).
+        // Active descendants are swept into the same recycle bin group (shared group id).
         // Descendants soft-deleted earlier keep their own group and restore independently.
         var descendants = await CollectActiveDescendantsAsync(id, ct);
         foreach (var descendant in descendants)
         {
             descendant.DeletedAt = deletedAt;
             descendant.IsDeletionRoot = false;
+            descendant.DeletionGroupId = groupId;
         }
 
         await db.SaveChangesAsync(ct);
@@ -775,8 +780,8 @@ public class NoteService(
                 n.Id == id && n.DeletedAt != null && n.IsDeletionRoot, ct);
         if (note is null) return false;
 
-        var groupDeletedAt = note.DeletedAt!.Value;
-        var groupMembers = await CollectDeletedGroupDescendantsAsync(id, groupDeletedAt, ct);
+        var groupId = note.DeletionGroupId!.Value;
+        var groupMembers = await CollectDeletedGroupDescendantsAsync(id, groupId, ct);
 
         if (note.ParentNoteId.HasValue)
         {
@@ -792,10 +797,12 @@ public class NoteService(
 
         note.DeletedAt = null;
         note.IsDeletionRoot = false;
+        note.DeletionGroupId = null;
         foreach (var member in groupMembers)
         {
             member.DeletedAt = null;
             member.IsDeletionRoot = false;
+            member.DeletionGroupId = null;
         }
 
         await db.SaveChangesAsync(ct);
@@ -819,12 +826,14 @@ public class NoteService(
         if (note.ArchivedAt is not null) return true; // idempotent no-op
 
         var archivedAt = UtcNowMicroseconds();
+        var groupId = Guid.NewGuid();
         note.ArchivedAt = archivedAt;
         note.IsArchiveRoot = true;
+        note.ArchiveGroupId = groupId;
 
-        // Sweep active descendants into the same archive group. The BFS sees
-        // archived descendants too (archive has no global filter), so skip them:
-        // independently archived subtrees keep their own root and timestamp.
+        // Sweep active descendants into the same archive group (shared group id). The
+        // BFS sees archived descendants too (archive has no global filter), so skip
+        // them: independently archived subtrees keep their own root and group id.
         var descendants = (await CollectActiveDescendantsAsync(id, ct))
             .Where(d => d.ArchivedAt == null)
             .ToList();
@@ -832,6 +841,7 @@ public class NoteService(
         {
             descendant.ArchivedAt = archivedAt;
             descendant.IsArchiveRoot = false;
+            descendant.ArchiveGroupId = groupId;
         }
 
         await db.SaveChangesAsync(ct);
@@ -854,15 +864,17 @@ public class NoteService(
             n.Id == id && n.ArchivedAt != null, ct);
         if (note is null) return false;
 
-        var groupArchivedAt = note.ArchivedAt!.Value;
-        var groupMembers = await CollectArchivedGroupDescendantsAsync(id, groupArchivedAt, ct);
+        var groupId = note.ArchiveGroupId!.Value;
+        var groupMembers = await CollectArchivedGroupDescendantsAsync(id, groupId, ct);
 
         note.ArchivedAt = null;
         note.IsArchiveRoot = false;
+        note.ArchiveGroupId = null;
         foreach (var member in groupMembers)
         {
             member.ArchivedAt = null;
             member.IsArchiveRoot = false;
+            member.ArchiveGroupId = null;
         }
 
         // Never resurrect an active note under a missing, soft-deleted, or
@@ -905,20 +917,24 @@ public class NoteService(
             })
             .ToListAsync(ct);
 
-        // Direct children swept in the same archive operation (same timestamp),
+        // Direct children swept in the same archive operation (same group id),
         // mirroring the recycle bin's per-root child counts.
         var ids = items.Select(i => i.Id).ToList();
         if (ids.Count > 0)
         {
+            var rootGroupIds = await db.Notes
+                .Where(n => ids.Contains(n.Id))
+                .Select(n => new { n.Id, n.ArchiveGroupId })
+                .ToDictionaryAsync(x => x.Id, x => x.ArchiveGroupId, ct);
             var children = await db.Notes
                 .Where(n => n.ArchivedAt != null
                     && n.ParentNoteId.HasValue
                     && ids.Contains(n.ParentNoteId.Value))
-                .Select(n => new { ParentId = n.ParentNoteId!.Value, n.ArchivedAt })
+                .Select(n => new { ParentId = n.ParentNoteId!.Value, n.ArchiveGroupId })
                 .ToListAsync(ct);
             foreach (var item in items)
                 item.ChildCount = children.Count(c =>
-                    c.ParentId == item.Id && c.ArchivedAt == item.ArchivedAt);
+                    c.ParentId == item.Id && c.ArchiveGroupId == rootGroupIds.GetValueOrDefault(item.Id));
         }
 
         return new PagedResult<ArchivedNoteSummary>
@@ -1062,19 +1078,19 @@ public class NoteService(
     private async Task<List<NoteItem>> CollectDescendantsUnfilteredAsync(Guid rootId, CancellationToken ct = default)
         => await CollectDescendantsAsync(rootId, db.Notes.IgnoreQueryFilters(), ct);
 
-    /// <summary>BFS over soft-deleted descendants sharing the given recycle-bin-group timestamp.</summary>
-    private async Task<List<NoteItem>> CollectDeletedGroupDescendantsAsync(Guid rootId, DateTime groupDeletedAt, CancellationToken ct = default)
+    /// <summary>BFS over soft-deleted descendants sharing the given recycle-bin group id.</summary>
+    private async Task<List<NoteItem>> CollectDeletedGroupDescendantsAsync(Guid rootId, Guid groupId, CancellationToken ct = default)
         => await CollectDescendantsAsync(
             rootId,
-            db.Notes.IgnoreQueryFilters().Where(n => n.DeletedAt == groupDeletedAt),
+            db.Notes.IgnoreQueryFilters().Where(n => n.DeletionGroupId == groupId),
             ct);
 
-    /// <summary>BFS over archived descendants sharing the given archive-group timestamp.
+    /// <summary>BFS over archived descendants sharing the given archive group id.
     /// Descends only through same-group notes, so independently archived subtrees stay put.</summary>
-    private async Task<List<NoteItem>> CollectArchivedGroupDescendantsAsync(Guid rootId, DateTime groupArchivedAt, CancellationToken ct = default)
+    private async Task<List<NoteItem>> CollectArchivedGroupDescendantsAsync(Guid rootId, Guid groupId, CancellationToken ct = default)
         => await CollectDescendantsAsync(
             rootId,
-            db.Notes.Where(n => n.ArchivedAt == groupArchivedAt),
+            db.Notes.Where(n => n.ArchiveGroupId == groupId),
             ct);
 
     private static async Task<List<NoteItem>> CollectDescendantsAsync(Guid rootId, IQueryable<NoteItem> source, CancellationToken ct = default)


### PR DESCRIPTION
Closes #302

## 배경
Archive/RecycleBin 그룹 판정이 `ArchivedAt`/`DeletedAt` 타임스탬프 동일성에 의존했다. 타임스탬프를 그룹 식별자로 쓰는 설계는 마이크로초 충돌 시 서로 다른 그룹이 하나로 합쳐질 수 있어 취약하다. 전용 GroupId(Guid)로 그룹 식별을 명확히 한다.

## 변경 사항
- **`NoteItem`에 두 개의 nullable Guid 컬럼 추가** — `ArchiveGroupId`, `DeletionGroupId` (둘 다 `[JsonIgnore]` 서버 내부 관리 필드).
  - **컬럼을 두 개로 분리한 이유:** 아카이브된 노트가 휴지통으로 이동할 수 있고(아카이브 → 휴지통, `ArchivedAt` 유지) 복원 시 다시 아카이브로 돌아간다. 단일 GroupId면 삭제 그룹이 아카이브 그룹을 덮어써 언아카이브가 깨진다. 두 라이프사이클을 독립적으로 유지한다.
- **그룹 판정 로직 전환** — `Archive`/`Delete`는 그룹 전체에 새 Guid를 부여하고, `Unarchive`/`Restore`·그룹 수집 헬퍼(`CollectArchivedGroupDescendantsAsync`/`CollectDeletedGroupDescendantsAsync`)·`GetArchive` 자식 카운트가 모두 타임스탬프 동일성 대신 GroupId 동일성으로 그룹을 식별한다.
- `ArchivedAt`/`DeletedAt`는 표시/정렬 용도로만 유지.
- `Create`에서 클라이언트 오버포스팅 방지를 위해 두 GroupId를 null로 강제(기존 `DeletedAt`/`ArchivedAt` 처리와 동일).
- **마이그레이션 `AddNoteGroupId`** — 두 컬럼 추가 + 기존 데이터 백필. 각 distinct `DeletedAt`/`ArchivedAt` 그룹에 `gen_random_uuid()`로 하나의 Guid를 부여해, 기존 타임스탬프 기반 그룹이 그대로 GroupId 그룹으로 이어지도록 무손실 전환한다.

## 완료 조건 검증
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 경고 0/오류 0.
- [x] EF Core 마이그레이션 추가 — `20260727022606_AddNoteGroupId`, 개발 DB에 `dotnet ef database update` 적용 성공(백필 SQL 포함).
- [x] 그룹 판정 로직이 타임스탬프 동일성 비교를 더 이상 사용하지 않음 — 5개 지점 모두 GroupId로 전환.
- [x] 아카이브/복원/휴지통 그룹 스윕이 GroupId 기준으로 동작, 회귀 없음 — `dotnet test` 224 통과(신규 회귀 테스트 3개 포함).

## 테스트
`ArchiveServiceTests`에 회귀 테스트 3개 추가:
- `Archive_AssignsSharedGroupId_DistinctPerOperation` — 그룹 내 공유·연산 간 구분.
- `Unarchive_TimestampCollisionBetweenGroups_UnarchivesOnlyOwnGroup` / `Restore_TimestampCollisionBetweenGroups_RestoresOnlyOwnGroup` — 두 그룹의 타임스탬프를 강제로 동일하게 만든 뒤 한 그룹만 unarchive/restore. 기존 타임스탬프 동일성 방식에서는 실패, GroupId 방식에서만 통과.

## 범위 밖 준수
- Archive 전역 쿼리 필터 미도입 — 기존 `ArchivedAt == null` 명시 술어 방식 유지.
- 기존 마이그레이션 파일 미수정 — 신규 마이그레이션만 추가.
- 신규 컬럼은 `[JsonIgnore]`라 API 응답 형태 변화 없음(api-specification 변경 불필요).