### PR TITLE
#305 조상/자손 순회를 재귀 CTE로 단일화

### DIFF
--- a/Vanadium.Note.REST.Tests/RecursiveTraversalTests.cs
+++ b/Vanadium.Note.REST.Tests/RecursiveTraversalTests.cs
@@ -1,0 +1,115 @@
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression tests for issue #305: ancestor (<see cref="Vanadium.Note.REST.Services.NoteService.HasCircularReference"/>)
+/// and descendant traversal were converted from per-level BFS round trips to a single recursive CTE.
+/// These lock in that the CTE produces the same results as the old BFS across DEEP (multi-level) trees —
+/// the whole point of the change was collapsing the per-level loop, so single-level coverage is not enough.
+/// The CTE is standard SQL exercised here on the in-memory SQLite host; production runs the same SQL on PostgreSQL.
+/// </summary>
+public class RecursiveTraversalTests
+{
+    /// <summary>Builds a linear chain root → n1 → n2 → … of the given depth and returns every node, root first.</summary>
+    private static async Task<List<NoteItem>> CreateChainAsync(TestHost h, int depth)
+    {
+        var chain = new List<NoteItem> { await h.CreateNoteAsync("root") };
+        for (var i = 1; i < depth; i++)
+            chain.Add(await h.CreateNoteAsync($"n{i}", chain[^1].Id));
+        return chain;
+    }
+
+    // ── HasCircularReference over a multi-level ancestor chain ────────────────
+
+    [Fact]
+    public async Task HasCircularReference_ProposedParentIsDeepDescendant_DetectsCycle()
+    {
+        using var h = new TestHost();
+        var chain = await CreateChainAsync(h, 5); // root, n1, n2, n3, n4
+
+        // Reparenting root under its own deep descendant n4 would close a cycle:
+        // the ancestor chain of n4 (n4→n3→n2→n1→root) contains root.
+        Assert.True(await h.Notes.HasCircularReference(chain[0].Id, chain[4].Id));
+    }
+
+    [Fact]
+    public async Task HasCircularReference_UnrelatedProposedParent_NoCycle()
+    {
+        using var h = new TestHost();
+        var chain = await CreateChainAsync(h, 5);
+
+        // Reparenting the deep leaf n4 under root is a normal move — root has no ancestors,
+        // so n4 never appears above it.
+        Assert.False(await h.Notes.HasCircularReference(chain[4].Id, chain[0].Id));
+    }
+
+    [Fact]
+    public async Task HasCircularReference_SelfParent_IsCycle()
+    {
+        using var h = new TestHost();
+        var root = await h.CreateNoteAsync("root");
+        Assert.True(await h.Notes.HasCircularReference(root.Id, root.Id));
+    }
+
+    [Fact]
+    public async Task HasCircularReference_StopsAtSoftDeletedAncestor()
+    {
+        using var h = new TestHost();
+        var chain = await CreateChainAsync(h, 4); // root, n1, n2
+        // Soft-delete the middle link n1. The old BFS walked db.Notes (global filter), so it
+        // stopped at a soft-deleted ancestor; the CTE follows only non-deleted notes to match.
+        Assert.True(await h.Notes.Delete(chain[1].Id));
+
+        // Ancestors of n2 above the deleted n1 (i.e. root) are no longer reachable, so no cycle
+        // is reported even though root is structurally above n2.
+        Assert.False(await h.Notes.HasCircularReference(chain[0].Id, chain[2].Id));
+    }
+
+    // ── Descendant sweep over a deep chain (CollectActiveDescendants) ─────────
+
+    [Fact]
+    public async Task Delete_SoftDeletesEntireDeepSubtree()
+    {
+        using var h = new TestHost();
+        var chain = await CreateChainAsync(h, 6); // 6 levels
+
+        Assert.True(await h.Notes.Delete(chain[0].Id));
+
+        // Every level, not just the first, is swept into the recycle bin.
+        foreach (var node in chain)
+        {
+            var reloaded = await h.FindAsync(node.Id);
+            Assert.NotNull(reloaded!.DeletedAt);
+        }
+    }
+
+    // ── Archive group descent stops at an independently-archived subtree ──────
+
+    [Fact]
+    public async Task Unarchive_DeepGroup_DoesNotSweepIndependentlyArchivedSubtree()
+    {
+        using var h = new TestHost();
+        // root → a → b → c (deep chain)
+        var chain = await CreateChainAsync(h, 4);
+
+        // Archive the lower subtree (b) on its own first — it gets its own archive group.
+        Assert.True(await h.Notes.Archive(chain[2].Id));
+        var bGroupBefore = (await h.FindAsync(chain[2].Id))!.ArchiveGroupId;
+
+        // Now archive the root. Its sweep only touches still-active descendants (a),
+        // leaving b/c in their independent group.
+        Assert.True(await h.Notes.Archive(chain[0].Id));
+
+        // Unarchiving root restores only the root group (root, a). The same-group CTE filter
+        // must NOT descend into b/c, so they stay archived under their original group.
+        Assert.True(await h.Notes.Unarchive(chain[0].Id));
+
+        Assert.Null((await h.FindAsync(chain[0].Id))!.ArchivedAt); // root restored
+        Assert.Null((await h.FindAsync(chain[1].Id))!.ArchivedAt); // a restored
+        Assert.NotNull((await h.FindAsync(chain[2].Id))!.ArchivedAt); // b still archived
+        Assert.NotNull((await h.FindAsync(chain[3].Id))!.ArchivedAt); // c still archived
+        Assert.Equal(bGroupBefore, (await h.FindAsync(chain[2].Id))!.ArchiveGroupId);
+    }
+}

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -595,17 +595,34 @@ public class NoteService(
     /// </summary>
     public async Task<bool> HasCircularReference(Guid noteId, Guid proposedParentId, CancellationToken ct = default)
     {
-        const int maxDepth = 100;
-        var current = (Guid?)proposedParentId;
-        for (var depth = 0; current.HasValue && depth < maxDepth; depth++)
-        {
-            if (current.Value == noteId) return true;
-            current = await db.Notes
-                .Where(n => n.Id == current.Value)
-                .Select(n => n.ParentNoteId)
-                .FirstOrDefaultAsync(ct);
-        }
-        return false;
+        // A note can never be reparented under itself. This also mirrors the old BFS, which
+        // evaluated this equality before issuing any (filtered) DB lookup for the parent.
+        if (proposedParentId == noteId) return true;
+
+        // Walk the ancestor chain upward from the proposed parent in a single recursive CTE
+        // instead of one DB round trip per level (issue #305). A cycle exists when noteId turns
+        // up anywhere above the proposed parent. Traversal follows only non-deleted notes, exactly
+        // mirroring the former db.Notes (global-filter) BFS which stopped at a soft-deleted ancestor.
+        // The Depth < 100 guard preserves the old maxDepth cap so a pre-existing cyclic parent chain
+        // can never loop forever. Standard SQL that runs on PostgreSQL (production) and SQLite (tests).
+        const string sql = """
+            WITH RECURSIVE "ancestors" AS (
+                SELECT n."Id", n."ParentNoteId", 1 AS "Depth"
+                FROM "Notes" n
+                WHERE n."Id" = {0} AND n."DeletedAt" IS NULL
+                UNION ALL
+                SELECT n."Id", n."ParentNoteId", a."Depth" + 1
+                FROM "Notes" n
+                INNER JOIN "ancestors" a ON n."Id" = a."ParentNoteId"
+                WHERE a."Depth" < 100 AND n."DeletedAt" IS NULL
+            )
+            SELECT 1 AS "Value" FROM "ancestors" a WHERE a."Id" = {1} LIMIT 1
+            """;
+
+        var matches = await db.Database
+            .SqlQueryRaw<int>(sql, proposedParentId, noteId)
+            .ToListAsync(ct);
+        return matches.Count > 0;
     }
 
     public async Task<List<MentionSuggestionDto>> SearchForMention(string query, int limit = 10, CancellationToken ct = default)
@@ -1105,44 +1122,57 @@ public class NoteService(
             note.Id, subtree.Count);
     }
 
