### PR TITLE
#306 정규식 콘텐츠 재작성을 AngleSharp DOM 조작으로 대체

### DIFF
--- a/Vanadium.Note.REST.Tests/ContentRewriteRobustnessTests.cs
+++ b/Vanadium.Note.REST.Tests/ContentRewriteRobustnessTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using Vanadium.Note.REST.Models;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Regression coverage for issue #306: note-content rewriting (mention title propagation, mention
+/// stripping, page-link title update) moved from <c>Regex.Replace</c> to AngleSharp DOM manipulation.
+/// A spec-compliant parser must rewrite references correctly regardless of attribute order or how
+/// deeply the reference is nested — the cases that made the regex approach fragile — while leaving the
+/// surrounding structure untouched. The <c>'$'</c> substitution-string class (issue #299) is combined
+/// in here too, since a DOM API cannot reintroduce it.
+/// </summary>
+public class ContentRewriteRobustnessTests
+{
+    /// <summary>Inserts an active note with exact content, bypassing the service sanitizer so the
+    /// reordered / nested reference markup under test reaches the rewrite path verbatim.</summary>
+    private static async Task<NoteItem> AddRawNoteAsync(TestHost h, string content)
+    {
+        var note = new NoteItem
+        {
+            Title = "Referencing",
+            Content = content,
+            ContentText = content,
+        };
+        h.Db.Notes.Add(note);
+        await h.Db.SaveChangesAsync();
+        return note;
+    }
+
+    [Fact]
+    public async Task TitlePropagation_RewritesReorderedAndNestedReferences_PreservesSurroundings()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Old Title");
+
+        // Attributes deliberately out of canonical order (data-title before data-note-id, data-type
+        // last) and the references buried inside blockquote > ul > li, next to sibling content that
+        // must survive the rewrite untouched.
+        var referrer = await AddRawNoteAsync(h,
+            "<blockquote><ul><li>See " +
+            $"<div class=\"page-link-block\" data-title=\"Old Title\" data-note-id=\"{target.Id}\" data-type=\"page-link\">📄 Old Title</div>" +
+            " and " +
+            $"<a class=\"note-mention\" data-title=\"Old Title\" data-note-id=\"{target.Id}\" data-type=\"note-mention\">@Old Title</a>" +
+            " here.</li></ul></blockquote>" +
+            "<p>Sibling paragraph that must survive.</p>");
+
+        // Rename to a title carrying substitution metacharacters ($&) that would have corrupted the
+        // regex replacement string.
+        const string newTitle = "New $& Title";
+        var (_, conflict, _) = await h.Notes.Update(target.Id,
+            new NoteItem { Title = newTitle, Content = target.Content, UpdatedAt = target.UpdatedAt });
+        Assert.False(conflict);
+
+        var fresh = await h.FindAsync(referrer.Id);
+        var encoded = WebUtility.HtmlEncode(newTitle); // "New $&amp; Title"
+
+        // Both references carry the new title verbatim, in the data-title attribute and visible text.
+        Assert.Contains($"data-title=\"{encoded}\"", fresh!.Content);
+        Assert.Contains($"📄 {encoded}</div>", fresh.Content);
+        Assert.Contains($"@{encoded}</a>", fresh.Content);
+        // The old title is gone everywhere, and the substitution metacharacters left no artifact.
+        Assert.DoesNotContain("Old Title", fresh.Content);
+        // Surrounding structure and sibling content are preserved.
+        Assert.Contains("<blockquote>", fresh.Content);
+        Assert.Contains("Sibling paragraph that must survive.", fresh.Content);
+    }
+
+    [Fact]
+    public async Task MentionStrip_UnwrapsNestedMention_KeepsTextAndSiblings()
+    {
+        using var h = new TestHost();
+        var target = await h.CreateNoteAsync("Target");
+
+        var referrer = await AddRawNoteAsync(h,
+            "<ul><li>Prefix " +
+            $"<a class=\"note-mention\" data-title=\"Target\" data-note-id=\"{target.Id}\" data-type=\"note-mention\">@Target</a>" +
+            " suffix</li></ul>");
+
+        // Soft-delete then permanently delete the target — this strips dead mention links.
+        Assert.True(await h.Notes.Delete(target.Id));
+        var (found, wasInBin) = await h.Notes.DeletePermanent(target.Id);
+        Assert.True(found);
+        Assert.True(wasInBin);
+
+        var fresh = await h.FindAsync(referrer.Id);
+        // The link wrapper is gone but its visible text and the surrounding text remain intact.
+        Assert.DoesNotContain($"data-note-id=\"{target.Id}\"", fresh!.Content);
+        Assert.Contains("Prefix @Target suffix", fresh.Content);
+    }
+}

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -1,5 +1,6 @@
-using System.Net;
 using System.Text.RegularExpressions;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
 using Microsoft.EntityFrameworkCore;
 using Vanadium.Note.REST.Data;
 using Vanadium.Note.REST.Models;
