### PR TITLE
#308 Web 테스트 도입 (bUnit 스모크 + Playwright 시나리오 3종)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,9 @@ ipch/
 
 # Visual Studio Trace Files
 *.e2e
+# The Web Playwright test project's name ends in ".E2E"; on case-insensitive filesystems the
+# *.e2e trace-file glob above would otherwise swallow the whole project, so re-include it (#308).
+!Vanadium.Note.Web.E2E/
 
 # TFS 2012 Local Workspace
 $tf/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,11 @@ A keyboard-first note switcher opened by `Ctrl+K` (Windows/Linux) / `Cmd+K` (mac
 
 ## When making changes
 
+- **Tests — keep them current in the SAME change.** Whenever you modify existing behavior or add a new feature/behavior, update the test projects in the same change so the suite always reflects the latest code: adjust the tests whose expectations the change breaks, and add coverage for the new/changed behavior. This is not optional cleanup for "later" — a code change and its test change ship together.
+  - Backend / service logic → `Vanadium.Note.REST.Tests` (xUnit + EF Core SQLite in-memory).
+  - Blazor components / frontend services → `Vanadium.Note.Web.Tests` (bUnit + xUnit), which runs in the normal pass.
+  - New front-end worst-path end-to-end flows → `Vanadium.Note.Web.E2E` (Playwright + NUnit); these self-ignore unless `VANADIUM_E2E_BASEURL` is set (see `Vanadium.Note.Web.E2E/README.md`).
+  - After the change, `dotnet test Vanadium.slnx` must stay green (the E2E project stays skipped without the env var). If a behavior genuinely cannot be unit-tested (e.g. PostgreSQL-only trigram search), say so explicitly rather than leaving it silently uncovered.
 - **Schema changes:** always create an EF Core migration (`dotnet ef migrations add <Name> --project Vanadium.Note.REST`). Never edit existing migration files.
 - **New API endpoint:** add (1) DTO in `Vanadium.Note.REST/Models`, (2) DTO mirror in `Vanadium.Note.Web/Models`, (3) HTTP client method in `NoteService`/`LabelService`/etc.
 - **API specification:** `docs/api-specification.md` is the reference contract for the REST API. Whenever a backend API changes — a new/removed endpoint, a changed route, request/response shape, auth requirement, or notable status code — update `docs/api-specification.md` in the **same** change so it never drifts from the controllers. The document is published in the public repo, so it must never contain secrets (connection strings, JWT secret, real password hashes).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ A keyboard-first note switcher opened by `Ctrl+K` (Windows/Linux) / `Cmd+K` (mac
 
 ## Known limitations
 
-- **Tests:** `Vanadium.Note.REST.Tests` (xUnit + EF Core SQLite in-memory) covers `NoteService`-level logic. PostgreSQL-only behavior (trigram `ILike` search) is out of unit scope and must be verified manually. Run with `dotnet test Vanadium.slnx`. The Web project has no tests.
+- **Tests:** `Vanadium.Note.REST.Tests` (xUnit + EF Core SQLite in-memory) covers `NoteService`-level logic. PostgreSQL-only behavior (trigram `ILike` search) is out of unit scope and must be verified manually. Run with `dotnet test Vanadium.slnx`. The Web project has two test projects (issue #308): `Vanadium.Note.Web.Tests` (bUnit + xUnit) for component/service smoke + worst-path unit coverage, run in the normal pass; and `Vanadium.Note.Web.E2E` (Playwright + NUnit) for three end-to-end worst-path scenarios (save-during-expiry / two-tab conflict / Korean-mention IME) that **self-ignore unless `VANADIUM_E2E_BASEURL` is set** — so `dotnet test Vanadium.slnx` stays green without browsers or a running app; see `Vanadium.Note.Web.E2E/README.md` to run them against a live stack.
 - **DTOs are duplicated** between REST and Web projects on purpose (kept simple). Do not introduce a shared `Vanadium.Note.Shared` project unless explicitly requested.
 - **No CI workflow** is set up. Build/lint must be verified locally with `dotnet build Vanadium.slnx`.
 - **No refresh tokens.** When the JWT expires, the user re-logs in. Don't propose refresh-token implementations without discussion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Vanadium is a personal project aimed at building a Notion-like note-taking app t
 - Public DTOs/contracts: PascalCase properties, no abbreviations.
 - Avoid introducing new top-level dependencies without justification — this is a personal project and dependency surface is intentionally small.
 - Prefer async/await end-to-end for I/O paths (EF Core, HttpClient, file I/O).
+- **Commit messages must NOT contain any `Co-Authored-By:` trailer for an AI assistant** (e.g. `Co-Authored-By: Claude ... <noreply@anthropic.com>`) or similar "Generated with / Co-authored by Claude" attribution. Do not add it to commits or PR bodies, even if a tool's default instructions say to. Write the commit message with the change description only.
 
 ## Overview
 

--- a/Vanadium.Note.Web.E2E/KoreanMentionImeScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/KoreanMentionImeScenarioTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace Vanadium.Note.Web.E2E;
+
+/// <summary>
+/// Scenario 3 — "Korean mention typed through an IME" (issue #308).
+///
+/// <para>
+/// Mentioning a note by a Hangul title exercises the IME path: an IME commits composed text via
+/// <c>input</c> events rather than discrete <c>keydown</c>s, and the mention suggestion plugin must
+/// still search and match on that composed text. This scenario opens the mention menu with
+/// <c>@</c>, commits Korean via <see cref="IKeyboard.InsertTextAsync"/> (Playwright's closest proxy
+/// for an IME commit), and verifies the Korean-titled note is found and inserted as a
+/// <c>a.note-mention</c> node carrying the Hangul title as text.
+/// </para>
+/// </summary>
+public sealed class KoreanMentionImeScenarioTests : PlaywrightScenarioBase
+{
+    private const string KoreanTitle = "회의록 2026";
+
+    [Test]
+    public async Task MentionByKoreanTitle_ViaImeCommit_InsertsMentionNode()
+    {
+        await using var context = await NewContextAsync();
+        var page = await context.NewPageAsync();
+        await LoginAsync(page);
+
+        // Seed a note whose title is Korean so the mention search has a Hangul target.
+        await page.GotoAsync("/editor");
+        await page.FillAsync(".editor-title", KoreanTitle);
+        await page.ClickAsync(".tiptap-wrapper .ProseMirror");
+        await page.Keyboard.TypeAsync("target note body");
+        await page.ClickAsync("button:has-text('Save')");
+        await page.WaitForURLAsync(u => u.Contains("/editor/"), new() { Timeout = 15_000 });
+
+        // In a fresh note, open the mention menu and commit the Korean query through the IME path.
+        await page.GotoAsync("/editor");
+        await page.ClickAsync(".tiptap-wrapper .ProseMirror");
+        await page.Keyboard.PressAsync("@");
+        await page.Keyboard.InsertTextAsync("회의"); // composed (IME-style) commit, not per-key keydowns
+
+        // The suggestion menu must surface the Korean-titled note.
+        var menuItem = page.Locator(".mention-menu-item", new() { HasTextString = "회의록" });
+        await Assertions.Expect(menuItem).ToBeVisibleAsync(new() { Timeout = 15_000 });
+        await menuItem.First.ClickAsync();
+
+        // The committed mention is a note-mention node bearing the Hangul title.
+        var mention = page.Locator("a.note-mention");
+        await Assertions.Expect(mention).ToBeVisibleAsync(new() { Timeout = 15_000 });
+        Assert.That(await mention.First.InnerTextAsync(), Does.Contain("회의록"));
+    }
+}

--- a/Vanadium.Note.Web.E2E/KoreanMentionImeScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/KoreanMentionImeScenarioTests.cs
@@ -4,15 +4,16 @@ using NUnit.Framework;
 namespace Vanadium.Note.Web.E2E;
 
 /// <summary>
-/// Scenario 3 — "Korean mention typed through an IME" (issue #308).
+/// Scenario 3 — "Korean mention typed by a Hangul title" (issue #308).
 ///
 /// <para>
-/// Mentioning a note by a Hangul title exercises the IME path: an IME commits composed text via
-/// <c>input</c> events rather than discrete <c>keydown</c>s, and the mention suggestion plugin must
-/// still search and match on that composed text. This scenario opens the mention menu with
-/// <c>@</c>, commits Korean via <see cref="IKeyboard.InsertTextAsync"/> (Playwright's closest proxy
-/// for an IME commit), and verifies the Korean-titled note is found and inserted as a
-/// <c>a.note-mention</c> node carrying the Hangul title as text.
+/// Mentioning a note by a Hangul title must search, match, and insert on Korean text. The scenario
+/// opens the mention menu with <c>@</c> and types the Hangul query. The mention suggestion plugin
+/// derives its query from ProseMirror document changes (not raw keydowns), so driving the query
+/// with <see cref="IKeyboard.TypeAsync"/> exercises the same search/match path an IME commit would.
+/// (<see cref="IKeyboard.InsertTextAsync"/> — a CDP <c>Input.insertText</c> — was tried as an
+/// IME-commit proxy but does not reliably update an already-open suggestion in headless Chromium;
+/// full native IME composition is not reproducible through Playwright's public API.)
 /// </para>
 /// </summary>
 public sealed class KoreanMentionImeScenarioTests : PlaywrightScenarioBase
@@ -34,19 +35,26 @@ public sealed class KoreanMentionImeScenarioTests : PlaywrightScenarioBase
         await page.ClickAsync("button:text-is('Save')"); // exact match, not "Save & close"
         await page.WaitForURLAsync(u => u.Contains("/editor/"), new() { Timeout = 15_000 });
 
-        // In a fresh note, open the mention menu and commit the Korean query through the IME path.
+        // In a fresh note, open the mention menu and search by the Korean title.
         await page.GotoAsync("/editor");
         await page.ClickAsync(".tiptap-wrapper .ProseMirror");
         // TypeAsync fires the full keydown/keypress/input sequence, which reliably drives
-        // ProseMirror's input handling and opens the suggestion menu; a bare PressAsync("@")
-        // does not always register as editor input.
+        // ProseMirror's input handling; a bare PressAsync("@") does not always register.
         await page.Keyboard.TypeAsync("@");
-        await page.Keyboard.InsertTextAsync("회의"); // composed (IME-style) commit, not per-key keydowns
+        // Checkpoint: '@' alone opens the menu (empty query → recent notes). Asserting this
+        // separately pinpoints whether a later failure is the trigger or the Hangul search.
+        await Assertions.Expect(page.Locator(".mention-menu")).ToBeVisibleAsync(
+            new() { Timeout = 15_000 });
 
-        // The suggestion menu must surface the Korean-titled note.
-        var menuItem = page.Locator(".mention-menu-item", new() { HasTextString = "회의록" });
+        // Type the Hangul query so the suggestion searches over Korean text.
+        await page.Keyboard.TypeAsync("회의");
+
+        // The suggestion menu must surface the Korean-titled note. Match .First: repeated seed
+        // runs can leave several identically-titled "회의록" notes, and any one proves the Hangul
+        // search matched — clicking it inserts a mention carrying the Korean title.
+        var menuItem = page.Locator(".mention-menu-item", new() { HasTextString = "회의록" }).First;
         await Assertions.Expect(menuItem).ToBeVisibleAsync(new() { Timeout = 15_000 });
-        await menuItem.First.ClickAsync();
+        await menuItem.ClickAsync();
 
         // The committed mention is a note-mention node bearing the Hangul title.
         var mention = page.Locator("a.note-mention");

--- a/Vanadium.Note.Web.E2E/KoreanMentionImeScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/KoreanMentionImeScenarioTests.cs
@@ -37,7 +37,10 @@ public sealed class KoreanMentionImeScenarioTests : PlaywrightScenarioBase
         // In a fresh note, open the mention menu and commit the Korean query through the IME path.
         await page.GotoAsync("/editor");
         await page.ClickAsync(".tiptap-wrapper .ProseMirror");
-        await page.Keyboard.PressAsync("@");
+        // TypeAsync fires the full keydown/keypress/input sequence, which reliably drives
+        // ProseMirror's input handling and opens the suggestion menu; a bare PressAsync("@")
+        // does not always register as editor input.
+        await page.Keyboard.TypeAsync("@");
         await page.Keyboard.InsertTextAsync("회의"); // composed (IME-style) commit, not per-key keydowns
 
         // The suggestion menu must surface the Korean-titled note.

--- a/Vanadium.Note.Web.E2E/KoreanMentionImeScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/KoreanMentionImeScenarioTests.cs
@@ -31,7 +31,7 @@ public sealed class KoreanMentionImeScenarioTests : PlaywrightScenarioBase
         await page.FillAsync(".editor-title", KoreanTitle);
         await page.ClickAsync(".tiptap-wrapper .ProseMirror");
         await page.Keyboard.TypeAsync("target note body");
-        await page.ClickAsync("button:has-text('Save')");
+        await page.ClickAsync("button:text-is('Save')"); // exact match, not "Save & close"
         await page.WaitForURLAsync(u => u.Contains("/editor/"), new() { Timeout = 15_000 });
 
         // In a fresh note, open the mention menu and commit the Korean query through the IME path.

--- a/Vanadium.Note.Web.E2E/PlaywrightScenarioBase.cs
+++ b/Vanadium.Note.Web.E2E/PlaywrightScenarioBase.cs
@@ -1,0 +1,68 @@
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace Vanadium.Note.Web.E2E;
+
+/// <summary>
+/// Base fixture for the Playwright worst-path scenarios (issue #308).
+///
+/// <para>
+/// These scenarios drive a real browser against a running Vanadium stack, so they are opt-in:
+/// the whole fixture self-ignores unless <c>VANADIUM_E2E_BASEURL</c> is set. That keeps the
+/// default <c>dotnet test Vanadium.slnx</c> pass green in environments without browsers or a live
+/// app. To actually run them, start the backend + frontend, install browsers once
+/// (<c>pwsh bin/Debug/net10.0/playwright.ps1 install chromium</c>), and set the env vars described
+/// in <c>README.md</c>.
+/// </para>
+/// </summary>
+[TestFixture]
+public abstract class PlaywrightScenarioBase
+{
+    protected string BaseUrl { get; private set; } = string.Empty;
+    protected string Password { get; private set; } = string.Empty;
+    private IPlaywright? _playwright;
+    protected IBrowser Browser { get; private set; } = null!;
+
+    [OneTimeSetUp]
+    public async Task GlobalSetupAsync()
+    {
+        BaseUrl = Environment.GetEnvironmentVariable("VANADIUM_E2E_BASEURL") ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(BaseUrl))
+        {
+            Assert.Ignore(
+                "VANADIUM_E2E_BASEURL is not set — Playwright scenarios require a running Vanadium " +
+                "stack and installed browsers. See Vanadium.Note.Web.E2E/README.md.");
+        }
+
+        Password = Environment.GetEnvironmentVariable("VANADIUM_E2E_PASSWORD") ?? string.Empty;
+
+        _playwright = await Playwright.CreateAsync();
+        var headed = Environment.GetEnvironmentVariable("VANADIUM_E2E_HEADED") == "1";
+        Browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = !headed,
+        });
+    }
+
+    [OneTimeTearDown]
+    public async Task GlobalTeardownAsync()
+    {
+        if (Browser is not null)
+            await Browser.DisposeAsync();
+        _playwright?.Dispose();
+    }
+
+    /// <summary>Opens a fresh, isolated browser context pinned to the app's base URL.</summary>
+    protected Task<IBrowserContext> NewContextAsync() =>
+        Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = BaseUrl });
+
+    /// <summary>Logs the given page into the app via the password-only login form.</summary>
+    protected async Task LoginAsync(IPage page)
+    {
+        await page.GotoAsync("/login");
+        await page.FillAsync("#password", Password);
+        await page.ClickAsync(".login-btn");
+        // Landing on Home clears /login from the URL.
+        await page.WaitForURLAsync(u => !u.Contains("/login"), new() { Timeout = 15_000 });
+    }
+}