-    /// <summary>BFS over active descendants only (global filter applies).</summary>
+    /// <summary>All active descendants only (soft-deleted notes excluded, and descent stops at them).</summary>
     private async Task<List<NoteItem>> CollectActiveDescendantsAsync(Guid rootId, CancellationToken ct = default)
-        => await CollectDescendantsAsync(rootId, db.Notes, ct);
+        => await CollectDescendantsAsync(rootId, """ AND n."DeletedAt" IS NULL""", [rootId], ct);
 
-    /// <summary>BFS over all descendants regardless of recycle bin state.</summary>
+    /// <summary>All descendants regardless of recycle bin state.</summary>
     private async Task<List<NoteItem>> CollectDescendantsUnfilteredAsync(Guid rootId, CancellationToken ct = default)
-        => await CollectDescendantsAsync(rootId, db.Notes.IgnoreQueryFilters(), ct);
+        => await CollectDescendantsAsync(rootId, "", [rootId], ct);
 
-    /// <summary>BFS over soft-deleted descendants sharing the given recycle-bin group id.</summary>
+    /// <summary>Soft-deleted descendants sharing the given recycle-bin group id.</summary>
     private async Task<List<NoteItem>> CollectDeletedGroupDescendantsAsync(Guid rootId, Guid groupId, CancellationToken ct = default)