@@ -533,61 +534,71 @@ public class NoteService(
         return false;
     }
 
-    private static string UpdateMentionTitleInContent(string content, Guid noteId, string newTitle)
+    // Shared AngleSharp parser for note-content rewriting (issue #306). HtmlParser is stateless and
+    // safe to reuse across threads; each call parses into its own document, so no shared mutable state
+    // leaks between callers.
+    private static readonly HtmlParser ContentParser = new();
+
+    /// <summary>
+    /// Parses <paramref name="content"/> as a body-context HTML fragment, applies <paramref name="mutate"/>
+    /// to the parsed DOM, and returns the reserialized fragment — or the original string unchanged when
+    /// <paramref name="mutate"/> reports it edited nothing. This replaces the former <c>Regex.Replace</c>
+    /// content rewriting (issue #306): a spec-compliant parser sets attribute and text values through the
+    /// DOM API, so it is immune to the <c>'$'</c> substitution-string bug (issue #299) and to nesting or
+    /// attribute-order variations that silently broke the regexes. The user-visible title always lands in
+    /// element text content (never an attribute value), preserving the serialization hard rule, and callers
+    /// still derive <c>ContentText</c> via <c>StripHtml</c> on the result.
+    /// </summary>
+    private static string RewriteContent(string content, Func<IElement, bool> mutate)
     {
         if (string.IsNullOrEmpty(content)) return content;
-        var idStr = noteId.ToString();
-        var encodedTitle = WebUtility.HtmlEncode(newTitle);
-        // HtmlEncode leaves '$' untouched, and '$' is a substitution metacharacter in a
-        // Regex.Replace replacement string ($1, $&, ...). Escape it as '$$' for the inner
-        // attribute rewrite so a title like "Cost is $100" is inserted literally (issue #299).
-        // The MatchEvaluator return below is used verbatim, so it keeps the unescaped title.
-        var replacementTitle = encodedTitle.Replace("$", "$$");
+        var document = ContentParser.ParseDocument(string.Empty);
+        var body = document.Body!;
+        body.InnerHtml = content;
+        return mutate(body) ? body.InnerHtml : content;
+    }
 
-        return Regex.Replace(
-            content,
-            $@"(<a\s[^>]*data-note-id=""{Regex.Escape(idStr)}""[^>]*>)@[^<]*(</a>)",
-            m =>
+    private static string UpdateMentionTitleInContent(string content, Guid noteId, string newTitle) =>
+        RewriteContent(content, body =>
+        {
+            // Mentions are the only <a> elements carrying data-note-id; page-links are <div>.
+            var mentions = body.QuerySelectorAll($"a[data-note-id=\"{noteId}\"]");
+            if (mentions.Length == 0) return false;
+            foreach (var mention in mentions)
             {
-                var openTag = Regex.Replace(m.Groups[1].Value, @"data-title=""[^""]*""", $@"data-title=""{replacementTitle}""");
-                return $"{openTag}@{encodedTitle}{m.Groups[2].Value}";
-            },
-            RegexOptions.Singleline | RegexOptions.IgnoreCase);
-    }
+                mention.SetAttribute("data-title", newTitle);
+                mention.TextContent = "@" + newTitle;
+            }
+            return true;
+        });
 