--- a/Vanadium.Note.Web.E2E/README.md
+++ b/Vanadium.Note.Web.E2E/README.md
@@ -1,0 +1,48 @@
+# Vanadium.Note.Web.E2E — Playwright worst-path scenarios
+
+End-to-end scenarios (issue #308) that drive a **real browser** against a **running Vanadium
+stack**. They cover the three front-end worst paths that unit/bUnit tests cannot reach end to end:
+
+1. **`SaveDuringExpiryScenarioTests`** — saving a note while the JWT expires mid-session must clear
+   the token and redirect to `/login` with a `returnUrl` (issues #117 / #297).
+2. **`TwoTabConflictScenarioTests`** — two tabs editing the same note: the stale save gets a 409
+   conflict banner with Force Save (issue #221), never a silent clobber.
+3. **`KoreanMentionImeScenarioTests`** — mentioning a note by a Hangul title through an IME commit
+   (`input` events, not per-key `keydown`s) must still search, match, and insert the mention.
+
+## Why these do not run in the normal test pass
+
+`PlaywrightScenarioBase` **self-ignores the whole fixture** unless `VANADIUM_E2E_BASEURL` is set, so
+`dotnet test Vanadium.slnx` stays green in CI / dev boxes that have no browsers or no running app.
+The scenarios execute (and can pass) only when you point them at a live stack, as below.
+
+## Running the scenarios
+
+1. Start the backend and frontend (see the repo `CLAUDE.md`):
+
+   ```bash
+   cd Vanadium.Note.REST && dotnet run      # https://localhost:7711
+   cd Vanadium.Note.Web  && dotnet run      # https://localhost:7700
+   ```
+
+2. Install the Playwright browsers once (after a build of this project):
+
+   ```bash
+   pwsh Vanadium.Note.Web.E2E/bin/Debug/net10.0/playwright.ps1 install chromium
+   ```
+
+3. Set the environment variables and run:
+
+   ```bash
+   # PowerShell
+   $env:VANADIUM_E2E_BASEURL = "https://localhost:7700"
+   $env:VANADIUM_E2E_PASSWORD = "<the dev login password>"
+   $env:VANADIUM_E2E_HEADED  = "1"   # optional: run headed to watch the browser
+   dotnet test Vanadium.Note.Web.E2E
+   ```
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `VANADIUM_E2E_BASEURL` | yes | Base URL of the running frontend; unset ⇒ all scenarios ignored |
+| `VANADIUM_E2E_PASSWORD` | yes (to log in) | Dev login password |
+| `VANADIUM_E2E_HEADED` | no | `1` runs the browser headed instead of headless |

--- a/Vanadium.Note.Web.E2E/SaveDuringExpiryScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/SaveDuringExpiryScenarioTests.cs
@@ -37,8 +37,9 @@ public sealed class SaveDuringExpiryScenarioTests : PlaywrightScenarioBase
                 localStorage.setItem('authToken', `${h || 'h'}.${b64url({ name: 'owner', exp: past })}.${s || 's'}`);
             }");
 
-        // Trigger a save with the now-expired token.
-        await page.ClickAsync("button:has-text('Save')");
+        // Trigger a save with the now-expired token. Exact-text match so this does not also
+        // hit the adjacent "Save & close" button.
+        await page.ClickAsync("button:text-is('Save')");
 
         // The 401 handler must bounce to login and preserve where we were.
         await page.WaitForURLAsync(u => u.Contains("/login"), new() { Timeout = 15_000 });

--- a/Vanadium.Note.Web.E2E/SaveDuringExpiryScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/SaveDuringExpiryScenarioTests.cs
@@ -10,7 +10,17 @@ namespace Vanadium.Note.Web.E2E;
 /// The user is editing a note when their JWT expires mid-session. The next auto-save comes back
 /// 401; the app must clear the token and redirect to <c>/login</c> carrying a <c>returnUrl</c>
 /// (issues #117/#297) rather than silently dropping the edit or flashing a broken logged-in shell.
-/// The expiry is forced by overwriting the stored <c>authToken</c> with an already-expired JWT.
+/// The expiry is simulated by intercepting the save call and returning 401 — the same signal a
+/// real expired-JWT request receives from the server.
+/// </para>
+///
+/// <para>
+/// Overwriting the stored <c>authToken</c> in <c>localStorage</c> is deliberately NOT used:
+/// <c>TokenStore</c> caches the token in memory after the first read, and the same-tab
+/// <c>storage</c> event never fires for a change made by the tab itself, so the app would keep
+/// sending the still-valid cached token and the save would succeed. Fulfilling the request with
+/// 401 reproduces exactly what an expired session does — the server rejecting the write — without
+/// depending on those cache internals.
 /// </para>
 /// </summary>
 public sealed class SaveDuringExpiryScenarioTests : PlaywrightScenarioBase
@@ -28,16 +38,13 @@ public sealed class SaveDuringExpiryScenarioTests : PlaywrightScenarioBase
         await page.ClickAsync(".tiptap-wrapper .ProseMirror");
         await page.Keyboard.TypeAsync("draft body before expiry");
 
-        // Force the session to expire: replace the stored JWT with one whose exp is in the past.
-        await page.EvaluateAsync(
-            @"() => {
-                const [h, , s] = (localStorage.getItem('authToken') || 'h.e.s').split('.');
-                const past = Math.floor(Date.now() / 1000) - 3600;
-                const b64url = obj => btoa(JSON.stringify(obj)).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
-                localStorage.setItem('authToken', `${h || 'h'}.${b64url({ name: 'owner', exp: past })}.${s || 's'}`);
-            }");
+        // Force the session to expire: the next note save comes back 401, exactly as it would
+        // if the JWT had expired. AuthTokenHandler still sends the (valid) cached token, so its
+        // 401 branch — clear token + redirect to /login?returnUrl — is what we exercise here.
+        await page.RouteAsync("**/api/notes**", route =>
+            route.FulfillAsync(new RouteFulfillOptions { Status = 401 }));
 
-        // Trigger a save with the now-expired token. Exact-text match so this does not also
+        // Trigger a save with the now-expired session. Exact-text match so this does not also
         // hit the adjacent "Save & close" button.
         await page.ClickAsync("button:text-is('Save')");
 

--- a/Vanadium.Note.Web.E2E/SaveDuringExpiryScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/SaveDuringExpiryScenarioTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace Vanadium.Note.Web.E2E;
+
+/// <summary>
+/// Scenario 1 — "save while the session expires" (issue #308).
+///
+/// <para>
+/// The user is editing a note when their JWT expires mid-session. The next auto-save comes back
+/// 401; the app must clear the token and redirect to <c>/login</c> carrying a <c>returnUrl</c>
+/// (issues #117/#297) rather than silently dropping the edit or flashing a broken logged-in shell.
+/// The expiry is forced by overwriting the stored <c>authToken</c> with an already-expired JWT.
+/// </para>
+/// </summary>
+public sealed class SaveDuringExpiryScenarioTests : PlaywrightScenarioBase
+{
+    [Test]
+    public async Task SaveAfterTokenExpires_RedirectsToLoginWithReturnUrl()
+    {
+        await using var context = await NewContextAsync();
+        var page = await context.NewPageAsync();
+        await LoginAsync(page);
+
+        // Create a note and open its editor.
+        await page.GotoAsync("/editor");
+        await page.FillAsync(".editor-title", "Expiry scenario note");
+        await page.ClickAsync(".tiptap-wrapper .ProseMirror");
+        await page.Keyboard.TypeAsync("draft body before expiry");
+
+        // Force the session to expire: replace the stored JWT with one whose exp is in the past.
+        await page.EvaluateAsync(
+            @"() => {
+                const [h, , s] = (localStorage.getItem('authToken') || 'h.e.s').split('.');
+                const past = Math.floor(Date.now() / 1000) - 3600;
+                const b64url = obj => btoa(JSON.stringify(obj)).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+                localStorage.setItem('authToken', `${h || 'h'}.${b64url({ name: 'owner', exp: past })}.${s || 's'}`);
+            }");
+
+        // Trigger a save with the now-expired token.
+        await page.ClickAsync("button:has-text('Save')");
+
+        // The 401 handler must bounce to login and preserve where we were.
+        await page.WaitForURLAsync(u => u.Contains("/login"), new() { Timeout = 15_000 });
+        Assert.That(page.Url, Does.Contain("returnUrl"));
+        Assert.That(Uri.UnescapeDataString(page.Url), Does.Contain("editor"));
+    }
+}

--- a/Vanadium.Note.Web.E2E/TwoTabConflictScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/TwoTabConflictScenarioTests.cs
@@ -41,6 +41,13 @@ public sealed class TwoTabConflictScenarioTests : PlaywrightScenarioBase
         await tabB.GotoAsync(noteUrl);
         await tabB.FillAsync(".editor-title", "Edited by tab B");
         await tabB.ClickAsync("button:text-is('Save')");
+        // Wait for Tab B's save to actually PERSIST (the "Saved" badge) before Tab A saves.
+        // The banner-absent check alone does not wait for the network round-trip, so without
+        // this Tab A's stale PUT can reach the server before Tab B's has advanced the row —
+        // the server then sees a matching version, returns 200, and no 409 conflict ever fires.
+        await Assertions.Expect(tabB.Locator(".save-status.status-saved")).ToBeVisibleAsync(
+            new() { Timeout = 15_000 });
+        // Tab B held the current version, so its own save must not have conflicted.
         await Assertions.Expect(tabB.Locator(conflictBanner)).Not.ToBeVisibleAsync();
 
         // Tab A now saves its stale copy → server 409 → conflict banner.

--- a/Vanadium.Note.Web.E2E/TwoTabConflictScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/TwoTabConflictScenarioTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace Vanadium.Note.Web.E2E;
+
+/// <summary>
+/// Scenario 2 — "two tabs edit the same note" (issue #308).
+///
+/// <para>
+/// Tab A and Tab B open the same note. Tab B saves first, advancing the server row. When Tab A
+/// then saves its stale copy the server rejects it with 409 and the editor must surface the
+/// conflict banner (optimistic concurrency, issue #221) offering Force Save — never silently
+/// clobbering Tab B's write. Force Save then overwrites and clears the banner.
+/// </para>
+/// </summary>
+public sealed class TwoTabConflictScenarioTests : PlaywrightScenarioBase
+{
+    [Test]
+    public async Task ConcurrentEdit_ShowsConflictBanner_ThenForceSaveResolves()
+    {
+        await using var context = await NewContextAsync(); // shared context = shared auth/token
+        var tabA = await context.NewPageAsync();
+        await LoginAsync(tabA);
+
+        // Create the note in tab A and capture its editor URL.
+        await tabA.GotoAsync("/editor");
+        await tabA.FillAsync(".editor-title", "Two-tab conflict note");
+        await tabA.ClickAsync(".tiptap-wrapper .ProseMirror");
+        await tabA.Keyboard.TypeAsync("original body");
+        await tabA.ClickAsync("button:has-text('Save')");
+        await tabA.WaitForURLAsync(u => u.Contains("/editor/"), new() { Timeout = 15_000 });
+        var noteUrl = tabA.Url;
+
+        // Tab B opens the same note and saves an edit first.
+        var tabB = await context.NewPageAsync();
+        await tabB.GotoAsync(noteUrl);
+        await tabB.FillAsync(".editor-title", "Edited by tab B");
+        await tabB.ClickAsync("button:has-text('Save')");
+        await Assertions.Expect(tabB.Locator(".conflict-banner")).Not.ToBeVisibleAsync();
+
+        // Tab A now saves its stale copy → server 409 → conflict banner.
+        await tabA.FillAsync(".editor-title", "Edited by tab A (stale)");
+        await tabA.ClickAsync("button:has-text('Save')");
+        await Assertions.Expect(tabA.Locator(".conflict-banner")).ToBeVisibleAsync(
+            new() { Timeout = 15_000 });
+
+        // Force Save resolves the conflict and dismisses the banner.
+        await tabA.ClickAsync(".conflict-banner .btn-danger");
+        await Assertions.Expect(tabA.Locator(".conflict-banner")).Not.ToBeVisibleAsync(
+            new() { Timeout = 15_000 });
+    }
+}

--- a/Vanadium.Note.Web.E2E/TwoTabConflictScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/TwoTabConflictScenarioTests.cs
@@ -32,6 +32,13 @@ public sealed class TwoTabConflictScenarioTests : PlaywrightScenarioBase
         await tabA.WaitForURLAsync(u => u.Contains("/editor/"), new() { Timeout = 15_000 });
         var noteUrl = tabA.Url;
 
+        // Let tab A go fully idle before the race. Typing armed a 1500ms debounced auto-save that
+        // the explicit Save does NOT cancel; it fires a trailing PUT ~1.5s later. If that late
+        // write lands after tab B's GET it advances the server row, so tab B's own save loses a
+        // false 409. Waiting for the idle badge guarantees the trailing write has landed and the
+        // server version is final. (Headed timing exposes this race that headless hid.)
+        await WaitForEditorIdleAsync(tabA);
+
         // The optimistic-concurrency conflict banner shares its .conflict-banner class with the
         // stashed-draft banner (NoteEditor.razor), so scope to the one carrying Force Save.
         const string conflictBanner = ".conflict-banner:has(.btn-danger)";
@@ -39,16 +46,25 @@ public sealed class TwoTabConflictScenarioTests : PlaywrightScenarioBase
         // Tab B opens the same note and saves an edit first.
         var tabB = await context.NewPageAsync();
         await tabB.GotoAsync(noteUrl);
+        // Wait for Tab B's editor to actually LOAD the note (title populated from the server)
+        // before editing, so its save carries the current version and lands a clean 200.
+        await Assertions.Expect(tabB.Locator(".editor-title")).ToHaveValueAsync(
+            "Two-tab conflict note", new() { Timeout = 15_000 });
         await tabB.FillAsync(".editor-title", "Edited by tab B");
-        await tabB.ClickAsync("button:text-is('Save')");
-        // Wait for Tab B's save to actually PERSIST (the "Saved" badge) before Tab A saves.
-        // The banner-absent check alone does not wait for the network round-trip, so without
-        // this Tab A's stale PUT can reach the server before Tab B's has advanced the row —
-        // the server then sees a matching version, returns 200, and no 409 conflict ever fires.
-        await Assertions.Expect(tabB.Locator(".save-status.status-saved")).ToBeVisibleAsync(
+        // Save and wait for the PUT to actually succeed (200) — the point at which the server row
+        // advances. The banner-absent check alone does not wait for the round-trip, so without
+        // this Tab A's stale PUT could reach the server first, match the version, and never 409.
+        await tabB.RunAndWaitForResponseAsync(
+            () => tabB.ClickAsync("button:text-is('Save')"),
+            resp => resp.Url.Contains("/api/notes/")
+                    && resp.Request.Method == "PUT"
+                    && resp.Status == 200,
             new() { Timeout = 15_000 });
         // Tab B held the current version, so its own save must not have conflicted.
         await Assertions.Expect(tabB.Locator(conflictBanner)).Not.ToBeVisibleAsync();
+        // Let tab B's own trailing auto-save settle too, so it cannot advance the row mid-way
+        // through tab A's stale save below.
+        await WaitForEditorIdleAsync(tabB);
 
         // Tab A now saves its stale copy → server 409 → conflict banner.
         await tabA.FillAsync(".editor-title", "Edited by tab A (stale)");
@@ -61,4 +77,15 @@ public sealed class TwoTabConflictScenarioTests : PlaywrightScenarioBase
         await Assertions.Expect(tabA.Locator(conflictBanner)).Not.ToBeVisibleAsync(
             new() { Timeout = 15_000 });
     }
+
+    /// <summary>
+    /// Waits until the editor has no save pending or in flight. The save-status badge
+    /// (<c>.save-status</c>) reads "Writing…"/"Saving…"/"Saved" while work is outstanding and
+    /// clears to empty only after ~2s with no save — so an empty badge means every debounced
+    /// auto-save (including the trailing one an explicit Save does not cancel) has landed and the
+    /// server row is final.
+    /// </summary>
+    private static Task WaitForEditorIdleAsync(IPage page) =>
+        Assertions.Expect(page.Locator(".save-status")).ToHaveTextAsync(
+            string.Empty, new() { Timeout = 15_000 });
 }

--- a/Vanadium.Note.Web.E2E/TwoTabConflictScenarioTests.cs
+++ b/Vanadium.Note.Web.E2E/TwoTabConflictScenarioTests.cs
@@ -27,26 +27,31 @@ public sealed class TwoTabConflictScenarioTests : PlaywrightScenarioBase
         await tabA.FillAsync(".editor-title", "Two-tab conflict note");
         await tabA.ClickAsync(".tiptap-wrapper .ProseMirror");
         await tabA.Keyboard.TypeAsync("original body");
-        await tabA.ClickAsync("button:has-text('Save')");
+        // Exact-text match so this does not also hit the adjacent "Save & close" button.
+        await tabA.ClickAsync("button:text-is('Save')");
         await tabA.WaitForURLAsync(u => u.Contains("/editor/"), new() { Timeout = 15_000 });
         var noteUrl = tabA.Url;
+
+        // The optimistic-concurrency conflict banner shares its .conflict-banner class with the
+        // stashed-draft banner (NoteEditor.razor), so scope to the one carrying Force Save.
+        const string conflictBanner = ".conflict-banner:has(.btn-danger)";
 
         // Tab B opens the same note and saves an edit first.
         var tabB = await context.NewPageAsync();
         await tabB.GotoAsync(noteUrl);
         await tabB.FillAsync(".editor-title", "Edited by tab B");
-        await tabB.ClickAsync("button:has-text('Save')");
-        await Assertions.Expect(tabB.Locator(".conflict-banner")).Not.ToBeVisibleAsync();
+        await tabB.ClickAsync("button:text-is('Save')");
+        await Assertions.Expect(tabB.Locator(conflictBanner)).Not.ToBeVisibleAsync();
 
         // Tab A now saves its stale copy → server 409 → conflict banner.
         await tabA.FillAsync(".editor-title", "Edited by tab A (stale)");
-        await tabA.ClickAsync("button:has-text('Save')");
-        await Assertions.Expect(tabA.Locator(".conflict-banner")).ToBeVisibleAsync(
+        await tabA.ClickAsync("button:text-is('Save')");
+        await Assertions.Expect(tabA.Locator(conflictBanner)).ToBeVisibleAsync(
             new() { Timeout = 15_000 });
 
         // Force Save resolves the conflict and dismisses the banner.
-        await tabA.ClickAsync(".conflict-banner .btn-danger");
-        await Assertions.Expect(tabA.Locator(".conflict-banner")).Not.ToBeVisibleAsync(
+        await tabA.ClickAsync($"{conflictBanner} .btn-danger");
+        await Assertions.Expect(tabA.Locator(conflictBanner)).Not.ToBeVisibleAsync(
             new() { Timeout = 15_000 });
     }
 }

--- a/Vanadium.Note.Web.E2E/Vanadium.Note.Web.E2E.csproj
+++ b/Vanadium.Note.Web.E2E/Vanadium.Note.Web.E2E.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Playwright drives a real browser against a running Vanadium stack for the three
+         worst-path E2E scenarios (issue #308). These do NOT run in the default unit-test pass:
+         PlaywrightScenarioBase self-ignores unless VANADIUM_E2E_BASEURL points at a live app,
+         so `dotnet test Vanadium.slnx` stays green without browsers installed. See README.md. -->
+    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.49.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+</Project>

--- a/Vanadium.Note.Web.Tests/Auth/JwtAuthStateExpiryTests.cs
+++ b/Vanadium.Note.Web.Tests/Auth/JwtAuthStateExpiryTests.cs
@@ -1,0 +1,64 @@
+using System.Buffers.Text;
+using System.Text.Json;
+using Bunit;
+using Microsoft.Extensions.Logging.Abstractions;
+using Vanadium.Note.Web.Auth;
+using Xunit;
+
+namespace Vanadium.Note.Web.Tests.Auth;
+
+/// <summary>
+/// Worst-path coverage for "save while the session expires" (issue #308): an expired JWT must
+/// resolve to an anonymous auth state so a stale token never flashes a logged-in shell before the
+/// first API 401 forces re-login (issue #297). Drives the real <see cref="TokenStore"/> over a
+/// bUnit-mocked localStorage so the whole client auth read path is exercised.
+/// </summary>
+public sealed class JwtAuthStateExpiryTests : TestContext
+{
+    private JwtAuthenticationStateProvider CreateProvider(string? token)
+    {
+        JSInterop.Setup<string?>("localStorage.getItem", "authToken").SetResult(token);
+        var store = new TokenStore(JSInterop.JSRuntime, NullLogger<TokenStore>.Instance);
+        return new JwtAuthenticationStateProvider(store, NullLogger<JwtAuthenticationStateProvider>.Instance);
+    }
+
+    private static string MakeJwt(long expUnixSeconds)
+    {
+        var payload = JsonSerializer.SerializeToUtf8Bytes(new { name = "owner", exp = expUnixSeconds });
+        return $"header.{Base64Url.EncodeToString(payload)}.signature";
+    }
+
+    [Fact]
+    public async Task ExpiredToken_ResolvesAnonymous()
+    {
+        var expired = MakeJwt(DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeSeconds());
+        var provider = CreateProvider(expired);
+
+        var state = await provider.GetAuthenticationStateAsync();
+
+        Assert.False(state.User.Identity?.IsAuthenticated ?? false);
+    }
+
+    [Fact]
+    public async Task ValidToken_ResolvesAuthenticated()
+    {
+        var valid = MakeJwt(DateTimeOffset.UtcNow.AddMinutes(60).ToUnixTimeSeconds());
+        var provider = CreateProvider(valid);
+
+        var state = await provider.GetAuthenticationStateAsync();
+
+        Assert.True(state.User.Identity?.IsAuthenticated ?? false);
+        // The provider maps raw JWT keys verbatim, so the owner name is carried on the "name" claim.
+        Assert.Equal("owner", state.User.FindFirst("name")?.Value);
+    }
+
+    [Fact]
+    public async Task NoToken_ResolvesAnonymous()
+    {
+        var provider = CreateProvider(null);
+
+        var state = await provider.GetAuthenticationStateAsync();
+
+        Assert.False(state.User.Identity?.IsAuthenticated ?? false);
+    }
+}

--- a/Vanadium.Note.Web.Tests/Components/PaginationSmokeTests.cs
+++ b/Vanadium.Note.Web.Tests/Components/PaginationSmokeTests.cs
@@ -1,0 +1,59 @@
+using Bunit;
+using Vanadium.Note.Web.Components;
+using Xunit;
+
+namespace Vanadium.Note.Web.Tests.Components;
+
+/// <summary>
+/// bUnit smoke test for the shared <see cref="Pagination"/> component (issue #308).
+/// Establishes that the Web project can render a real Blazor component in-process and
+/// that the pager's core contract (hide on single page, emit the selected page) holds.
+/// </summary>
+public sealed class PaginationSmokeTests : TestContext
+{
+    [Fact]
+    public void RendersNothing_WhenSinglePage()
+    {
+        var cut = RenderComponent<Pagination>(parameters => parameters
+            .Add(p => p.CurrentPage, 1)
+            .Add(p => p.TotalPages, 1)
+            .Add(p => p.InfoText, "1-1 of 1")
+            .Add(p => p.OnPageChanged, _ => { }));
+
+        // The component deliberately renders empty markup when there is only one page,
+        // so callers no longer need their own guard.
+        Assert.Empty(cut.Markup.Trim());
+    }
+
+    [Fact]
+    public void RendersPageButtons_WhenMultiplePages()
+    {
+        var cut = RenderComponent<Pagination>(parameters => parameters
+            .Add(p => p.CurrentPage, 2)
+            .Add(p => p.TotalPages, 5)
+            .Add(p => p.InfoText, "31-60 of 150")
+            .Add(p => p.OnPageChanged, _ => { }));
+
+        Assert.Contains("pagination-bar", cut.Markup);
+        // Active page marker is applied to the current page only.
+        var active = cut.FindAll(".page-btn-active");
+        Assert.Single(active);
+        Assert.Equal("2", active[0].TextContent.Trim());
+    }
+
+    [Fact]
+    public void RaisesOnPageChanged_WithTargetPage()
+    {
+        int? changedTo = null;
+        var cut = RenderComponent<Pagination>(parameters => parameters
+            .Add(p => p.CurrentPage, 2)
+            .Add(p => p.TotalPages, 5)
+            .Add(p => p.InfoText, "31-60 of 150")
+            .Add(p => p.OnPageChanged, page => changedTo = page));
+
+        // The "»" last-page control jumps to TotalPages.
+        cut.FindAll("button.page-btn").Last().Click();
+
+        Assert.Equal(5, changedTo);
+    }
+}

--- a/Vanadium.Note.Web.Tests/Services/AuthTokenHandlerExpiryTests.cs
+++ b/Vanadium.Note.Web.Tests/Services/AuthTokenHandlerExpiryTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Vanadium.Note.Web.Auth;
+using Vanadium.Note.Web.Services;
+using Xunit;
+
+namespace Vanadium.Note.Web.Tests.Services;
+
+/// <summary>
+/// Worst-path coverage for "save while the session expires" (issue #308): when a request (e.g. an
+/// auto-save PUT) comes back 401 because the JWT expired mid-session, <see cref="AuthTokenHandler"/>
+/// must clear the stored token and redirect to <c>/login</c>, carrying the current location as a
+/// <c>returnUrl</c> (issue #117) so re-login lands the user back on the note being edited.
+/// </summary>
+public sealed class AuthTokenHandlerExpiryTests : TestContext
+{
+    private sealed class StubInnerHandler(HttpStatusCode code) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(code));
+    }
+
+    private HttpClient BuildClient(HttpStatusCode innerStatus, out FakeNavigationManager nav)
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose; // token writes/clears are void interop no-ops here
+        JSInterop.Setup<string?>("localStorage.getItem", "authToken").SetResult("stale.jwt.token");
+
+        var store = new TokenStore(JSInterop.JSRuntime, NullLogger<TokenStore>.Instance);
+        var authProvider = new JwtAuthenticationStateProvider(store, NullLogger<JwtAuthenticationStateProvider>.Instance);
+        nav = Services.GetRequiredService<FakeNavigationManager>();
+
+        var handler = new AuthTokenHandler(store, authProvider, nav)
+        {
+            InnerHandler = new StubInnerHandler(innerStatus),
+        };
+        return new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+    }
+
+    [Fact]
+    public async Task Unauthorized_RedirectsToLogin_WithReturnUrl()
+    {
+        var client = BuildClient(HttpStatusCode.Unauthorized, out var nav);
+        nav.NavigateTo("editor/abc123"); // user is editing a note when the save fails
+
+        await client.PutAsync("api/notes/abc123", new StringContent("{}"));
+
+        Assert.Contains("login", nav.Uri);
+        Assert.Contains("returnUrl", nav.Uri);
+        Assert.Contains("editor", Uri.UnescapeDataString(nav.Uri));
+    }
+
+    [Fact]
+    public async Task SuccessfulSave_DoesNotRedirect()
+    {
+        var client = BuildClient(HttpStatusCode.OK, out var nav);
+        var before = nav.Uri;
+
+        await client.PutAsync("api/notes/abc123", new StringContent("{}"));
+
+        Assert.Equal(before, nav.Uri);
+    }
+}

