### PR TITLE
#304 고아 스캔 N+1 제거 — 참조 GUID 집합 1회 추출로 역전

### DIFF
--- a/Vanadium.Note.REST.Tests/FileCleanupReferenceScanTests.cs
+++ b/Vanadium.Note.REST.Tests/FileCleanupReferenceScanTests.cs
@@ -97,4 +97,31 @@ public class FileCleanupReferenceScanTests
         Assert.Null(await h.Db.FileAttachments.FindAsync(attachment.Id));
         Assert.False(File.Exists(PhysicalPath(h, attachment.Id)));
     }
+
+    /// <summary>
+    /// Issue #304: after replacing the per-file <c>ILIKE '%guid%'</c> probe with a single
+    /// referenced-GUID set built from note content, one scan must still keep every referenced
+    /// attachment while removing only the unreferenced one — partitioning by set membership,
+    /// not by per-file query.
+    /// </summary>
+    [Fact]
+    public async Task OrphanScan_MixedReferences_KeepsReferencedRemovesOrphanInSameScan()
+    {
+        using var h = new TestHost();
+        var referenced   = await AddAttachmentAsync(h, DateTime.UtcNow - BeyondGrace);
+        var unreferenced = await AddAttachmentAsync(h, DateTime.UtcNow - BeyondGrace);
+
+        await AddNoteAsync(
+            h, $"<p><a href=\"/api/files/{referenced.Id}\">spec.pdf</a></p>");
+
+        // The orphan must already have been observed unreferenced beyond the grace window.
+        h.OrphanTracker.ObserveUnreferenced(unreferenced.Id, DateTime.UtcNow - BeyondGrace);
+
+        await h.FileCleanup.DeleteAllOrphansAsync();
+
+        Assert.NotNull(await h.Db.FileAttachments.FindAsync(referenced.Id));
+        Assert.True(File.Exists(PhysicalPath(h, referenced.Id)));
+        Assert.Null(await h.Db.FileAttachments.FindAsync(unreferenced.Id));
+        Assert.False(File.Exists(PhysicalPath(h, unreferenced.Id)));
+    }
 }

