### PR TITLE
#294 공유 응답 재-sanitize + 레거시 콘텐츠 1회 백필

### DIFF
--- a/Vanadium.Note.REST.Tests/NoteSharingServiceTests.cs
+++ b/Vanadium.Note.REST.Tests/NoteSharingServiceTests.cs
@@ -41,6 +41,104 @@ public class NoteSharingServiceTests
     }
 
     [Fact]
+    public async Task GetSharedByToken_SanitizesLegacyContentBeforeReturning()
+    {
+        using var h = new TestHost();
+
+        // Seed a "legacy" note directly, bypassing Create's persist-time sanitizer, so the stored
+        // row carries active content the way a pre-sanitizer row would (issue #294).
+        var note = new NoteItem
+        {
+            Id = Guid.NewGuid(),
+            Title = "Legacy",
+            Content = "<p>hello</p><script>alert(1)</script>",
+            ContentText = "hello",
+            UpdatedAt = DateTime.UtcNow,
+            ShareToken = "legacy-token",
+            ShareMode = ShareMode.Public,
+            SharedAt = DateTime.UtcNow
+        };
+        h.Db.Notes.Add(note);
+        await h.Db.SaveChangesAsync();
+
+        var resolved = await h.Notes.GetSharedByToken("legacy-token");
+
+        Assert.NotNull(resolved);
+        Assert.DoesNotContain("<script", resolved!.Content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("hello", resolved.Content);
+
+        // The in-memory read-time sanitize must NOT be flushed back to the stored row (AsNoTracking).
+        var stored = await h.FindAsync(note.Id);
+        Assert.Contains("<script", stored!.Content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReSanitizeAllContent_StripsActiveContentFromLegacyRows()
+    {
+        using var h = new TestHost();
+
+        var dirty = new NoteItem
+        {
+            Id = Guid.NewGuid(),
+            Title = "Legacy",
+            Content = "<p>keep</p><script>alert(1)</script>",
+            ContentText = "keep",
+            UpdatedAt = DateTime.UtcNow
+        };
+        h.Db.Notes.Add(dirty);
+        await h.Db.SaveChangesAsync();
+
+        var updated = await h.Notes.ReSanitizeAllContentAsync();
+
+        Assert.Equal(1, updated);
+        var stored = await h.FindAsync(dirty.Id);
+        Assert.DoesNotContain("<script", stored!.Content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("keep", stored.Content);
+        // ContentText is re-derived from the sanitized markup, keeping the Create/Update invariant.
+        Assert.DoesNotContain("alert", stored.ContentText, StringComparison.OrdinalIgnoreCase);
+
+        // Idempotent: a second pass finds nothing to change.
+        Assert.Equal(0, await h.Notes.ReSanitizeAllContentAsync());
+    }
+
+    [Fact]
+    public async Task ReSanitizeAllContent_IncludesArchivedAndSoftDeletedNotes()
+    {
+        using var h = new TestHost();
+
+        var archived = new NoteItem
+        {
+            Id = Guid.NewGuid(),
+            Title = "Archived",
+            Content = "<p>a</p><script>alert(1)</script>",
+            ContentText = "a",
+            UpdatedAt = DateTime.UtcNow,
+            ArchivedAt = DateTime.UtcNow,
+            IsArchiveRoot = true
+        };
+        var deleted = new NoteItem
+        {
+            Id = Guid.NewGuid(),
+            Title = "Deleted",
+            Content = "<p>d</p><script>alert(2)</script>",
+            ContentText = "d",
+            UpdatedAt = DateTime.UtcNow,
+            DeletedAt = DateTime.UtcNow,
+            IsDeletionRoot = true
+        };
+        h.Db.Notes.AddRange(archived, deleted);
+        await h.Db.SaveChangesAsync();
+
+        var updated = await h.Notes.ReSanitizeAllContentAsync();
+
+        Assert.Equal(2, updated);
+        var storedArchived = await h.FindAsync(archived.Id);
+        var storedDeleted = await h.FindAsync(deleted.Id);
+        Assert.DoesNotContain("<script", storedArchived!.Content, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<script", storedDeleted!.Content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task GetSharedByToken_WrongToken_ReturnsNull()
     {
         using var h = new TestHost();

--- a/Vanadium.Note.REST/Migrations/20260727041332_AddLegacyContentSanitizedFlag.Designer.cs
+++ b/Vanadium.Note.REST/Migrations/20260727041332_AddLegacyContentSanitizedFlag.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Vanadium.Note.REST.Data;
@@ -11,9 +12,11 @@ using Vanadium.Note.REST.Data;
 namespace Vanadium.Note.REST.Migrations
 {
     [DbContext(typeof(NoteDbContext))]
-    partial class NoteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727041332_AddLegacyContentSanitizedFlag")]
+    partial class AddLegacyContentSanitizedFlag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Vanadium.Note.REST/Migrations/20260727041332_AddLegacyContentSanitizedFlag.cs
+++ b/Vanadium.Note.REST/Migrations/20260727041332_AddLegacyContentSanitizedFlag.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Vanadium.Note.REST.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLegacyContentSanitizedFlag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "LegacyContentSanitized",
+                table: "UserSettings",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LegacyContentSanitized",
+                table: "UserSettings");
+        }
+    }
+}

--- a/Vanadium.Note.REST/Models/UserSettings.cs
+++ b/Vanadium.Note.REST/Models/UserSettings.cs
@@ -16,4 +16,11 @@ public class UserSettings
 
     [MaxLength(6)]
     public string Theme { get; set; } = "system";
+
+    /// <summary>
+    /// Maintenance flag (issue #294): true once the one-time legacy content re-sanitize
+    /// backfill has run. Not a user preference — it gates the startup backfill so notes
+    /// stored before the persist-time sanitizer are cleaned exactly once, and never again.
+    /// </summary>
+    public bool LegacyContentSanitized { get; set; }
 }

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authentication;
 using Vanadium.Note.REST.Auth;
 using Vanadium.Note.REST.Data;
 using Vanadium.Note.REST.Middleware;
+using Vanadium.Note.REST.Models;
 using Vanadium.Note.REST.Security;
 using Vanadium.Note.REST.Services;
 
@@ -300,9 +301,30 @@ if (!app.Environment.IsEnvironment("Testing"))
 {
     using var scope = app.Services.CreateScope();
     var startupLogger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+    var db = scope.ServiceProvider.GetRequiredService<NoteDbContext>();
     startupLogger.LogInformation("Applying database migrations...");
-    scope.ServiceProvider.GetRequiredService<NoteDbContext>().Database.Migrate();
+    db.Database.Migrate();
     startupLogger.LogInformation("Database migrations applied.");
+
+    // One-time legacy content re-sanitize backfill (issue #294). The re-sanitize itself cannot
+    // run inside the EF migration because HtmlSanitizer is C#, not SQL, so it runs here right
+    // after Migrate() and is gated by a persisted flag on the UserSettings singleton — this makes
+    // it fire exactly once (crash-safe: the flag is only set after the backfill's own commit).
+    var settings = await db.UserSettings.FirstOrDefaultAsync();
+    if (settings is null)
+    {
+        settings = new UserSettings { Id = Guid.NewGuid() };
+        db.UserSettings.Add(settings);
+    }
+    if (!settings.LegacyContentSanitized)
+    {
+        var noteService = scope.ServiceProvider.GetRequiredService<NoteService>();
+        var updated = await noteService.ReSanitizeAllContentAsync();
+        settings.LegacyContentSanitized = true;
+        await db.SaveChangesAsync();
+        startupLogger.LogInformation(
+            "Legacy content re-sanitize backfill complete; {UpdatedCount} note(s) updated.", updated);
+    }
 }
 
 // Must run before any middleware that reads the client IP or request scheme

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -278,9 +278,44 @@ public class NoteService(
     public async Task<NoteItem?> GetSharedByToken(string? token, CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(token)) return null;
-        return await db.Notes
+        var note = await db.Notes
+            .AsNoTracking()
             .FirstOrDefaultAsync(n =>
                 n.ShareToken == token && n.ShareMode != ShareMode.None, ct);
+        if (note is null) return null;
+        // Defense in depth (issue #294): the persist-time sanitizer runs only on Create/Update,
+        // so legacy rows saved before it — or any future gap — could still carry active content.
+        // Sanitize once more right before the note leaves the anonymous read path so a shared
+        // page can never serve script/event handlers. AsNoTracking keeps this in-memory pass
+        // from being flushed back to the row (which would desync the persisted ContentText).
+        note.Content = htmlSanitizer.Sanitize(note.Content);
+        return note;
+    }
+
+    /// <summary>
+    /// One-time backfill (issue #294): re-sanitize every stored note's <c>Content</c> so legacy
+    /// rows saved before the persist-time sanitizer can never serve active content on the
+    /// anonymous share path. Archived and soft-deleted notes are included
+    /// (<c>IgnoreQueryFilters</c>) because either can be restored/re-shared later. Idempotent:
+    /// rows whose sanitized content is unchanged are left untouched, and <c>ContentText</c> is
+    /// re-derived only when <c>Content</c> actually changed — the same Content/ContentText
+    /// invariant the Create/Update paths maintain (the StripHtml derivation itself is unchanged).
+    /// Returns the number of notes updated.
+    /// </summary>
+    public async Task<int> ReSanitizeAllContentAsync(CancellationToken ct = default)
+    {
+        var notes = await db.Notes.IgnoreQueryFilters().ToListAsync(ct);
+        var changed = 0;
+        foreach (var note in notes)
+        {
+            var sanitized = htmlSanitizer.Sanitize(note.Content);
+            if (string.Equals(sanitized, note.Content, StringComparison.Ordinal)) continue;
+            note.Content = sanitized;
+            note.ContentText = StripHtml(sanitized);
+            changed++;
+        }
+        if (changed > 0) await db.SaveChangesAsync(ct);
+        return changed;
     }
 
     private static void ClearShare(NoteItem note)

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -405,7 +405,9 @@ This is the only content endpoint reachable without authentication.
 - **Response `200`:** `SharedNote` — `{ id, title, content, updatedAt }`. Lean, read-only; never exposes
   the token, structure, labels, or lifecycle fields. Cross-note reference markup (page-link / note-mention)
   is redacted from `content` — each node is replaced with a `🔒 private page` placeholder so a referenced
-  (possibly non-shared) note's GUID and title are never disclosed. For `Link` mode, an
+  (possibly non-shared) note's GUID and title are never disclosed. `content` is also re-sanitized
+  at read time, so a shared page never serves active content (scripts / event handlers) even if a
+  legacy row predates the persist-time sanitizer. For `Link` mode, an
   `X-Robots-Tag: noindex, nofollow` header is added; `Public` mode omits it.
 - **Status codes:** `200` · `404` unknown, revoked, or soft-deleted note.
 


### PR DESCRIPTION
Closes #294

## 목적
sanitize가 Create/Update 시점에만 수행되고 공유는 MarkupString 직주입 방식이라, sanitizer 도입 이전에 저장된 레거시 콘텐츠에 스크립트가 남아 있으면 익명 뷰어에게 그대로 서빙될 수 있었다. 이슈 #293의 CSP esm.sh 허용과 결합 시 실행 가능성도 있어, 읽기 시점 재-sanitize와 레거시 저장분 1회 백필을 추가한다.

## 변경 사항
- **읽기 시점 재-sanitize:** `GetSharedByToken`이 반환 직전 `Content`를 한 번 더 sanitize한다. `AsNoTracking`으로 조회해 이 인메모리 정리가 저장분(및 파생 `ContentText`)에 flush되지 않도록 했다.
- **1회 백필:** `NoteService.ReSanitizeAllContentAsync`가 아카이브/휴지통 노트를 포함(`IgnoreQueryFilters`)해 전체 노트를 재-sanitize한다. 멱등(변화 없는 행은 미수정)하며, `Content`가 실제로 바뀐 경우에만 기존 Create/Update와 동일한 `StripHtml`로 `ContentText`를 재파생한다.
- **마이그레이션 + 기동 훅:** `HtmlSanitizer`는 C#이라 SQL 마이그레이션 안에서 실행할 수 없으므로, `UserSettings.LegacyContentSanitized` 플래그 컬럼을 추가하는 마이그레이션(`AddLegacyContentSanitizedFlag`)을 두고 `Program.cs`에서 `Migrate()` 직후 플래그 기반으로 백필을 **정확히 1회** 실행한다(플래그는 백필 커밋 이후에만 설정 → 중간 크래시에도 안전).

## 완료 조건 검증
- **빌드 클린:** `dotnet build Vanadium.slnx` → 경고 0 / 오류 0.
- **EF Core 마이그레이션 추가:** `20260727041332_AddLegacyContentSanitizedFlag`, dev DB에 `dotnet ef database update` 적용 확인.
- **GetSharedByToken 반환 Content가 항상 sanitize됨:** `GetSharedByToken_SanitizesLegacyContentBeforeReturning` — 레거시 행(`<script>` 포함)을 직접 시드 후 반환값에 `<script>` 없음, 저장분은 미변경(AsNoTracking) 확인.
- **백필 후 활성 콘텐츠 잔존 없음:** `ReSanitizeAllContent_StripsActiveContentFromLegacyRows`(제거·멱등·ContentText 재파생), `ReSanitizeAllContent_IncludesArchivedAndSoftDeletedNotes`(아카이브/휴지통 포함) 통과.
- 전체 테스트 227 통과 / 3 스킵(기존 PostgreSQL 전용).

## 범위 밖 준수
- `StripHtml`/트라이그램 검색 로직 미변경(동일 `StripHtml`로 일관성만 유지).
- Create/Update 경로의 기존 sanitize 로직 유지.
