### PR TITLE
#312 Web NoteItem 동시성 토큰 기본값을 default로 가드

### DIFF
--- a/Vanadium.Note.Web.Tests/Models/NoteItemConcurrencyTokenTests.cs
+++ b/Vanadium.Note.Web.Tests/Models/NoteItemConcurrencyTokenTests.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Vanadium.Note.Web.Models;
+using Vanadium.Note.Web.Services;
+using Xunit;
+
+namespace Vanadium.Note.Web.Tests.Models;
+
+/// <summary>
+/// Guards the Web DTO concurrency-token default (issue #312). <see cref="NoteItem.UpdatedAt"/> is
+/// the optimistic-concurrency token echoed to the server on save; its default must be an
+/// obviously-empty <c>default</c>, never a plausible-looking <c>DateTime.UtcNow</c>. A "now" default
+/// silently produced a version the server row could never match, so any construction that forgot to
+/// copy the tracked timestamp made every save 409. These tests fail if that default ever regresses
+/// back to a non-default value.
+/// </summary>
+public sealed class NoteItemConcurrencyTokenTests
+{
+    [Fact]
+    public void UpdatedAt_DefaultsToDefault_NotUtcNow()
+    {
+        var note = new NoteItem();
+
+        Assert.Equal(default, note.UpdatedAt);
+    }
+
+    /// <summary>
+    /// Captures the JSON actually sent to the server. Without the guard, a note constructed without
+    /// setting <see cref="NoteItem.UpdatedAt"/> would ship a fresh <c>DateTime.UtcNow</c> as the
+    /// concurrency version — a value the server row can never match — re-introducing the spurious
+    /// 409. With the guard the serialized version is <c>default</c> (the unmistakably-unset sentinel).
+    /// </summary>
+    [Fact]
+    public async Task Save_WithoutSettingUpdatedAt_SendsDefaultVersion_NotAFreshTimestamp()
+    {
+        var handler = new CapturingHandler();
+        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var service = new NoteService(client, NullLogger<NoteService>.Instance);
+
+        // A caller that forgets to copy the server-tracked timestamp (the exact mistake #312 guards).
+        var note = new NoteItem { Id = Guid.NewGuid(), Title = "no version set", Content = "<p>x</p>" };
+
+        await service.SaveAsync(note);
+
+        Assert.NotNull(handler.CapturedBody);
+        using var doc = JsonDocument.Parse(handler.CapturedBody!);
+        var sentUpdatedAt = doc.RootElement.GetProperty("updatedAt").GetDateTime();
+        Assert.Equal(default, sentUpdatedAt);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string? CapturedBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+                CapturedBody = await request.Content.ReadAsStringAsync(cancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new NoteItem { Title = "saved" }),
+            };
+        }
+    }
+}

--- a/Vanadium.Note.Web/Models/NoteItem.cs
+++ b/Vanadium.Note.Web/Models/NoteItem.cs
@@ -5,7 +5,17 @@ public class NoteItem
     public Guid Id { get; set; } = Guid.NewGuid();
     public string Title { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
-    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Optimistic-concurrency token echoed back to the server on save. It is a *semantic* field:
+    /// its value must always be the server-issued timestamp the client last saw, never a
+    /// client-invented one. The default is therefore <c>default</c> (an obviously-empty sentinel),
+    /// NOT <c>DateTime.UtcNow</c> — a plausible-looking "now" default silently produced a version
+    /// the server row could never match, so a construction that forgot to copy the tracked
+    /// timestamp made every save 409 (issue #312). <c>default</c> fails the same way but reads as
+    /// unmistakably unset; the server already rejects a default/zero version as a conflict (#221).
+    /// </summary>
+    public DateTime UpdatedAt { get; set; }
 
     /// <summary>Non-null = the note is archived; the editor switches to read-only mode.</summary>
     public DateTime? ArchivedAt { get; set; }


### PR DESCRIPTION
Closes #312

## 목적
Web `NoteItem.UpdatedAt`은 서버가 발급한 낙관적 동시성 토큰을 저장 시 되돌려 보내는 **의미 필드**다. 기본값이 `DateTime.UtcNow`였던 탓에, 서버 추적 타임스탬프를 복사하지 않은 채 `NoteItem`을 생성하면 서버 행과 절대 일치하지 않는 버전이 실려 매 저장이 409로 실패하는 버그가 실재했다(`SubNoteDialog.razor` 주석 흔적). 의미 필드 기본값을 `default`로 통일하는 가드를 추가한다.

## 변경 내용
- `Vanadium.Note.Web/Models/NoteItem.cs`: `UpdatedAt` 기본값 `= DateTime.UtcNow` 제거 → `default`. 왜 `default`여야 하는지(그럴듯한 "현재 시각" 대신 명백히 미설정 센티널) 설명하는 XML 주석 추가.
- `Vanadium.Note.Web.Tests/Models/NoteItemConcurrencyTokenTests.cs`: 회귀 테스트 2종 추가.

## 안전성
서버는 이미 default/zero 버전을 충돌로 거부하므로(#221) 저장 실패 동작은 동일하되, 값이 미설정임이 분명해진다. `UpdatedAt`을 설정하지 않는 생성 경로(`Board.razor`, `NoteEditor.razor`)는 모두 `Id = Guid.Empty`의 **생성**이라 서버가 토큰을 무시 → 영향 없음.

## 완료 조건 검증
- [x] 빌드 클린 — `dotnet build Vanadium.slnx` 0 errors (실행 중인 REST 앱/VS가 기본 bin을 잠가 출력 경로를 스크래치로 우회, 컴파일 자체는 클린)
- [x] Web DTO 동시성 토큰 기본값이 `DateTime.UtcNow` 등 비-default가 아니라 `default` — `NoteItem.UpdatedAt` 초기화자 제거
- [x] 회귀 테스트 존재 — `UpdatedAt_DefaultsToDefault_NotUtcNow`(기본값 검증) + `Save_WithoutSettingUpdatedAt_SendsDefaultVersion_NotAFreshTimestamp`(직렬화 페이로드에 가짜 타임스탬프 미전송 검증)
- [x] 테스트 통과 — REST.Tests 236 passed, Web.Tests 12 passed(신규 2종 포함), E2E 3 skipped(설계상)

## 범위
`NoteItem.cs` + 신규 테스트 파일만 변경. 공유 프로젝트 통합 없음, REST 무변경.