--- a/Vanadium.Note.Web.Tests/Services/NoteServiceConflictTests.cs
+++ b/Vanadium.Note.Web.Tests/Services/NoteServiceConflictTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Vanadium.Note.Web.Models;
+using Vanadium.Note.Web.Services;
+using Xunit;
+
+namespace Vanadium.Note.Web.Tests.Services;
+
+/// <summary>
+/// Worst-path coverage for the "two tabs edit the same note" conflict (issue #308): a plain save
+/// of a note whose server row moved on must surface as a conflict (server 409 → optimistic
+/// concurrency), while an explicit force-save (<c>?force=true</c>, issue #221) overwrites and
+/// succeeds. Exercises <see cref="NoteService.SaveAsync"/> against a stub transport.
+/// </summary>
+public sealed class NoteServiceConflictTests
+{
+    private sealed class ForceAwareHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("force=true"))
+            {
+                var ok = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new NoteItem { Title = "forced" }),
+                };
+                return Task.FromResult(ok);
+            }
+            // Second tab already advanced the row → optimistic concurrency rejection.
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Conflict));
+        }
+    }
+
+    private static NoteService BuildService()
+    {
+        var client = new HttpClient(new ForceAwareHandler()) { BaseAddress = new Uri("http://localhost/") };
+        return new NoteService(client, NullLogger<NoteService>.Instance);
+    }
+
+    [Fact]
+    public async Task Save_WithoutForce_ReturnsConflict()
+    {
+        var service = BuildService();
+        var note = new NoteItem { Id = Guid.NewGuid(), Title = "tab A", Content = "<p>A</p>" };
+
+        var result = await service.SaveAsync(note);
+
+        Assert.False(result.IsSuccess);
+        Assert.True(result.IsConflict);
+    }
+
+    [Fact]
+    public async Task Save_WithForce_Overwrites()
+    {
+        var service = BuildService();
+        var note = new NoteItem { Id = Guid.NewGuid(), Title = "tab A", Content = "<p>A</p>" };
+
+        var result = await service.SaveAsync(note, force: true);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.IsConflict);
+        Assert.Equal("forced", result.Value?.Title);
+    }
+}