-        => await CollectDescendantsAsync(
-            rootId,
-            db.Notes.IgnoreQueryFilters().Where(n => n.DeletionGroupId == groupId),
-            ct);
+        => await CollectDescendantsAsync(rootId, """ AND n."DeletionGroupId" = {1}""", [rootId, groupId], ct);
 
-    /// <summary>BFS over archived descendants sharing the given archive group id.
-    /// Descends only through same-group notes, so independently archived subtrees stay put.</summary>
+    /// <summary>Archived descendants sharing the given archive group id.
+    /// Descends only through same-group (and non-deleted, matching the old global filter) notes,
+    /// so independently archived subtrees stay put.</summary>
     private async Task<List<NoteItem>> CollectArchivedGroupDescendantsAsync(Guid rootId, Guid groupId, CancellationToken ct = default)
-        => await CollectDescendantsAsync(
-            rootId,
-            db.Notes.Where(n => n.ArchiveGroupId == groupId),
-            ct);
+        => await CollectDescendantsAsync(rootId, """ AND n."ArchiveGroupId" = {1} AND n."DeletedAt" IS NULL""", [rootId, groupId], ct);
 
-    private static async Task<List<NoteItem>> CollectDescendantsAsync(Guid rootId, IQueryable<NoteItem> source, CancellationToken ct = default)
+    /// <summary>
+    /// Collects every descendant of <paramref name="rootId"/> in a single recursive CTE, replacing
+    /// the former per-level BFS round trips (issue #305). <paramref name="nodeFilter"/> is an optional
+    /// SQL predicate on the note alias <c>n</c> (e.g. <c>AND n."DeletedAt" IS NULL</c>) applied to both
+    /// the anchor and every recursive step, exactly reproducing the per-level <c>Where</c> the BFS used —
+    /// so a filtered-out note halts descent through it rather than merely being dropped from the result.
+    /// Parameter <c>{0}</c> is always the root id; any extra parameters referenced as <c>{1}</c>, <c>{2}</c>…
+    /// inside <paramref name="nodeFilter"/> follow, in order, in <paramref name="parameters"/>. The
+    /// <c>Depth &lt; 100</c> guard preserves the old maxDepth cap against a cyclic parent chain. All
+    /// filtering is explicit in the CTE, so global query filters are bypassed; entities are tracked so
+    /// callers can mutate and save them exactly as before. Standard SQL: PostgreSQL (production) + SQLite (tests).
+    /// </summary>
+    private async Task<List<NoteItem>> CollectDescendantsAsync(
+        Guid rootId, string nodeFilter, object[] parameters, CancellationToken ct = default)
     {
-        const int maxDepth = 100;
-        var result = new List<NoteItem>();
-        var frontier = new List<Guid> { rootId };
-        for (var depth = 0; frontier.Count > 0 && depth < maxDepth; depth++)
-        {
-            var children = await source
-                .Where(n => n.ParentNoteId.HasValue && frontier.Contains(n.ParentNoteId.Value))
-                .ToListAsync(ct);
-            if (children.Count == 0) break;
-            result.AddRange(children);
-            frontier = children.Select(c => c.Id).ToList();
-        }
-        return result;
+        var sql = $$"""
+            WITH RECURSIVE "descendants" AS (
+                SELECT n."Id", n."ParentNoteId", 1 AS "Depth"
+                FROM "Notes" n
+                WHERE n."ParentNoteId" = {0}{{nodeFilter}}
+                UNION ALL
+                SELECT n."Id", n."ParentNoteId", d."Depth" + 1
+                FROM "Notes" n
+                INNER JOIN "descendants" d ON n."ParentNoteId" = d."Id"
+                WHERE d."Depth" < 100{{nodeFilter}}
+            )
+            SELECT * FROM "Notes" WHERE "Id" IN (SELECT "Id" FROM "descendants")
+            """;
+
+        return await db.Notes
+            .FromSqlRaw(sql, parameters)
+            .IgnoreQueryFilters()
+            .ToListAsync(ct);
     }
 
     private async Task StripMentionReferencesAsync(Guid noteId, CancellationToken ct = default)


