### PR TITLE
#293 익명 공유 페이지(/share/*)에 별도 엄격 CSP 적용

### DIFF
--- a/Vanadium.Note.Web/nginx.conf
+++ b/Vanadium.Note.Web/nginx.conf
@@ -22,6 +22,28 @@ server {
     # the anti-XSS guarantee above.
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: http:; font-src 'self' data:; connect-src 'self' https: http:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;
 
+    # Stricter, dedicated CSP for the anonymous share surface (issue #293).
+    # /share/{token} is served by the same Blazor WASM app, so it still needs the
+    # WASM runtime ('wasm-unsafe-eval') and the self-hosted editor modules from
+    # 'self' — script-src is therefore identical to the global policy. Two
+    # tightenings are safe here and matter specifically for anonymous viewers:
+    #   - img-src drops the broad https:/http: allowance so a shared note whose
+    #     (sanitized-but-still-permitted) HTML embeds an external <img> cannot
+    #     beacon the anonymous viewer's IP/User-Agent to a third-party host.
+    #     Embedded note images/attachments live on the authenticated API origin
+    #     an anonymous viewer cannot load anyway (Share.razor swaps them for
+    #     placeholders), so no legitimate image is lost.
+    #   - form-action is 'none': the read-only share page submits no forms.
+    # nginx does NOT inherit the server-level add_header into a location that
+    # defines its own add_header, so this block fully replaces the CSP above for
+    # /share/* (the only server-level header is that CSP), and the SPA fallback
+    # serves index.html for the client-side /share/{token} route.
+    location /share/ {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https: http:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'none'" always;
+    }
+
     location / {
         root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Closes #293

## 배경
이슈 #293은 두 가지를 요구했다.
1. 에디터 의존성 self-host 전환 + `script-src`를 `'self' 'wasm-unsafe-eval'`로 축소 (esm.sh/jsdelivr/`unsafe-eval` 제거)
2. 최소한 `/share/*`에 별도의 엄격한 CSP 적용

**1번은 이미 #307(PR #367, main 병합 완료)에서 처리되었다.** 현재 main의 `nginx.conf` 전역 CSP는 `script-src 'self' 'wasm-unsafe-eval'`로 외부 CDN 허용이 제거된 상태다. 이 PR은 **남은 2번(공유 페이지 전용 엄격 CSP)** 을 완성한다.

## 변경 내용
`Vanadium.Note.Web/nginx.conf`에 `location /share/` 블록을 추가하고 그 안에 전용 CSP를 설정했다.

`/share/{token}`은 동일한 Blazor WASM 앱으로 서빙되므로 WASM 런타임(`'wasm-unsafe-eval'`)과 self-host 에디터 모듈(`'self'`) 로드가 필요하다 → `script-src`는 전역 정책과 **동일**하게 유지한다. 익명 열람 표면에 한정해 안전하게 강화 가능한 두 항목만 조였다:

- **`img-src`에서 광범위한 `https:`/`http:` 허용 제거** (`'self' data: blob:`만 유지)
  새니타이저(Ganss.Xss)는 기본적으로 외부 `http(s)` `<img src>`를 통과시킨다. 따라서 공유 노트 HTML에 `<img src="https://attacker/pixel.png">`가 들어 있으면 익명 열람자의 브라우저가 이를 요청해 IP/User-Agent가 제3자 호스트로 유출되는 **트래킹 픽셀 벡터**가 된다. 전역 CSP는 `img-src ... https: http:`로 이를 허용한다. `/share`에서만 이를 차단한다.
  실제 노트 이미지/첨부는 인증된 API 오리진(`/api/images/{guid}` 등)에 있어 익명 열람자가 어차피 로드할 수 없고(모든 배포에서 401), `Share.razor`가 이미 플레이스홀더로 치환하므로 **정상적으로 보이던 이미지는 하나도 손실되지 않는다.** `data:`/`blob:` 인라인 이미지는 계속 렌더된다.
- **`form-action 'none'`**: 읽기 전용 공유 페이지는 폼을 제출하지 않는다.

`connect-src`는 전역과 동일하게 넓게 유지했다 — 공유 페이지의 WASM 앱이 배포 시점에 결정되는 `API_BASE_URL`로 공유 노트를 조회해야 하기 때문이며, 이는 이슈의 "범위 밖"과 일치한다. 전역 CSP는 전혀 건드리지 않았다.

### nginx 동작 관련
nginx는 자체 `add_header`를 가진 `location`에 server 레벨 `add_header`를 상속하지 않으므로, 이 블록이 `/share/*` 한정으로 전역 CSP를 완전히 대체한다(server 레벨 헤더는 이 CSP 하나뿐). SPA fallback(`try_files $uri /index.html`)이 클라이언트 라우트 `/share/{token}`에 index.html을 서빙하며, 그 문서 응답의 CSP가 페이지를 지배한다. prefix `location /share/`는 최장 일치로 `location /`보다 우선한다.

## Acceptance Criteria 검증
- **빌드 클린 (`dotnet build Vanadium.slnx`)**: 경고 0 / 오류 0 확인. (C# 변경 없음, nginx.conf만 수정)
- **script-src에서 esm.sh/jsdelivr(+`unsafe-eval`) 제거**: #307에서 전역 제거 완료. 신규 `/share` CSP에도 없음.
- **에디터/다이어그램(Tiptap/Mermaid/lowlight) self-host 정상 동작**: #307에서 확보. `/share` CSP도 `script-src 'self' 'wasm-unsafe-eval'`를 유지해 `renderMermaidIn`/`highlightSharedCode`/`enableSharedToggles` interop가 동일하게 동작한다.
- **`/share/*` 페이지가 엄격 CSP에서 정상 렌더**: 강화한 항목은 `img-src`(외부 이미지는 익명 열람 시 원래 로드 불가 → 플레이스홀더)와 `form-action`(폼 없음)뿐이라 렌더에 영향 없음. `script-src`/`style-src`/`connect-src`/`worker-src`/`font-src`는 앱이 필요로 하는 값을 그대로 유지.

## 검증 방법 / 한계
- `nginx.conf`는 인프라 설정으로 단위 테스트 대상이 아니다(Web 프로젝트에 테스트 없음). 문법은 nginx 문법 규칙에 따라 수기 검토했다. 로컬에 Docker 데몬이 없어 `nginx -t` 실행은 불가했으므로, 컨테이너 배포 시 `nginx -t`로 최종 확인 권장.
- 실제 브라우저에서 `/share/{token}` 열람 시 개발자도구 Network/Console로 외부 `<img>` 차단 및 정상 렌더 육안 확인 권장(수동 확인 필요).