-    private static string StripMentionLinksFromContent(string content, Guid noteId)
-    {
-        if (string.IsNullOrEmpty(content)) return content;
-        var idStr = noteId.ToString();
-        return Regex.Replace(
-            content,
-            $@"<a\s[^>]*data-note-id=""{Regex.Escape(idStr)}""[^>]*>(@[^<]*)</a>",
-            "$1",
-            RegexOptions.Singleline | RegexOptions.IgnoreCase);
-    }
-
-    private static string UpdatePageLinkTitleInContent(string content, Guid noteId, string newTitle)
-    {
-        if (string.IsNullOrEmpty(content)) return content;
-        var idStr = noteId.ToString();
-        var encodedTitle = WebUtility.HtmlEncode(newTitle);
-        // '$' survives HtmlEncode and is a substitution metacharacter in a Regex.Replace
-        // replacement string, so escape it as '$$' before both inner rewrites — otherwise a title
-        // like "Cost is $100" would corrupt the page-link markup (issue #299).
-        var replacementTitle = encodedTitle.Replace("$", "$$");
-
-        return Regex.Replace(
-            content,
-            $@"<div\s[^>]*data-note-id=""{Regex.Escape(idStr)}""[^>]*>.*?</div>",
-            m =>
+    private static string StripMentionLinksFromContent(string content, Guid noteId) =>
+        RewriteContent(content, body =>
+        {
+            var mentions = body.QuerySelectorAll($"a[data-note-id=\"{noteId}\"]");
+            if (mentions.Length == 0) return false;
+            foreach (var mention in mentions)
             {
-                var tag = m.Value;
-                tag = Regex.Replace(tag, @"data-title=""[^""]*""", $@"data-title=""{replacementTitle}""");
-                tag = Regex.Replace(tag, @">.*?</div>$", $">📄 {replacementTitle}</div>", RegexOptions.Singleline);
-                return tag;
-            },
-            RegexOptions.Singleline | RegexOptions.IgnoreCase);
-    }
+                // Unwrap the link: keep its visible text ("@Title"), drop the anchor wrapper.
+                var text = mention.Owner!.CreateTextNode(mention.TextContent);
+                mention.Parent!.ReplaceChild(text, mention);
+            }
+            return true;
+        });
+
+    private static string UpdatePageLinkTitleInContent(string content, Guid noteId, string newTitle) =>
+        RewriteContent(content, body =>
+        {
+            // Page-links are the only <div> elements carrying data-note-id.
+            var pageLinks = body.QuerySelectorAll($"div[data-note-id=\"{noteId}\"]");
+            if (pageLinks.Length == 0) return false;
+            foreach (var pageLink in pageLinks)
+            {
+                pageLink.SetAttribute("data-title", newTitle);
+                pageLink.TextContent = "📄 " + newTitle;
+            }
+            return true;
+        });
 
     /// <summary>
     /// Returns true if making <paramref name="proposedParentId"/> the parent of
@@ -1195,16 +1206,15 @@ public class NoteService(
             await db.SaveChangesAsync(ct);
     }
 
-    private static string RemovePageLinkFromContent(string content, Guid noteId)
-    {
-        if (string.IsNullOrEmpty(content)) return content;
-        var idStr = noteId.ToString();
-        return Regex.Replace(
-            content,
-            $@"<div\s[^>]*data-note-id=""{Regex.Escape(idStr)}""[^>]*>.*?</div>",
-            string.Empty,
-            RegexOptions.Singleline | RegexOptions.IgnoreCase);
-    }
+    private static string RemovePageLinkFromContent(string content, Guid noteId) =>
+        RewriteContent(content, body =>
+        {
+            var pageLinks = body.QuerySelectorAll($"div[data-note-id=\"{noteId}\"]");
+            if (pageLinks.Length == 0) return false;
+            foreach (var pageLink in pageLinks)
+                pageLink.Remove();
+            return true;
+        });
 
     private static IQueryable<NoteItem> ApplyFilters(
         IQueryable<NoteItem> query, string? search, Guid[]? labelIds)

