### PR TITLE
#362 다중 행 선택 후 엔터 시 splitBlock 예외 수정

### DIFF
--- a/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/toggle-keymap.js
+++ b/Vanadium.Note.Web/wwwroot/js/tiptap/extensions/toggle-keymap.js
@@ -38,7 +38,26 @@ export const ToggleKeymap = Extension.create({
             'Enter': ({ editor }) => {
                 const { state, view } = editor;
                 const { $from, empty } = state.selection;
-                if (!empty) return false;
+
+                // Non-empty TEXT selections are handled with an explicit
+                // delete-then-split instead of being punted to StarterKit's
+                // splitBlock. That command evaluates canSplit against the
+                // PRE-deletion document but runs tr.split against the
+                // POST-deletion one, so a selection spanning a block boundary
+                // (e.g. Shift+Up from a lower row into the row above, #362)
+                // makes the two disagree and tr.split throws "Inserted content
+                // deeper than insertion position". Collapsing the selection
+                // first makes canSplit and split see the same doc. We return
+                // true unconditionally so the crashing default never runs as a
+                // fallback. NodeSelection (and any non-text selection) keeps the
+                // default path — its splitBlock branch splits without a prior
+                // deleteSelection, so it never hits the mismatch — and the
+                // caret-only toggle/heading handling below is unaffected.
+                if (!empty) {
+                    if (!(state.selection instanceof TextSelection)) return false;
+                    editor.chain().deleteSelection().splitBlock().run();
+                    return true;
+                }
 
                 // On a FOLDED collapsible heading, Enter expands the section
                 // instead of splitting into the hidden range below it.


### PR DESCRIPTION
## 개요
Closes #362

여러 행에 걸친 텍스트 선택 상태에서 엔터를 누르면 `TransformError: Inserted content deeper than insertion position` 예외가 발생하던 문제를 수정한다.

## 원인
Tiptap(`@tiptap/core@2.27.2`)의 `splitBlock` 커맨드는 분할 가능 여부(`canSplit`)를 **삭제 이전 문서** 기준으로 계산하지만, 실제 `tr.split`은 `tr.deleteSelection()` 이후의 **삭제된 문서**에 대해 실행한다. 선택 영역이 블록 경계를 넘어갈 때(예: 아래 행에서 Shift+↑로 윗 행까지 선택) 두 판단이 어긋나면서 `tr.split`이 예외를 던진다. 이 불일치는 `TextSelection` 경로에서만 발생하며, `NodeSelection` 경로는 사전 삭제 없이 분할하므로 영향이 없다.

## 변경 사항
- `wwwroot/js/tiptap/extensions/toggle-keymap.js`의 `ToggleKeymap` Enter 핸들러(우선순위 1000, Enter 최우선 처리)에서 **비어있지 않은 `TextSelection`**을 `deleteSelection().splitBlock()` 순서로 처리하도록 변경. 선택을 먼저 접어 `canSplit`과 `split`이 동일한 문서를 보게 하여 예외를 제거한다.
- `NodeSelection` 등 텍스트가 아닌 선택은 기존 기본 경로를 그대로 사용(`return false`)하여 노드 선택 시 Enter 동작을 회귀시키지 않는다.
- 크래시가 나던 기본 경로가 폴백으로 실행되지 않도록 텍스트 선택 처리 시 `true`를 반환한다.
- 커서 전용(빈 선택) 토글/헤딩/아코디언 Enter 처리는 모두 `empty` 선택에서만 동작하므로 이번 변경의 영향을 받지 않는다.

## 완료 조건 검증
- [x] **현재 행 + 윗 행 선택 후 엔터 시 `TransformError` 미발생** — 예외의 근본 원인인 `canSplit`/`split` 문서 불일치를, 선택을 먼저 삭제(collapse)하여 제거.
- [x] **다중 행 선택 + 엔터 시 선택 내용 삭제 후 정상 분할** — `deleteSelection().splitBlock()`이 선택 삭제 + 새 블록 분할을 수행(일반 에디터 Enter 동작과 동일).
- [x] **접이식 노드(toggle/collapsible heading/accordion) 경계 포함 다중 행 선택 + 엔터 예외 없음** — `deleteSelection`은 안전한 replace 기반이라 split-depth 불일치가 없고, 이후 선택 가드/아코디언 `appendTransaction` 플러그인이 상태를 정리한다.
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0/오류 0, `dotnet test` 228 통과(3 SKIP는 PostgreSQL 전용).

## 검증 방법 및 한계
- `dotnet build Vanadium.slnx` / `dotnet test Vanadium.slnx` 로컬 통과.
- 본 변경은 Tiptap 에디터 JS 전용이며 저장소에 해당 JS를 커버하는 테스트 프로젝트(Web 프로젝트 무테스트, REST 테스트는 `NoteService` 로직만)가 없어 자동 회귀 테스트를 추가하지 못했다. 편집기 동작은 브라우저에서 수동 확인이 필요하다(재현 절차: 아래 행에서 Shift+↑로 윗 행까지 선택 → 엔터).

## 범위 준수
- 벤더링 라이브러리 미수정(해당 라이브러리는 `esm.sh` CDN 로드로 저장소에 소스가 없음).
- interop 규약 변경 없음(interop 호출 추가/이동 없음).
