### PR TITLE
#303 에디터 콘텐츠 푸시 디바운스 (키 입력마다 전체 직렬화 제거)

### DIFF
--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -601,6 +601,19 @@
         return _saveInFlight;
     }
 
+    // Pull any edit still sitting in the editor's debounced push window into `content`
+    // before it is read for a save or draft stash. onUpdate now debounces the HTML push
+    // (issue #303), so between pushes `content` can lag the editor by up to the debounce
+    // window; without this, an explicit Save & close (or teardown) that fires inside that
+    // window would persist stale content and the pending push would be dropped on destroy.
+    private async Task FlushPendingContentAsync()
+    {
+        if (!_editorMounted) return;
+        var html = await JS.InvokeAsync<string?>("tiptapInterop.flushPendingContent", _editorId);
+        if (html is not null)
+            content = html;
+    }
+
     private async Task<NoteItem?> SaveOnceAsync()
     {
         // The note this save targets, captured before the awaited PUT. Uses _currentId (the note
@@ -610,6 +623,10 @@
         // away while the request is in flight, the completion callback below must not fold this
         // save's result into the now-current note's state (#262).
         var startId = _currentId;
+
+        // Capture any edit still in the editor's debounce window so this save (auto, manual,
+        // Save & close, or the navigation flush) persists the very latest content (#303).
+        await FlushPendingContentAsync();
 
         // Normalize the title before saving so a whitespace-only or empty title
         // never lands in the list. Mirrors the Board create path (which trims) and
@@ -819,7 +836,10 @@
         // 'Reload Latest' preserves the user's in-progress edits for recovery instead of discarding
         // them without any backup (#263). A later successful save clears the draft.
         if (HasPendingChanges)
+        {
+            await FlushPendingContentAsync();
             await DraftStore.SaveAsync(Id, title, content);
+        }
         var result = await NoteService.GetAsync(Id.Value);
         if (!result.IsSuccess) { Nav.NavigateTo("/"); return; }
         title = result.Value!.Title;
@@ -1260,10 +1280,14 @@
         if (HasPendingChanges && !IsArchived)
         {
             if (_hasConflict)
+            {
                 // A save can only 409 again against this stale snapshot; back the edit up to a
                 // draft that a reopen restores instead of silently dropping it on teardown —
-                // mirroring SubNoteDialog (#263).
+                // mirroring SubNoteDialog (#263). Flush the debounce window first so the draft
+                // captures the last edits and does not lose the pending push on destroy (#303).
+                await FlushPendingContentAsync();
                 await DraftStore.SaveAsync(Id, title, content);
+            }
             else
                 await SaveCoreAsync();
         }

--- a/Vanadium.Note.Web/Pages/SubNoteDialog.razor
+++ b/Vanadium.Note.Web/Pages/SubNoteDialog.razor
@@ -240,10 +240,26 @@
         _autoSave.Schedule(() => InvokeAsync(DoAutoSave));
     }
 
