### PR TITLE
#270 검색/필터/페이지 변경 시 트리 확장 상태 보존

### DIFF
--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -383,8 +383,12 @@
             return;
         }
 
-        expandedNoteIds.Clear();
-        childrenCache.Clear();
+        // Preserve tree expansion across search/filter/page changes (issue #270): keep the
+        // expanded state and cached children for notes still reachable in the new result set,
+        // and drop entries for notes that dropped out. Reachability walks down from the new
+        // top-level notes through the retained cache, so a still-present branch keeps its
+        // nested expansions while a vanished note's whole subtree is pruned.
+        PruneStaleTreeState();
         // Record the freshly-loaded list so the next background poll can tell whether
         // anything actually changed before it re-renders.
         _lastListSignature = ComputeListSignature(notes, totalCount);
@@ -473,6 +477,30 @@
     // as well as sub-note count changes, so the poll skips a re-render when nothing moved.
     private static string ComputeListSignature(List<NoteSummary> items, int total)
         => total + "|" + string.Join(";", items.Select(n => $"{n.Id}:{n.UpdatedAt.Ticks}:{n.ChildCount}"));
+
+    // Drops expansion/cache entries for notes no longer reachable from the current top-level
+    // list, while keeping everything still present (issue #270). Reachability starts at the
+    // freshly-loaded top-level notes and descends through the existing childrenCache, so a
+    // branch that survives the reload retains its nested expansions and cached children, and a
+    // note that dropped out of the results has its whole subtree cleaned up.
+    private void PruneStaleTreeState()
+    {
+        var reachable = new HashSet<Guid>();
+        var queue = new Queue<Guid>(notes.Select(n => n.Id));
+        while (queue.Count > 0)
+        {
+            var id = queue.Dequeue();
+            if (!reachable.Add(id))
+                continue;
+            if (childrenCache.TryGetValue(id, out var children))
+                foreach (var child in children)
+                    queue.Enqueue(child.Id);
+        }
+
+        expandedNoteIds.RemoveWhere(id => !reachable.Contains(id));
+        foreach (var staleId in childrenCache.Keys.Where(id => !reachable.Contains(id)).ToList())
+            childrenCache.Remove(staleId);
+    }
 
     private async Task ToggleExpand(Guid noteId)
     {


### PR DESCRIPTION
Closes #270

## 목적
`LoadNotes` 공통 경로 말미에서 매번 `expandedNoteIds.Clear()` + `childrenCache.Clear()`를 호출해, 검색·필터·페이지 이동마다 트리 확장 상태가 전부 리셋되고 탐색 맥락을 잃던 문제를 해결한다.

## 변경 내용
- `Home.razor`의 무조건적 `Clear()` 두 줄을 `PruneStaleTreeState()` 도달성 기반 정리로 교체.
- 새로 로드된 최상위 `notes`에서 시작해 기존 `childrenCache`를 따라 BFS로 내려가며 도달 가능한 노트 ID 집합을 계산.
- 도달 가능한 노트는 확장 상태(`expandedNoteIds`)와 캐시된 자식(`childrenCache`)을 그대로 유지 — 살아남은 가지는 중첩 확장까지 보존.
- 결과에서 사라진 노트는 `expandedNoteIds`와 `childrenCache`에서 제거 — 하위 트리 전체가 정리됨.
- 서버측 페이징/검색 쿼리, `childrenCache` 데이터 소스, 트리 렌더링/자식 로드 구조는 건드리지 않음(범위 밖 준수). 변경 파일은 `Home.razor` 하나.

## 완료 조건 검증
- **빌드 클린**: 변경 프로젝트(`Vanadium.Note.Web`)를 대체 출력 경로로 빌드 → 경고 0, 오류 0. (솔루션 전체 빌드는 로컬에서 실행 중인 REST 앱/Visual Studio가 출력 파일을 잠가 복사 단계만 실패 — 컴파일 오류 아님.)
- **결과에 남은 노트의 확장 상태 유지**: 재로드 후에도 최상위 `notes`에 존재하는 노트는 도달 가능 → 확장/캐시 유지됨(도달성 로직으로 보장).
- **사라진 노트의 확장/캐시 정리**: 최상위 목록에서 빠진 노트는 도달 불가 → `expandedNoteIds`/`childrenCache`에서 제거됨.

## 테스트
Web 프로젝트는 전용 테스트 프로젝트가 없어(Blazor 컴포넌트) 자동화 단위 테스트를 추가하지 않았다. 본 변경은 프런트엔드 전용이라 REST 테스트(`NoteService` 대상)에는 영향이 없다. 검증은 클린 빌드 + 도달성 로직 검토로 수행.