### PR DESCRIPTION
Closes #305

## 개요
`HasCircularReference`의 조상 체인 순회와 `CollectDescendantsAsync`의 자손 수집 BFS가 각각 깊이(레벨)당 DB 왕복을 하던 것을 `WITH RECURSIVE` **단일 쿼리**로 전환한다. PostgreSQL(운영)과 SQLite(테스트) 양쪽에서 동작하는 표준 SQL을 사용해, 기존 SQLite 인메모리 테스트가 CTE 경로를 그대로 커버한다.

## 변경 내용
- **`HasCircularReference`** — `proposedParent`에서 조상 체인을 재귀 CTE로 거슬러 올라가 `noteId` 등장 여부만 확인. `proposedParent == noteId` 자기참조는 기존 BFS의 최초 루프 검사와 동일하게 선반환. 순회는 소프트 삭제되지 않은 노드만 따라가 기존 `db.Notes`(global filter) BFS가 삭제된 조상에서 멈추던 동작을 유지.
- **`CollectDescendantsAsync`** — `nodeFilter` SQL 조각을 앵커·재귀 양쪽에 동일 적용하도록 재작성. active / unfiltered / 삭제 그룹 / 아카이브 그룹 4개 호출 경로가 기존 레벨별 `Where` 조건을 그대로 재현(필터로 걸러진 노드에서 하강이 멈추는 것까지 동일). 결과 추적(tracked) 엔티티를 반환해 호출부의 변경·저장 로직은 그대로 동작.
- `Depth < 100` 가드로 기존 `maxDepth` 무한 루프 방지 의미 보존.

## 완료 조건 검증
- ✅ **빌드 클린** — `dotnet build Vanadium.slnx` 경고 0 / 오류 0
- ✅ **레벨당 왕복 없이 단일 쿼리** — 두 순회 모두 CTE 1회 실행
- ✅ **BFS와 결과 동일(회귀 없음)** — 전체 234개 테스트 통과. 다단계(6레벨) 트리 소프트삭제 스윕, 다단계 순환 감지, 삭제 조상에서의 순회 중단을 검증하는 회귀 테스트(`RecursiveTraversalTests`) 6건 추가
- ✅ **아카이브 same-group 제약 유지** — CTE가 `ArchiveGroupId = {group}`으로 하강, 독립 아카이브 서브트리를 스윕하지 않음을 `Unarchive_DeepGroup_DoesNotSweepIndependentlyArchivedSubtree`로 검증
- ✅ **maxDepth 100 가드 유지**

## 수동 검증 필요
- 재귀 CTE는 SQLite에서 자동 검증되지만, 운영 PostgreSQL에서의 실제 순환 참조 감지 / 아카이브·휴지통 그룹 자손 수집은 동일 표준 SQL이므로 회귀 위험은 낮으나 필요 시 Swagger로 확인 권장(CLAUDE.md 정책).