### PR TITLE
#277 퀵 네비게이션 팔레트에 포커스 트랩 적용

### DIFF
--- a/Vanadium.Note.Web/Components/QuickNavDialog.razor
+++ b/Vanadium.Note.Web/Components/QuickNavDialog.razor
@@ -10,6 +10,7 @@
 {
     <div class="quicknav-backdrop" @onclick="Close">
         <div class="quicknav-panel"
+             @ref="_panel"
              role="dialog"
              aria-modal="true"
              aria-label="Quick note navigation"
@@ -110,6 +111,7 @@
     private record HighlightSegment(string Text, bool Match);
 
     private ElementReference _input;
+    private ElementReference _panel;
     private string _query = string.Empty;
     private int _selected;
     private string[] _terms = [];
@@ -125,7 +127,12 @@
         if (Open && !_wasOpen)
             await OnOpened();
         else if (!Open && _wasOpen)
+        {
             _searchCts?.Cancel();
+            // Release the focus trap and restore focus to the element that opened
+            // the palette. Covers every close path (Esc, backdrop, row open, parent toggle).
+            try { await JS.InvokeVoidAsync("focusTrap.deactivate"); } catch { /* JS may be gone */ }
+        }
         _wasOpen = Open;
     }
 
@@ -145,6 +152,9 @@
         if (_focusQueued)
         {
             _focusQueued = false;
+            // Activate the trap before moving focus, so it captures the pre-open active
+            // element as the restore target (mirrors the Board dialog pattern).
+            try { await JS.InvokeVoidAsync("focusTrap.activate", _panel); } catch { /* JS may be gone */ }
             try { await _input.FocusAsync(); } catch { /* element may be gone */ }
         }
         if (_scrollQueued)


### PR DESCRIPTION
Closes #277

## 목적

퀵 네비게이션 팔레트(`QuickNavDialog`)가 `aria-modal="true"`를 선언하면서도 실제 포커스 트랩을 적용하지 않아 Tab이 배경 페이지로 탈출했다. 이미 존재하는 `focus-trap.js` 인프라를 재사용해 선언과 동작을 일치시킨다.

## 변경

`Vanadium.Note.Web/Components/QuickNavDialog.razor` 한 파일:

- 패널 `div`에 `@ref="_panel"` 추가.
- 팔레트가 열릴 때(`OnAfterRenderAsync`의 `_focusQueued` 처리) 입력 포커스보다 **먼저** `focusTrap.activate(_panel)` 호출 — Board 다이얼로그와 동일한 순서로, 팔레트를 연 요소를 복귀 대상(`previouslyFocused`)으로 캡처하기 위함.
- 닫힘 전이(`OnParametersSetAsync`의 `!Open && _wasOpen`)에서 `focusTrap.deactivate()` 호출 — Esc/백드롭 클릭/행 선택/부모 토글 등 **모든** 닫힘 경로를 한 곳에서 일괄 처리.

기존 인프라(`focus-trap.js`)는 수정하지 않았고, 팔레트 내부 키 처리(Esc/화살표/Enter)도 그대로 유지(범위 밖 준수).

## 완료 조건 검증

- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0. `dotnet test` 228 통과 / 3 스킵(PostgreSQL 전용) / 0 실패.
- [x] **팔레트 열림 중 Tab/Shift+Tab 포커스가 다이얼로그 내부에 갇힘** — `focusTrap.activate`가 캡처 단계 `keydown` 리스너를 등록해 `_panel` 내부에서만 포커스를 순환시킴(Board 다이얼로그가 쓰는 검증된 인프라 그대로 재사용).
- [x] **닫힐 때 이전 포커스 요소로 복귀** — `activate`가 이동 전 `document.activeElement`(= 팔레트를 연 요소)를 저장하고, `deactivate`가 이를 복원.

> 참고: Web 프로젝트에는 테스트 하네스가 없고(브라우저 상호작용/JS interop), 포커스 트랩은 런타임 브라우저 동작이라 단위 테스트 대상이 아니다. 실제 Tab 순환/복귀는 브라우저에서 수동 확인이 필요하다.