--- a/Vanadium.Note.REST/Services/FileCleanupService.cs
+++ b/Vanadium.Note.REST/Services/FileCleanupService.cs
@@ -80,6 +80,12 @@ public class FileCleanupService(
         // GUIDs still present this scan, so the tracker can prune vanished assets afterwards.
         var liveIds = new HashSet<Guid>();
 
+        // Build the set of GUIDs referenced by any note ONCE, in a single streamed pass over
+        // note content, instead of running a per-file ILIKE '%guid%' probe (the old N+1: one
+        // query per attachment/image, thousands of low-selectivity trigram scans on a large
+        // corpus). Orphans are then decided by set membership below (issue #304).
+        var (referencedFileIds, referencedImageIds) = await GetReferencedIdsAsync(ct);
+
         // --- File attachments (have DB records) ---
         var attachments = await db.FileAttachments.ToListAsync(ct);
 
@@ -93,7 +99,7 @@ public class FileCleanupService(
         {
             liveIds.Add(attachment.Id);
 
-            if (await IsReferencedInAnyNoteAsync(attachment.Id, ct))
+            if (referencedFileIds.Contains(attachment.Id))
             {
                 // Referenced again — reset any accumulated unreferenced grace.
                 tracker.Forget(attachment.Id);
@@ -146,7 +152,7 @@ public class FileCleanupService(
 
             liveIds.Add(imageId);
 
-            if (await IsReferencedInAnyNoteAsync(imageId, ct))
+            if (referencedImageIds.Contains(imageId))
             {
                 tracker.Forget(imageId);
                 continue;
@@ -179,6 +185,48 @@ public class FileCleanupService(
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Extracts, in a single streamed pass over note content, the set of file-attachment and
+    /// image GUIDs referenced by any note. This replaces the periodic scan's per-file
+    /// <c>ILIKE '%guid%'</c> probe (issue #304): reference detection now costs one content scan
+    /// regardless of how many files are on disk, and reuses the same <c>/api/files/{guid}</c> /
+    /// <c>/api/images/{guid}</c> patterns as the on-delete path (<see cref="ExtractIds"/>).
+    /// <para>
+    /// Content is streamed (not materialized as a list) so the whole note corpus is never held
+    /// in memory at once — only one note's HTML plus the accumulated GUID sets.
+    /// </para>
+    /// <para>
+    /// IgnoreQueryFilters: content of soft-deleted (recycle-bin) and archived notes still counts
+    /// as a live reference until the note is permanently deleted, so their assets are not
+    /// garbage-collected early.
+    /// </para>
+    /// </summary>
+    private async Task<(HashSet<Guid> Files, HashSet<Guid> Images)> GetReferencedIdsAsync(
+        CancellationToken ct)
+    {
+        var fileIds  = new HashSet<Guid>();
+        var imageIds = new HashSet<Guid>();
+
+        var contents = db.Notes
+                         .IgnoreQueryFilters()
+                         .Select(n => n.Content)
+                         .AsAsyncEnumerable();
+
+        await foreach (var content in contents.WithCancellation(ct))
+        {
+            if (string.IsNullOrEmpty(content))
+                continue;
+
+            foreach (Match m in FilePattern.Matches(content))
+                fileIds.Add(Guid.Parse(m.Groups[1].Value));
+
+            foreach (Match m in ImagePattern.Matches(content))
+                imageIds.Add(Guid.Parse(m.Groups[1].Value));
+        }
+
+        return (fileIds, imageIds);
+    }
 
     private async Task<int> DeleteFileAttachmentsAsync(
         IEnumerable<Guid> ids, CancellationToken ct)


### PR DESCRIPTION
Closes #304

## 목적
주기적 고아 스캔(`FileCleanupService.DeleteAllOrphansAsync`)이 첨부·이미지마다 개별 `ILIKE '%guid%'` 쿼리를 실행하던 N+1 GC를 제거한다. 파일 수천 개면 24h 잡이 수천 쿼리 + 저선택도 trigram 스캔이 되던 문제.

## 변경 내용
- **`GetReferencedIdsAsync`** 추가: 노트 콘텐츠를 **1회 스트리밍**하며 `/api/files/{guid}`·`/api/images/{guid}` 정규식(기존 온-딜리트 경로의 `ExtractIds`와 동일 패턴)으로 참조 GUID 집합(파일/이미지 분리)을 구성.
- `DeleteAllOrphansAsync`가 파일마다 `IsReferencedInAnyNoteAsync`(per-GUID `ILIKE`)를 호출하던 두 지점을 **집합 멤버십 조회**(`HashSet.Contains`)로 교체.
- 콘텐츠를 `ToList`가 아닌 `AsAsyncEnumerable`로 순회 → 전체 노트 코퍼스를 메모리에 적재하지 않고 노트당 HTML 1개 + GUID 집합만 유지.
- 온-딜리트 경로(`DeleteOrphanedFromContentAsync` → `DeleteFileAttachmentsAsync`/`DeleteImageFilesAsync`)는 삭제된 노트 1개의 소수 GUID만 다뤄 N+1 대상이 아니므로 기존 `IsReferencedInAnyNoteAsync`를 그대로 유지.

## 완료 조건 검증
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0.
- [x] **파일 수 무관 상수 회 스캔** — `GetReferencedIdsAsync`가 노트 콘텐츠를 단일 스트리밍 쿼리로 1회 순회해 참조 집합 구성. 파일/이미지 개수와 무관.
- [x] **`IgnoreQueryFilters()`로 소프트 삭제 노트 콘텐츠를 라이브 참조로 계산** — `GetReferencedIdsAsync`가 `db.Notes.IgnoreQueryFilters()`를 사용. 기존 회귀 테스트 `OrphanScan_AttachmentReferencedBySoftDeletedNote_IsKept` / `...ByArchivedNote_IsKept` 통과로 확인.
- [x] **참조 파일 유지, 미참조만 제거 (회귀 없음)** — 신규 테스트 `OrphanScan_MixedReferences_KeepsReferencedRemovesOrphanInSameScan` + 기존 11개 FileCleanup 테스트 통과. 전체 스위트 228 통과 / 3 스킵(PostgreSQL 전용).

## 범위
- URL 형식(`/api/files/{guid}`·`/api/images/{guid}`) 변경 없음 — 기존 정규식 패턴 재사용.
- 변경 파일 2개: `FileCleanupService.cs`, `FileCleanupReferenceScanTests.cs`.