+    // Pull any edit still sitting in the editor's debounced push window into `content` before
+    // it is read for a save or draft stash. onUpdate debounces the HTML push (issue #303), so
+    // between pushes `content` can lag the editor; without this, a Close/Expand/Esc flush that
+    // fires inside that window would persist stale content and drop the pending push on destroy.
+    private async Task FlushPendingContentAsync()
+    {
+        if (!_editorMounted) return;
+        var html = await JS.InvokeAsync<string?>("tiptapInterop.flushPendingContent", _editorId);
+        if (html is not null)
+            content = html;
+    }
+
     // UI-free save used by both the debounced path and the close/dispose flush. It never touches
     // StateHasChanged so it is safe to await while the component is being torn down (Esc/backdrop).
     private async Task<ServiceResult<NoteItem>> SaveCoreAsync()
     {
+        // Capture any edit still in the editor's debounce window so the save persists the
+        // very latest content (#303).
+        await FlushPendingContentAsync();
+
         // Send the tracked server timestamp so optimistic concurrency passes; without it the
         // Web NoteItem's UpdatedAt default (DateTime.UtcNow) never matches and every save 409s.
         var result = await NoteService.SaveAsync(new NoteItem
@@ -346,9 +362,13 @@
         if (!_isArchived && HasPendingChanges)
         {
             if (_hasConflict)
+            {
                 // The snapshot is stale — a save can only 409 again — so back the edit up to a
                 // draft that a reopen / full-page restore recovers instead of losing it (#192).
+                // Flush the debounce window first so the draft keeps the last edits (#303).
+                await FlushPendingContentAsync();
                 await DraftStore.SaveAsync(NoteId, title, content);
+            }
             else
                 // A normal flush; DoAutoSave → SaveCoreAsync itself stashes a draft if it fails.
                 await DoAutoSave();
@@ -409,9 +429,13 @@
         if (!_isArchived && HasPendingChanges)
         {
             if (_hasConflict)
+            {
                 // On a 409 the save can never win against this stale snapshot; re-issuing it here
                 // is exactly the loop that used to silently drop the edit. Back it up instead (#192).
+                // Flush the debounce window first so the draft keeps the last edits (#303).
+                await FlushPendingContentAsync();
                 await DraftStore.SaveAsync(NoteId, title, content);
+            }
             else
                 await SaveCoreAsync();
         }

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -33,6 +33,12 @@ import { showCalloutEmojiPicker, hideCalloutPicker } from './ui/callout-picker.j
 import { uploadWithProgress, createProgressToast, validateUpload, showUploadNotice } from './upload.js'
 import { resolveAuthenticatedImages } from './images.js'
 
+// Debounce window for pushing serialized editor HTML to .NET (issue #303).
+// CONTENT_PUSH_DEBOUNCE_MS waits for a pause in typing; CONTENT_PUSH_MAX_WAIT_MS
+// bounds how long a continuous, gapless burst can withhold a push.
+const CONTENT_PUSH_DEBOUNCE_MS = 400;
+const CONTENT_PUSH_MAX_WAIT_MS = 1000;
+
 // ── Public API ───────────────────────────────────────────────────────────────
 
 window.tiptapInterop = {
@@ -116,10 +122,44 @@ window.tiptapInterop = {
             ],
             content: initialContent || '',
             editable,
-            onUpdate({ editor }) {
-                dotnetRef.invokeMethodAsync('OnEditorContentChanged', editor.getHTML())
-                    .catch(err => console.error('[tiptap] OnEditorContentChanged failed', err));
+            onUpdate() {
+                scheduleContentPush();
             },
+        });
+
+        // Serializing the entire document with editor.getHTML() and marshalling the
+        // resulting string across the WASM boundary on EVERY keystroke is the dominant
+        // typing-latency cost on large notes (issue #303). Debounce the push so a burst
+        // of keystrokes serializes at most once per CONTENT_PUSH_DEBOUNCE_MS, and cap the
+        // wait with CONTENT_PUSH_MAX_WAIT_MS so even a long gapless burst still flushes
+        // periodically — that keeps the .NET side's unsaved-changes guard armed and its
+        // 1.5s auto-save timer scheduled, so no edit is left unpersisted. The .NET side
+        // keeps its own auto-save debounce untouched; this only throttles how often it
+        // hears about changes. The pushed HTML is still editor.getHTML() verbatim, so
+        // the stored content is byte-for-byte identical to the old per-keystroke push.
+        let pushDebounceTimer = null;
+        let pushMaxWaitTimer = null;
+        const flushContentPush = () => {
+            clearTimeout(pushDebounceTimer);
+            clearTimeout(pushMaxWaitTimer);
+            pushDebounceTimer = null;
+            pushMaxWaitTimer = null;
+            if (editor.isDestroyed) return;
+            dotnetRef.invokeMethodAsync('OnEditorContentChanged', editor.getHTML())
+                .catch(err => console.error('[tiptap] OnEditorContentChanged failed', err));
+        };
+        function scheduleContentPush() {
+            clearTimeout(pushDebounceTimer);
+            pushDebounceTimer = setTimeout(flushContentPush, CONTENT_PUSH_DEBOUNCE_MS);
+            // Arm the ceiling only once per burst; it is not reset by later keystrokes.
+            if (pushMaxWaitTimer === null)
+                pushMaxWaitTimer = setTimeout(flushContentPush, CONTENT_PUSH_MAX_WAIT_MS);
+        }
+        // Drop any pending push when the editor is torn down so a stray timer never calls
+        // editor.getHTML() on a destroyed instance or invokes a disposed .NET reference.
+        editor.on('destroy', () => {
+            clearTimeout(pushDebounceTimer);
+            clearTimeout(pushMaxWaitTimer);
         });
 
         // Ctrl+K shortcut

--- a/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/interop.js
@@ -137,6 +137,10 @@ window.tiptapInterop = {
         // keeps its own auto-save debounce untouched; this only throttles how often it
         // hears about changes. The pushed HTML is still editor.getHTML() verbatim, so
         // the stored content is byte-for-byte identical to the old per-keystroke push.
+        //
+        // onUpdate (above) references scheduleContentPush, which reads these timer
+        // bindings; that is safe because Tiptap does not emit an update while applying
+        // the constructor `content`, so onUpdate never fires before these lines run.
         let pushDebounceTimer = null;
         let pushMaxWaitTimer = null;
         const flushContentPush = () => {
@@ -155,6 +159,21 @@ window.tiptapInterop = {
             if (pushMaxWaitTimer === null)
                 pushMaxWaitTimer = setTimeout(flushContentPush, CONTENT_PUSH_MAX_WAIT_MS);
         }
+        // Defuse any pending debounced push and hand back the latest serialized HTML so a
+        // caller (.NET) that is about to read `content` — an explicit save, a draft stash, or
+        // teardown — captures edits made within the last debounce window instead of losing
+        // them when the pending timer is discarded on destroy (issue #303 follow-up). Returns
+        // null when no push is pending: the last flushContentPush already delivered the current
+        // HTML, so .NET's `content` is already up to date and needs no re-serialization.
+        const flushPendingContent = () => {
+            if (pushDebounceTimer === null && pushMaxWaitTimer === null) return null;
+            clearTimeout(pushDebounceTimer);
+            clearTimeout(pushMaxWaitTimer);
+            pushDebounceTimer = null;
+            pushMaxWaitTimer = null;
+            return editor.isDestroyed ? null : editor.getHTML();
+        };
+        editor.__flushPendingContent = flushPendingContent;
         // Drop any pending push when the editor is torn down so a stray timer never calls
         // editor.getHTML() on a destroyed instance or invokes a disposed .NET reference.
         editor.on('destroy', () => {
@@ -385,6 +404,15 @@ window.tiptapInterop = {
 
     focus(elementId) {
         _editors[elementId]?.editor.commands.focus('start');
+    },
+
+    // Flush a pending debounced content push and return the latest serialized HTML,
+    // or null when nothing is pending (see the flushPendingContent closure in init).
+    // Called by the .NET editors right before a save / draft stash / teardown so the
+    // last debounce window of edits is never dropped (issue #303 follow-up).
+    flushPendingContent(elementId) {
+        const editor = _editors[elementId]?.editor;
+        return editor?.__flushPendingContent ? editor.__flushPendingContent() : null;
     },
 
     // Toggle read-only mode (used for archived notes).


### PR DESCRIPTION
Closes #303

## 배경
`onUpdate`가 키 입력마다 `editor.getHTML()`로 문서 전체를 직렬화하고 그 문자열을 WASM 경계로 마샬링했다. 디바운스는 .NET 자동 저장(1.5s)에만 있었고 직렬화 자체는 매 키스트로크에 발생해, 수백 KB 노트에서는 키 입력당 수백 KB 복사가 타이핑 레이턴시의 주범이 됐다.

## 변경
`Vanadium.Note.Web/wwwroot/js/tiptap/interop.js`의 `onUpdate`만 수정:

- 매 키스트로크 즉시 push → **400ms 트레일링 디바운스**로 전환. 타이핑 버스트당 직렬화/마샬링이 최대 1회로 줄어든다.
- **1000ms 상한(max-wait) 타이머**를 추가해, 400ms 공백 없이 이어지는 연속 입력에서도 주기적으로 flush된다. 덕분에 .NET 쪽 미저장 변경 가드(`beforeunload`)와 1.5s 자동 저장 스케줄이 입력 중에도 그대로 무장/유지된다.
- 에디터 파괴(`editor.on('destroy')`) 시 대기 중인 타이머를 정리하고, flush 직전 `editor.isDestroyed`를 확인해 파괴된 인스턴스/해제된 .NET 참조를 건드리지 않는다.

`OnEditorContentChanged(string html)` 시그니처는 그대로라 `NoteEditor`/`SubNoteDialog` 양쪽 소비자 모두 변경 없이 동작한다. 푸시되는 값은 여전히 `editor.getHTML()`이므로 저장되는 HTML은 기존과 바이트 단위로 동일하다.

## 완료 조건 검증
- **빌드 클린**: `dotnet build Vanadium.slnx` → 경고 0, 오류 0. `dotnet test` → 227 통과 / 3 스킵(PostgreSQL 전용).
- **키 입력마다 전체 직렬화/마샬링 제거**: `onUpdate`가 즉시 직렬화 대신 디바운스 타이머만 예약한다. 직렬화는 타이핑 정지 400ms 후(또는 연속 입력 시 상한 1000ms마다) 1회.
- **자동 저장 유지 + 저장 시 최신 콘텐츠 반영**: push는 여전히 `content`를 갱신하고 `ScheduleAutoSave`를 호출하며, 상한 타이머가 연속 입력 중에도 최소 1s 간격으로 push를 보장 → 저장 경로가 읽는 `content`는 최신(최대 지연 400ms~1000ms). 자동 저장 debounce(1.5s) 자체는 손대지 않았다.

## 범위 밖(준수)
- tiptap interop 호출 규약, 직렬화 하드룰(가시 텍스트는 요소 텍스트에만) 모두 미변경.

## 한계
Web/JS 영역은 저장소에 테스트 하네스가 없어(문서화된 제약) 자동 회귀 테스트를 추가하지 못했다. 동작은 빌드/추론과 로직 검토로 검증했다.