--- a/Vanadium.Note.REST/Vanadium.Note.REST.csproj
+++ b/Vanadium.Note.REST/Vanadium.Note.REST.csproj
@@ -18,6 +18,11 @@
          AngleSharp alone against a 9.0.x HtmlSanitizer compiled for 0.17 is not runtime-safe
          (NU1608); upgrading the sanitizer keeps the AngleSharp graph vendor-coherent. -->
     <PackageReference Include="HtmlSanitizer" Version="9.1.966-beta" />
+    <!-- Explicit reference for parser-based note-content rewriting (issue #306): mention/page-link
+         title propagation and stripping use AngleSharp DOM manipulation instead of Regex.Replace.
+         Pinned to 1.5.2 — the same patched version HtmlSanitizer 9.1.x already resolves, so the
+         AngleSharp graph stays vendor-coherent and clear of the vulnerable < 1.5.0 line (GHSA-pgww-w46g-26qg). -->
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <!-- Pinned to patch GHSA-v5pm-xwqc-g5wc; Swashbuckle.AspNetCore 10.1.7 pulls in the vulnerable 2.4.1 transitively. -->
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />


### PR DESCRIPTION
Closes #306

## 배경
제목 전파·멘션 링크 strip·page-link 제거가 모두 `Regex.Replace` 기반이라 콘텐츠 무결성의 단일 실패점이었다. `$` 치환 메타문자 버그(#299)가 그 실례이며, 속성 순서·중첩 구조 변화에 취약하고 테스트도 어려웠다.

## 변경 사항
`NoteService`의 4개 정규식 재작성 메서드를 **AngleSharp DOM 조작**으로 전환 (이슈가 제시한 과도기적 파서 접근):

- `UpdateMentionTitleInContent` / `StripMentionLinksFromContent` / `UpdatePageLinkTitleInContent` / `RemovePageLinkFromContent`
- 공용 헬퍼 `RewriteContent(content, mutate)`: body 컨텍스트 프래그먼트로 파싱 → DOM 조작 → 재직렬화. 대상 요소가 없으면 원본 문자열을 그대로 반환해 호출부의 `updated == content` 단축 판정을 보존.
- 속성값·텍스트를 DOM API로 설정하므로 `$` 치환 메타문자 버그가 구조적으로 재현 불가.
- `AngleSharp` 1.5.2를 명시 참조 — HtmlSanitizer 9.1.x가 이미 해석하는 **패치 버전**이라 취약(<1.5.0) 라인을 피하고 그래프가 일관됨.

## 범위 결정: #141 참조 정규화 테이블은 별도
AC의 마이그레이션 항목은 "참조 정규화 테이블 도입 시"로 **조건부**다. #141 테이블 이행은 훨씬 큰 아키텍처 변경(별도 이슈)이므로, 최소 변경 원칙에 따라 이슈가 권장한 **과도기 AngleSharp 접근**만 구현한다. 스키마 변경·마이그레이션 없음.

## 완료 조건 확인
- [x] 빌드 클린 (`dotnet build Vanadium.slnx` — 경고 0)
- [–] EF Core 마이그레이션 — 참조 정규화 테이블을 도입하지 않으므로 해당 없음 (AC 조건부 항목)
- [x] 멘션 제목 전파/링크 strip/page-link 제목 갱신·제거가 `Regex.Replace`에 비의존 — 4개 메서드 모두 AngleSharp DOM으로 대체
- [x] 중첩 구조·속성 순서와 무관하게 정확 동작, `$` 치환류 버그 재현 불가 — `ContentRewriteRobustnessTests` 2건 신규 (속성 순서 뒤섞임·blockquote>ul>li 중첩·`$&` 결합), 기존 `TitleDollarEscapingTests`/`ReferenceCleanupRecycleBinTests` 그대로 통과

## 범위 밖 준수
- 방문자 텍스트는 요소 텍스트 콘텐츠에만 저장(`TextContent`), 속성엔 `data-title`만 — 직렬화 하드룰 유지
- `ContentText`는 기존대로 호출부에서 `StripHtml`로 파생 — 변경 없음
- AngleSharp 취약 버전 회피 (1.5.2)

## 검증
- `dotnet build Vanadium.slnx` → 경고 0, 오류 0
- `dotnet test Vanadium.slnx` → 236 통과 / 3 스킵(PostgreSQL 전용 trigram) / 0 실패