--- a/Vanadium.Note.Web.Tests/Vanadium.Note.Web.Tests.csproj
+++ b/Vanadium.Note.Web.Tests/Vanadium.Note.Web.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <!-- bunit 1.40.0 is compiled against AngleSharp 1.2.0 and its IHtmlCollection indexer is not
+         binary-compatible with the patched 1.5.x line, so the transitive 1.2.0 must stay. That
+         version trips NU1902 (GHSA-pgww-w46g-26qg, mXSS), but bunit's AngleSharp only parses the
+         component's own in-test rendered markup — never untrusted network input — so the advisory
+         is unreachable here. Scoped to this test-only project (issue #308). -->
+    <NoWarn>$(NoWarn);NU1902</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- bUnit renders Blazor components in-process (no browser); this is the Web project's
+         smoke-test harness (issue #308). Pinned to the latest 1.x line. -->
+    <PackageReference Include="bunit" Version="1.40.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Vanadium.Note.Web\Vanadium.Note.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Vanadium.slnx
+++ b/Vanadium.slnx
@@ -3,4 +3,5 @@
   <Project Path="Vanadium.Note.REST/Vanadium.Note.REST.csproj" />
   <Project Path="Vanadium.Note.REST.Tests/Vanadium.Note.REST.Tests.csproj" />
   <Project Path="Vanadium.Note.Web.Tests/Vanadium.Note.Web.Tests.csproj" />
+  <Project Path="Vanadium.Note.Web.E2E/Vanadium.Note.Web.E2E.csproj" />
 </Solution>

--- a/Vanadium.slnx
+++ b/Vanadium.slnx
@@ -2,4 +2,5 @@
   <Project Path="Vanadium.Note.Web/Vanadium.Note.Web.csproj" />
   <Project Path="Vanadium.Note.REST/Vanadium.Note.REST.csproj" />
   <Project Path="Vanadium.Note.REST.Tests/Vanadium.Note.REST.Tests.csproj" />
+  <Project Path="Vanadium.Note.Web.Tests/Vanadium.Note.Web.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
Closes #308

## 목적
Web 프로젝트 테스트가 0이던 상태를 해소한다. 프론트 최악 경로(만료 중 저장 / 두 탭 충돌 / 한글 멘션 IME)를 커버하는 테스트 인프라를 도입한다.

## 변경 사항
### 1) `Vanadium.Note.Web.Tests` — bUnit 스모크 + 최악 경로 단위 커버리지 (기본 테스트 패스 포함)
- **bunit + xUnit** 프로젝트 신설, 솔루션 등록.
- `PaginationSmokeTests` — 실제 Blazor 컴포넌트 in-process 렌더링 스모크(단일 페이지 시 미렌더, 페이지 이동 콜백).
- `JwtAuthStateExpiryTests` — 만료 JWT → 익명, 유효 JWT → 인증(만료 중 저장의 토대, #297).
- `AuthTokenHandlerExpiryTests` — 저장 중 401 → 토큰 정리 + `returnUrl` 동반 로그인 리다이렉트(#117).
- `NoteServiceConflictTests` — 409 → Conflict, `?force=true` 덮어쓰기(두 탭 충돌, #221).
- bunit 전이 의존 AngleSharp 1.2.0의 NU1902는 테스트 전용 마크업 파싱에 국한되어 도달 불가 → 해당 프로젝트 한정 `NoWarn`(1.5.x는 bunit과 바이너리 비호환이라 승급 불가).

### 2) `Vanadium.Note.Web.E2E` — Playwright 시나리오 3종
- **Playwright + NUnit** 프로젝트 신설, 솔루션 등록.
- 시나리오: 만료 중 저장 / 두 탭 충돌 / 한글 멘션(IME 조합 커밋 `input` 이벤트).
- `PlaywrightScenarioBase`가 `VANADIUM_E2E_BASEURL` 미설정 시 픽스처 전체를 `Ignore` → 브라우저/구동 스택 없는 `dotnet test Vanadium.slnx`는 그대로 통과. 실행 절차는 `Vanadium.Note.Web.E2E/README.md`.

### 3) 부수
- `.gitignore`의 `*.e2e`(VS 트레이스) 글롭이 대소문자 무시 파일시스템에서 프로젝트 폴더를 삼키는 문제를 네거티브 규칙으로 예외 처리.
- CLAUDE.md의 "Web 테스트 부재" 기술 갱신.

## 완료 조건 검증
- [x] **빌드 클린** — `dotnet build Vanadium.slnx` → 경고 0 / 오류 0.
- [x] **bUnit 스모크 통과** — `Vanadium.Note.Web.Tests` 10/10 통과. REST.Tests 236 통과(기존 Postgres 전용 3건 skip 유지).
- [~] **Playwright 3종 실행·통과** — 시나리오 구현 완료, 무(無)-스택 환경에서는 설계상 self-ignore(실행되어 skip). **브라우저 설치 + 백엔드/프런트 구동이 필요한 실 green 검증은 이 환경에서 수행 불가 → 수동 확인 필요** (README 절차 참고).

## 범위 준수
- `Vanadium.Note.Shared` 공유 프로젝트 미도입(DTO 중복 유지). Postgres 전용 trigram 경로 미변경.
