### PR TITLE
#343 노트 프로퍼티 기능 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,19 @@ Labels have an optional `LabelCategory`. Within a category, labels are mutually 
 
 `NoteItem.Labels` (`[NotMapped]`) is populated from `NoteLabels` navigation property by `NoteService.PopulateLabels()` — it is never persisted directly.
 
+### Note properties
+
+Notion-style **typed metadata** (issue #343): global `PropertyDefinition`s (name + `PropertyType` + `SortOrder`, and for Select kinds an ordered `PropertyOption` list) plus per-note **values**. Six v1 types: `Text`, `Number`, `Select`, `MultiSelect`, `Date`, `Checkbox`. Managed by `PropertyService` + `PropertiesController`; full design in `docs/plannings/note-property/note-properties-feature.md`.
+
+- **Storage is EAV, not JSONB** (decision §4.1): one `NotePropertyValues` row per (note, definition) with one nullable typed column each (`TextValue`/`NumberValue`/`DateValue`/`BoolValue`/`SelectedOptionId`), plus a `NotePropertySelectedOptions` join table for MultiSelect. This mirrors the `NoteLabel` pattern (composite PKs, matching soft-delete query filters, DB cascades) and keeps every filter/sort translatable + SQLite-testable. A composite alternate key `PropertyOption (DefinitionId, Id)` makes "option belongs to its definition" (INV-P3) a DB guarantee.
+- **INV-P1 (row ⇔ non-empty)**: a value row exists **iff** the value is non-empty. Exactly the typed column for the definition's type is set; Checkbox rows only ever hold `true` (writing `false` deletes the row), and MultiSelect rows always have ≥1 selection (empty selection deletes the row). `empty`/`notempty` filters therefore reduce to `NOT EXISTS`/`EXISTS`.
+- **INV-P4 `IgnoreQueryFilters()` rule**: `NotePropertyValue`/`NotePropertySelectedOption` carry `DeletedAt == null` query filters like `NoteLabel`. **Any definition-level scan — type-change guard, usage counts, MultiSelect empty-row cleanup — MUST use `IgnoreQueryFilters()`** or it undercounts recycle-bin notes' values and breaks lossless restore (see `PropertyService`). Note *value* endpoints use the default-filtered set (a recycle-bin note is invisible → 404).
+- **Values are server-owned (INV-P5)**: never read from the `POST/PUT /api/notes` payload (`Properties` is `[NotMapped]`, `PropertyValues` is `[JsonIgnore]`). The dedicated `PUT/DELETE /api/notes/{noteId}/properties/{definitionId}` endpoints are the only mutation path, and they do **not** bump `NoteItem.UpdatedAt` (same reasoning as label add/remove and `SetShare`).
+- **Read model**: `NoteItem.Properties` / `NoteSummary.Properties` (both `[NotMapped]`/projected) carry non-empty values ordered by definition `SortOrder`, populated like `Labels`.
+- **Filter/sort**: `GET /api/notes` + `/api/notes/summaries` take repeatable `pf={definitionId}:{op}[:{value}]` (grammar §6.3, AND semantics, max 20), applied in both search and non-search branches via `NoteService.ApplyPropertyFilters`. `GET /api/notes` also takes `sortBy=prop:{definitionId}` (non-search branch only; MultiSelect/unknown → 400); empty-valued notes always sort last regardless of direction. Malformed `pf`/`sortBy` → 400 (`NoteService.PropertyQueryException`).
+- **Caps** (server 400 + client mirror): 50 definitions, 100 options/definition, 500-char Text value, 20 `pf`/request.
+- **Frontend**: `NotePropertyPanel` (editor, between title and Tiptap body — pure Blazor, no `tiptapInterop`), `PropertyValueEditor`, `PropertyFilterBar` (Home/Board), `/properties` management page. Web `PropertyService` caches definitions per circuit (invalidated after any definition/option mutation).
+
 ### Frontend pages
 
 | Route | Component |
@@ -134,6 +147,7 @@ Labels have an optional `LabelCategory`. Within a category, labels are mutually 
 | `/board` | `Board.razor` — kanban-style board view |
 | `/editor` | `NoteEditor.razor` — new note |
 | `/editor/{id}` | `NoteEditor.razor` — edit existing note (read-only when archived) |
+| `/properties` | `Properties.razor` — property definition management (create / rename / type change / reorder / options / delete) |
 | `/archive` | `Archive.razor` — archive list (unarchive / delete to recycle bin) |
 | `/recycle-bin` | `RecycleBin.razor` — recycle bin list (restore / delete forever / empty) |
 | `/login` | `Login.razor` |

--- a/Vanadium.Note.REST.Tests/NoteServiceCancellationTests.cs
+++ b/Vanadium.Note.REST.Tests/NoteServiceCancellationTests.cs
@@ -25,7 +25,7 @@ public class NoteServiceCancellationTests
         await h.CreateNoteAsync("A");
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-            h.Notes.GetPaged(1, 30, null, "date", "desc", null, Cancelled()));
+            h.Notes.GetPaged(1, 30, null, "date", "desc", null, null, Cancelled()));
     }
 
     [Fact]

--- a/Vanadium.Note.REST.Tests/PropertyDefinitionServiceTests.cs
+++ b/Vanadium.Note.REST.Tests/PropertyDefinitionServiceTests.cs
@@ -1,0 +1,221 @@
+using Microsoft.EntityFrameworkCore;
+using Vanadium.Note.REST.Models;
+using Vanadium.Note.REST.Services;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Note Properties (issue #343) definition/option lifecycle: creation ordering + usage counts (T-1),
+/// caps (T-11), type-change guard incl. recycle-bin values (T-14), account wipe (T-16), duplicate
+/// names (T-18), definition/option delete cascades (T-15, T-17).
+/// </summary>
+public class PropertyDefinitionServiceTests
+{
+    // T-1
+    [Fact]
+    public async Task GetAll_OrdersBySortOrder_UsageZeroInitially()
+    {
+        using var h = new TestHost();
+        await h.Properties.CreateAsync("Priority", PropertyType.Number);
+        await h.Properties.CreateAsync("Due", PropertyType.Date);
+        var status = await h.Properties.CreateAsync("Status", PropertyType.Select);
+        await h.Properties.AddOptionAsync(status.Id, "Todo");
+
+        var defs = await h.Properties.GetAllAsync(includeUsage: true);
+
+        Assert.Equal(["Priority", "Due", "Status"], defs.Select(d => d.Name));
+        Assert.All(defs, d => Assert.Equal(0, d.ValueCount));
+        var statusDto = defs.Single(d => d.Name == "Status");
+        Assert.Equal(0, statusDto.Options.Single().NoteCount);
+    }
+
+    // T-18
+    [Fact]
+    public async Task Create_DuplicateName_CaseInsensitive_Throws()
+    {
+        using var h = new TestHost();
+        await h.Properties.CreateAsync("Priority", PropertyType.Number);
+        await Assert.ThrowsAsync<PropertyService.DuplicateNameException>(
+            () => h.Properties.CreateAsync("priority", PropertyType.Text));
+    }
+
+    // T-18
+    [Fact]
+    public async Task AddOption_DuplicateName_CaseInsensitive_Throws()
+    {
+        using var h = new TestHost();
+        var def = await h.Properties.CreateAsync("Status", PropertyType.Select);
+        await h.Properties.AddOptionAsync(def.Id, "Todo");
+        await Assert.ThrowsAsync<PropertyService.DuplicateNameException>(
+            () => h.Properties.AddOptionAsync(def.Id, "todo"));
+    }
+
+    // T-18
+    [Fact]
+    public async Task Rename_ToAnotherExistingName_Throws_ButSelfRenameOk()
+    {
+        using var h = new TestHost();
+        var a = await h.Properties.CreateAsync("Priority", PropertyType.Number);
+        await h.Properties.CreateAsync("Due", PropertyType.Date);
+
+        await Assert.ThrowsAsync<PropertyService.DuplicateNameException>(
+            () => h.Properties.UpdateAsync(a.Id, "due", PropertyType.Number, a.SortOrder));
+
+        // Renaming to a case variant of itself is allowed.
+        var updated = await h.Properties.UpdateAsync(a.Id, "PRIORITY", PropertyType.Number, a.SortOrder);
+        Assert.Equal("PRIORITY", updated!.Name);
+    }
+
+    // T-11
+    [Fact]
+    public async Task Caps_Definitions_50thSucceeds_51stThrows()
+    {
+        using var h = new TestHost();
+
+        for (var i = 0; i < PropertyService.MaxDefinitions; i++)
+            await h.Properties.CreateAsync($"P{i}", PropertyType.Text);
+        await Assert.ThrowsAsync<PropertyService.CapExceededException>(
+            () => h.Properties.CreateAsync("overflow", PropertyType.Text));
+    }
+
+    // T-11 (option cap on its own host so the definition cap doesn't interfere)
+    [Fact]
+    public async Task Caps_OptionsPerDefinition_BoundarySucceeds_OverflowThrows()
+    {
+        using var h = new TestHost();
+        var def = await h.Properties.CreateAsync("Sel", PropertyType.MultiSelect);
+        for (var i = 0; i < PropertyService.MaxOptionsPerDefinition; i++)
+            await h.Properties.AddOptionAsync(def.Id, $"o{i}");
+        await Assert.ThrowsAsync<PropertyService.CapExceededException>(
+            () => h.Properties.AddOptionAsync(def.Id, "overflow"));
+    }
+
+    // T-11
+    [Fact]
+    public async Task Caps_TextValue_501Chars_Throws_500Ok()
+    {
+        using var h = new TestHost();
+        var def = await h.Properties.CreateAsync("Notes", PropertyType.Text);
+        var note = await h.CreateNoteAsync();
+
+        var ok = await h.Properties.SetValueAsync(note.Id, def.Id,
+            new SetNotePropertyValueRequest { TextValue = new string('x', 500) });
+        Assert.Equal(new string('x', 500), ok!.TextValue);
+
+        await Assert.ThrowsAsync<PropertyService.PropertyValidationException>(
+            () => h.Properties.SetValueAsync(note.Id, def.Id,
+                new SetNotePropertyValueRequest { TextValue = new string('x', 501) }));
+    }
+
+    // T-14
+    [Fact]
+    public async Task TypeChange_ZeroValues_Ok_WithActiveValue_Blocked_WithRecycleBinValue_Blocked()
+    {
+        using var h = new TestHost();
+        var def = await h.Properties.CreateAsync("Priority", PropertyType.Number);
+
+        // Zero values: type change allowed.
+        var changed = await h.Properties.UpdateAsync(def.Id, "Priority", PropertyType.Text, def.SortOrder);
+        Assert.Equal(PropertyType.Text, changed!.Type);
+
+        // Back to Number, then attach a value on an ACTIVE note → change blocked.
+        await h.Properties.UpdateAsync(def.Id, "Priority", PropertyType.Number, def.SortOrder);
+        var note = await h.CreateNoteAsync();
+        await h.Properties.SetValueAsync(note.Id, def.Id, new SetNotePropertyValueRequest { NumberValue = 3 });
+        await Assert.ThrowsAsync<PropertyService.TypeChangeBlockedException>(
+            () => h.Properties.UpdateAsync(def.Id, "Priority", PropertyType.Text, def.SortOrder));
+
+        // Move the note to the recycle bin — the value must STILL block the change (E6, IgnoreQueryFilters).
+        await h.Notes.Delete(note.Id);
+        await Assert.ThrowsAsync<PropertyService.TypeChangeBlockedException>(
+            () => h.Properties.UpdateAsync(def.Id, "Priority", PropertyType.Text, def.SortOrder));
+    }
+
+    // T-15
+    [Fact]
+    public async Task DeleteDefinition_RemovesValuesEverywhere_RestoreLeavesNoOrphans()
+    {
+        using var h = new TestHost();
+        var def = await h.Properties.CreateAsync("Priority", PropertyType.Number);
+        var active = await h.CreateNoteAsync("active");
+        var deleted = await h.CreateNoteAsync("deleted");
+        await h.Properties.SetValueAsync(active.Id, def.Id, new SetNotePropertyValueRequest { NumberValue = 1 });
+        await h.Properties.SetValueAsync(deleted.Id, def.Id, new SetNotePropertyValueRequest { NumberValue = 2 });
+        await h.Notes.Delete(deleted.Id);
+
+        Assert.True(await h.Properties.DeleteAsync(def.Id));
+
+        Assert.Equal(0, await h.Db.NotePropertyValues.IgnoreQueryFilters().CountAsync());
+        await h.Notes.Restore(deleted.Id);
+        var restored = await h.Notes.Get(deleted.Id);
+        Assert.Empty(restored!.Properties);
+    }
+
+    // T-17
+    [Fact]
+    public async Task DeleteOption_RemovesSelectValues_CleansEmptyMultiSelectRows_IncludingRecycleBin()
+    {
+        using var h = new TestHost();
+        var multi = await h.Properties.CreateAsync("Tags", PropertyType.MultiSelect);
+        var a = await h.Properties.AddOptionAsync(multi.Id, "A");
+        var b = await h.Properties.AddOptionAsync(multi.Id, "B");
+
+        var keepsB = await h.CreateNoteAsync("keeps-b");   // {A, B} → loses A, keeps B (row survives)
+        var onlyA = await h.CreateNoteAsync("only-a");     // {A}    → loses last option (row cleaned up)
+        var binned = await h.CreateNoteAsync("binned");    // {A} on a recycle-bin note (E7)
+        await h.Properties.SetValueAsync(keepsB.Id, multi.Id, new SetNotePropertyValueRequest { OptionIds = [a!.Id, b!.Id] });
+        await h.Properties.SetValueAsync(onlyA.Id, multi.Id, new SetNotePropertyValueRequest { OptionIds = [a.Id] });
+        await h.Properties.SetValueAsync(binned.Id, multi.Id, new SetNotePropertyValueRequest { OptionIds = [a.Id] });
+        await h.Notes.Delete(binned.Id);
+
+        Assert.True(await h.Properties.DeleteOptionAsync(multi.Id, a.Id));
+
+        // keepsB still has a value row (with B); onlyA's row is gone; binned's row is gone too.
+        var keepsBValues = await h.Db.NotePropertyValues.IgnoreQueryFilters()
+            .Include(v => v.SelectedOptions)
+            .Where(v => v.DefinitionId == multi.Id).ToListAsync();
+        Assert.Single(keepsBValues);
+        Assert.Equal(keepsB.Id, keepsBValues[0].NoteId);
+        Assert.Equal(b.Id, keepsBValues[0].SelectedOptions.Single().OptionId);
+    }
+
+    // T-16
+    [Fact]
+    public async Task AccountWipe_RemovesAllPropertyTables()
+    {
+        using var h = new TestHost();
+        var multi = await h.Properties.CreateAsync("Tags", PropertyType.MultiSelect);
+        var a = await h.Properties.AddOptionAsync(multi.Id, "A");
+        var num = await h.Properties.CreateAsync("Priority", PropertyType.Number);
+        var note = await h.CreateNoteAsync();
+        await h.Properties.SetValueAsync(note.Id, multi.Id, new SetNotePropertyValueRequest { OptionIds = [a!.Id] });
+        await h.Properties.SetValueAsync(note.Id, num.Id, new SetNotePropertyValueRequest { NumberValue = 5 });
+
+        await h.Account.PurgeAllDataAsync();
+
+        Assert.Equal(0, await h.Db.PropertyDefinitions.IgnoreQueryFilters().CountAsync());
+        Assert.Equal(0, await h.Db.PropertyOptions.IgnoreQueryFilters().CountAsync());
+        Assert.Equal(0, await h.Db.NotePropertyValues.IgnoreQueryFilters().CountAsync());
+        Assert.Equal(0, await h.Db.NotePropertySelectedOptions.IgnoreQueryFilters().CountAsync());
+    }
+
+    [Fact]
+    public async Task AddOption_OnNonSelectDefinition_Throws()
+    {
+        using var h = new TestHost();
+        var text = await h.Properties.CreateAsync("Notes", PropertyType.Text);
+        await Assert.ThrowsAsync<PropertyService.PropertyValidationException>(
+            () => h.Properties.AddOptionAsync(text.Id, "nope"));
+    }
+
+    [Fact]
+    public async Task TypeChange_AwayFromSelect_DropsOptions()
+    {
+        using var h = new TestHost();
+        var def = await h.Properties.CreateAsync("Status", PropertyType.Select);
+        await h.Properties.AddOptionAsync(def.Id, "Todo");
+        await h.Properties.UpdateAsync(def.Id, "Status", PropertyType.Text, def.SortOrder);
+        Assert.Equal(0, await h.Db.PropertyOptions.CountAsync());
+    }
+}

--- a/Vanadium.Note.REST.Tests/PropertyFilterSortTests.cs
+++ b/Vanadium.Note.REST.Tests/PropertyFilterSortTests.cs
@@ -1,0 +1,217 @@
+using Vanadium.Note.REST.Models;
+using Vanadium.Note.REST.Services;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Note Properties (issue #343) filtering + sorting: per-op semantics (T-7), checkbox eq:false
+/// includes never-set notes (T-8), sort with empties-last + tiebreak (T-9), empty/notempty (T-10),
+/// malformed pf / sort validation (T-19), and pf on both GetPaged and GetAllSummaries (T-21).
+/// </summary>
+public class PropertyFilterSortTests
+{
+    private static List<PropertyFilter> Pf(params PropertyFilter[] f) => [.. f];
+
+    private static async Task<HashSet<Guid>> FilterIds(TestHost h, params PropertyFilter[] filters)
+    {
+        var result = await h.Notes.GetPaged(1, 50, null, "date", "desc", null, Pf(filters));
+        return result.Items.Select(n => n.Id).ToHashSet();
+    }
+
+    // T-7 (Number range), T-10 combined
+    [Fact]
+    public async Task NumberFilters_RangeAndEquality()
+    {
+        using var h = new TestHost();
+        var num = await h.Properties.CreateAsync("Priority", PropertyType.Number);
+        var one = await h.CreateNoteAsync("one");
+        var five = await h.CreateNoteAsync("five");
+        var ten = await h.CreateNoteAsync("ten");
+        var none = await h.CreateNoteAsync("none");
+        await h.Properties.SetValueAsync(one.Id, num.Id, new SetNotePropertyValueRequest { NumberValue = 1 });
+        await h.Properties.SetValueAsync(five.Id, num.Id, new SetNotePropertyValueRequest { NumberValue = 5 });
+        await h.Properties.SetValueAsync(ten.Id, num.Id, new SetNotePropertyValueRequest { NumberValue = 10 });
+
+        Assert.Equal([five.Id], await FilterIds(h, new PropertyFilter(num.Id, PropertyFilterOp.Eq, "5")));
+        Assert.Equal(new[] { one.Id, ten.Id }.ToHashSet(), await FilterIds(h, new PropertyFilter(num.Id, PropertyFilterOp.Ne, "5")));
+        // between 2 and 9 (two pf entries → AND)
+        Assert.Equal([five.Id], await FilterIds(h,
+            new PropertyFilter(num.Id, PropertyFilterOp.Gte, "2"),
+            new PropertyFilter(num.Id, PropertyFilterOp.Lt, "9")));
+        // ne never matches the empty note
+        Assert.DoesNotContain(none.Id, await FilterIds(h, new PropertyFilter(num.Id, PropertyFilterOp.Ne, "5")));
+    }
+
+    // T-7 (Date range)
+    [Fact]
+    public async Task DateFilters_Range()
+    {
+        using var h = new TestHost();
+        var due = await h.Properties.CreateAsync("Due", PropertyType.Date);
+        var jun = await h.CreateNoteAsync("jun");
+        var jul = await h.CreateNoteAsync("jul");
+        var aug = await h.CreateNoteAsync("aug");
+        await h.Properties.SetValueAsync(jun.Id, due.Id, new SetNotePropertyValueRequest { DateValue = new DateOnly(2026, 6, 15) });
+        await h.Properties.SetValueAsync(jul.Id, due.Id, new SetNotePropertyValueRequest { DateValue = new DateOnly(2026, 7, 15) });
+        await h.Properties.SetValueAsync(aug.Id, due.Id, new SetNotePropertyValueRequest { DateValue = new DateOnly(2026, 8, 15) });
+
+        Assert.Equal([jul.Id], await FilterIds(h,
+            new PropertyFilter(due.Id, PropertyFilterOp.Gte, "2026-07-01"),
+            new PropertyFilter(due.Id, PropertyFilterOp.Lt, "2026-08-01")));
+    }
+
+    // T-8
+    [Fact]
+    public async Task CheckboxFalse_MatchesUnchecked_AndNeverSet()
+    {
+        using var h = new TestHost();
+        var done = await h.Properties.CreateAsync("Done", PropertyType.Checkbox);
+        var checkedNote = await h.CreateNoteAsync("checked");
+        var neverSet = await h.CreateNoteAsync("never");
+        await h.Properties.SetValueAsync(checkedNote.Id, done.Id, new SetNotePropertyValueRequest { BoolValue = true });
+
+        Assert.Equal([checkedNote.Id], await FilterIds(h, new PropertyFilter(done.Id, PropertyFilterOp.Eq, "true")));
+        var falseIds = await FilterIds(h, new PropertyFilter(done.Id, PropertyFilterOp.Eq, "false"));
+        Assert.Contains(neverSet.Id, falseIds);
+        Assert.DoesNotContain(checkedNote.Id, falseIds);
+    }
+
+    // T-7 (Select/MultiSelect anyof)
+    [Fact]
+    public async Task SelectAndMultiSelect_EqAndAnyOf()
+    {
+        using var h = new TestHost();
+        var sel = await h.Properties.CreateAsync("Status", PropertyType.Select);
+        var todo = await h.Properties.AddOptionAsync(sel.Id, "Todo");
+        var doing = await h.Properties.AddOptionAsync(sel.Id, "Doing");
+        var multi = await h.Properties.CreateAsync("Tags", PropertyType.MultiSelect);
+        var x = await h.Properties.AddOptionAsync(multi.Id, "X");
+        var y = await h.Properties.AddOptionAsync(multi.Id, "Y");
+
+        var a = await h.CreateNoteAsync("a");
+        var b = await h.CreateNoteAsync("b");
+        await h.Properties.SetValueAsync(a.Id, sel.Id, new SetNotePropertyValueRequest { OptionId = todo!.Id });
+        await h.Properties.SetValueAsync(b.Id, sel.Id, new SetNotePropertyValueRequest { OptionId = doing!.Id });
+        await h.Properties.SetValueAsync(a.Id, multi.Id, new SetNotePropertyValueRequest { OptionIds = [x!.Id] });
+        await h.Properties.SetValueAsync(b.Id, multi.Id, new SetNotePropertyValueRequest { OptionIds = [x.Id, y!.Id] });
+
+        Assert.Equal([a.Id], await FilterIds(h, new PropertyFilter(sel.Id, PropertyFilterOp.Eq, todo.Id.ToString())));
+        Assert.Equal(new[] { a.Id, b.Id }.ToHashSet(),
+            await FilterIds(h, new PropertyFilter(sel.Id, PropertyFilterOp.AnyOf, $"{todo.Id},{doing.Id}")));
+        Assert.Equal([b.Id], await FilterIds(h, new PropertyFilter(multi.Id, PropertyFilterOp.Eq, y.Id.ToString())));
+        Assert.Equal(new[] { a.Id, b.Id }.ToHashSet(),
+            await FilterIds(h, new PropertyFilter(multi.Id, PropertyFilterOp.AnyOf, $"{x.Id}")));
+    }
+
+    // T-10
+    [Fact]
+    public async Task EmptyAndNotEmpty()
+    {
+        using var h = new TestHost();
+        var num = await h.Properties.CreateAsync("N", PropertyType.Number);
+        var has = await h.CreateNoteAsync("has");
+        var empty = await h.CreateNoteAsync("empty");
+        await h.Properties.SetValueAsync(has.Id, num.Id, new SetNotePropertyValueRequest { NumberValue = 1 });
+
+        Assert.Equal([has.Id], await FilterIds(h, new PropertyFilter(num.Id, PropertyFilterOp.NotEmpty, null)));
+        Assert.Equal([empty.Id], await FilterIds(h, new PropertyFilter(num.Id, PropertyFilterOp.Empty, null)));
+    }
+
+    // T-9
+    [Fact]
+    public async Task Sort_ByNumber_EmptiesLast_TiebreakByUpdatedAt()
+    {
+        using var h = new TestHost();
+        var num = await h.Properties.CreateAsync("Priority", PropertyType.Number);
+        var three = await h.CreateNoteAsync("three");
+        var one = await h.CreateNoteAsync("one");
+        var empty = await h.CreateNoteAsync("empty");
+        await h.Properties.SetValueAsync(three.Id, num.Id, new SetNotePropertyValueRequest { NumberValue = 3 });
+        await h.Properties.SetValueAsync(one.Id, num.Id, new SetNotePropertyValueRequest { NumberValue = 1 });
+
+        var asc = await h.Notes.GetPaged(1, 50, null, $"prop:{num.Id}", "asc", null);
+        Assert.Equal([one.Id, three.Id, empty.Id], asc.Items.Select(n => n.Id));
+
+        var desc = await h.Notes.GetPaged(1, 50, null, $"prop:{num.Id}", "desc", null);
+        // Empties still last, values descending.
+        Assert.Equal([three.Id, one.Id, empty.Id], desc.Items.Select(n => n.Id));
+    }
+
+    // T-9 (Select by option order)
+    [Fact]
+    public async Task Sort_BySelect_UsesOptionSortOrder()
+    {
+        using var h = new TestHost();
+        var sel = await h.Properties.CreateAsync("Status", PropertyType.Select);
+        var todo = await h.Properties.AddOptionAsync(sel.Id, "Todo");     // SortOrder 0
+        var doing = await h.Properties.AddOptionAsync(sel.Id, "Doing");   // SortOrder 1
+        var noteDoing = await h.CreateNoteAsync("doing");
+        var noteTodo = await h.CreateNoteAsync("todo");
+        await h.Properties.SetValueAsync(noteDoing.Id, sel.Id, new SetNotePropertyValueRequest { OptionId = doing!.Id });
+        await h.Properties.SetValueAsync(noteTodo.Id, sel.Id, new SetNotePropertyValueRequest { OptionId = todo!.Id });
+
+        var asc = await h.Notes.GetPaged(1, 50, null, $"prop:{sel.Id}", "asc", null);
+        Assert.Equal([noteTodo.Id, noteDoing.Id], asc.Items.Select(n => n.Id));
+    }
+
+    // T-19
+    [Fact]
+    public async Task Validation_MalformedFilters_And_BadSort_Throw()
+    {
+        using var h = new TestHost();
+        var num = await h.Properties.CreateAsync("N", PropertyType.Number);
+        var multi = await h.Properties.CreateAsync("Tags", PropertyType.MultiSelect);
+
+        // Unknown definition id.
+        await Assert.ThrowsAsync<NoteService.PropertyQueryException>(
+            () => h.Notes.GetPaged(1, 50, null, "date", "desc", null,
+                Pf(new PropertyFilter(Guid.NewGuid(), PropertyFilterOp.Eq, "1"))));
+        // Op/type mismatch (lt on nothing… actually contains-like op on Number is fine; use anyof on Number).
+        await Assert.ThrowsAsync<NoteService.PropertyQueryException>(
+            () => h.Notes.GetPaged(1, 50, null, "date", "desc", null,
+                Pf(new PropertyFilter(num.Id, PropertyFilterOp.AnyOf, "x"))));
+        // Unparsable number.
+        await Assert.ThrowsAsync<NoteService.PropertyQueryException>(
+            () => h.Notes.GetPaged(1, 50, null, "date", "desc", null,
+                Pf(new PropertyFilter(num.Id, PropertyFilterOp.Gt, "notanumber"))));
+        // Sort by unknown definition.
+        await Assert.ThrowsAsync<NoteService.PropertyQueryException>(
+            () => h.Notes.GetPaged(1, 50, null, $"prop:{Guid.NewGuid()}", "asc", null));
+        // Sort by MultiSelect is rejected.
+        await Assert.ThrowsAsync<NoteService.PropertyQueryException>(
+            () => h.Notes.GetPaged(1, 50, null, $"prop:{multi.Id}", "asc", null));
+    }
+
+    // T-11 (filter cap)
+    [Fact]
+    public async Task Filter_Over20_Throws()
+    {
+        using var h = new TestHost();
+        var num = await h.Properties.CreateAsync("N", PropertyType.Number);
+        var filters = Enumerable.Range(0, 21)
+            .Select(_ => new PropertyFilter(num.Id, PropertyFilterOp.Gt, "0")).ToArray();
+        await Assert.ThrowsAsync<NoteService.PropertyQueryException>(
+            () => h.Notes.GetPaged(1, 50, null, "date", "desc", null, Pf(filters)));
+    }
+
+    // T-21
+    [Fact]
+    public async Task Pf_AppliesTo_GetAllSummaries()
+    {
+        using var h = new TestHost();
+        var done = await h.Properties.CreateAsync("Done", PropertyType.Checkbox);
+        var yes = await h.CreateNoteAsync("yes");
+        var no = await h.CreateNoteAsync("no");
+        await h.Properties.SetValueAsync(yes.Id, done.Id, new SetNotePropertyValueRequest { BoolValue = true });
+
+        var summaries = await h.Notes.GetAllSummaries(null, Pf(new PropertyFilter(done.Id, PropertyFilterOp.Eq, "true")));
+        Assert.Equal([yes.Id], summaries.Select(s => s.Id));
+        // The projected Properties carry the value for list chips.
+        Assert.True(summaries.Single().Properties.Single(p => p.DefinitionId == done.Id).BoolValue);
+    }
+
+    // Note: pf + trigram ILIKE search composition in GetPaged's search branch is PostgreSQL-only
+    // (EF.Functions.ILike is not translated by the SQLite provider), so it stays in manual scope —
+    // mirroring the repo's other skipped search tests.
+}

--- a/Vanadium.Note.REST.Tests/PropertyValueServiceTests.cs
+++ b/Vanadium.Note.REST.Tests/PropertyValueServiceTests.cs
@@ -1,0 +1,216 @@
+using Microsoft.EntityFrameworkCore;
+using Vanadium.Note.REST.Models;
+using Vanadium.Note.REST.Services;
+using Xunit;
+
+namespace Vanadium.Note.REST.Tests;
+
+/// <summary>
+/// Note Properties (issue #343) value upsert/clear + read-model projection: all six kinds (T-2),
+/// overwrite normalization (T-3), idempotent clear (T-4), checkbox false (T-5), multiselect replace
+/// (T-6), payload validation (T-12), archive/recycle-bin/unknown guards (T-13), soft-delete round
+/// trip (T-20).
+/// </summary>
+public class PropertyValueServiceTests
+{
+    // T-2
+    [Fact]
+    public async Task SetValue_AllSixKinds_ProjectedIntoNote_OrderedBySortOrder()
+    {
+        using var h = new TestHost();
+        var text = await h.Properties.CreateAsync("Text", PropertyType.Text);
+        var number = await h.Properties.CreateAsync("Number", PropertyType.Number);
+        var select = await h.Properties.CreateAsync("Select", PropertyType.Select);
+        var multi = await h.Properties.CreateAsync("Multi", PropertyType.MultiSelect);
+        var date = await h.Properties.CreateAsync("Date", PropertyType.Date);
+        var check = await h.Properties.CreateAsync("Check", PropertyType.Checkbox);
+        var sOpt = await h.Properties.AddOptionAsync(select.Id, "S1");
+        var m1 = await h.Properties.AddOptionAsync(multi.Id, "M1");
+        var m2 = await h.Properties.AddOptionAsync(multi.Id, "M2");
+
+        var note = await h.CreateNoteAsync();
+        await h.Properties.SetValueAsync(note.Id, text.Id, new SetNotePropertyValueRequest { TextValue = "hello" });
+        await h.Properties.SetValueAsync(note.Id, number.Id, new SetNotePropertyValueRequest { NumberValue = 42 });
+        await h.Properties.SetValueAsync(note.Id, select.Id, new SetNotePropertyValueRequest { OptionId = sOpt!.Id });
+        await h.Properties.SetValueAsync(note.Id, multi.Id, new SetNotePropertyValueRequest { OptionIds = [m1!.Id, m2!.Id] });
+        await h.Properties.SetValueAsync(note.Id, date.Id, new SetNotePropertyValueRequest { DateValue = new DateOnly(2026, 8, 1) });
+        await h.Properties.SetValueAsync(note.Id, check.Id, new SetNotePropertyValueRequest { BoolValue = true });
+
+        var loaded = await h.Notes.Get(note.Id);
+        var props = loaded!.Properties;
+
+        Assert.Equal(["Text", "Number", "Select", "Multi", "Date", "Check"], props.Select(p => p.Name));
+        Assert.Equal("hello", props[0].TextValue);
+        Assert.Equal(42, props[1].NumberValue);
+        Assert.Equal(sOpt.Id, props[2].OptionId);
+        Assert.Equal(new[] { m1.Id, m2.Id }.OrderBy(x => x), props[3].OptionIds.OrderBy(x => x));
+        Assert.Equal(new DateOnly(2026, 8, 1), props[4].DateValue);
+        Assert.True(props[5].BoolValue);
+    }
+
+    // T-3
+    [Fact]
+    public async Task Overwrite_SameDefinition_UpdatesSingleRow_NullsOtherColumns()
+    {
+        using var h = new TestHost();
+        var num = await h.Properties.CreateAsync("N", PropertyType.Number);
+        var note = await h.CreateNoteAsync();
+        await h.Properties.SetValueAsync(note.Id, num.Id, new SetNotePropertyValueRequest { NumberValue = 1 });
+        await h.Properties.SetValueAsync(note.Id, num.Id, new SetNotePropertyValueRequest { NumberValue = 2 });
+
+        var rows = await h.Db.NotePropertyValues.Where(v => v.DefinitionId == num.Id).ToListAsync();
+        Assert.Single(rows);
+        Assert.Equal(2, rows[0].NumberValue);
+        Assert.Null(rows[0].TextValue);
+        Assert.Null(rows[0].BoolValue);
+    }
+
+    // T-4
+    [Fact]
+    public async Task Clear_RemovesRow_SecondClearStillSucceeds()
+    {
+        using var h = new TestHost();
+        var num = await h.Properties.CreateAsync("N", PropertyType.Number);
+        var note = await h.CreateNoteAsync();
+        await h.Properties.SetValueAsync(note.Id, num.Id, new SetNotePropertyValueRequest { NumberValue = 1 });
+
+        Assert.True(await h.Properties.ClearValueAsync(note.Id, num.Id));
+        Assert.Equal(0, await h.Db.NotePropertyValues.CountAsync());
+        Assert.True(await h.Properties.ClearValueAsync(note.Id, num.Id));   // idempotent
+    }
+
+    // T-5
+    [Fact]
+    public async Task Checkbox_True_ThenFalse_DeletesRow()
+    {
+        using var h = new TestHost();
+        var check = await h.Properties.CreateAsync("Done", PropertyType.Checkbox);
+        var note = await h.CreateNoteAsync();
+
+        await h.Properties.SetValueAsync(note.Id, check.Id, new SetNotePropertyValueRequest { BoolValue = true });
+        Assert.Equal(1, await h.Db.NotePropertyValues.CountAsync());
+
+        await h.Properties.SetValueAsync(note.Id, check.Id, new SetNotePropertyValueRequest { BoolValue = false });
+        Assert.Equal(0, await h.Db.NotePropertyValues.CountAsync());
+    }
+
+    // T-6
+    [Fact]
+    public async Task MultiSelect_ReplaceThenEmpty_NormalizesSelections()
+    {
+        using var h = new TestHost();
+        var multi = await h.Properties.CreateAsync("Tags", PropertyType.MultiSelect);
+        var a = await h.Properties.AddOptionAsync(multi.Id, "A");
+        var b = await h.Properties.AddOptionAsync(multi.Id, "B");
+        var c = await h.Properties.AddOptionAsync(multi.Id, "C");
+        var note = await h.CreateNoteAsync();
+
+        await h.Properties.SetValueAsync(note.Id, multi.Id, new SetNotePropertyValueRequest { OptionIds = [a!.Id, b!.Id] });
+        await h.Properties.SetValueAsync(note.Id, multi.Id, new SetNotePropertyValueRequest { OptionIds = [b.Id, c!.Id] });
+
+        var selections = await h.Db.NotePropertySelectedOptions.Select(s => s.OptionId).ToListAsync();
+        Assert.Equal(new[] { b.Id, c.Id }.OrderBy(x => x), selections.OrderBy(x => x));
+
+        // Empty list clears the whole value row.
+        await h.Properties.SetValueAsync(note.Id, multi.Id, new SetNotePropertyValueRequest { OptionIds = [] });
+        Assert.Equal(0, await h.Db.NotePropertyValues.CountAsync());
+        Assert.Equal(0, await h.Db.NotePropertySelectedOptions.CountAsync());
+    }
+
+    // T-12
+    [Fact]
+    public async Task Validation_WrongTypedPayloads_Throw_NothingPersisted()
+    {
+        using var h = new TestHost();
+        var number = await h.Properties.CreateAsync("N", PropertyType.Number);
+        var select = await h.Properties.CreateAsync("S", PropertyType.Select);
+        var other = await h.Properties.CreateAsync("Other", PropertyType.Select);
+        var optOther = await h.Properties.AddOptionAsync(other.Id, "X");
+        var note = await h.CreateNoteAsync();
+
+        // Wrong member for the type (Text on a Number).
+        await Assert.ThrowsAsync<PropertyService.PropertyValidationException>(
+            () => h.Properties.SetValueAsync(note.Id, number.Id, new SetNotePropertyValueRequest { TextValue = "x" }));
+        // Two members set.
+        await Assert.ThrowsAsync<PropertyService.PropertyValidationException>(
+            () => h.Properties.SetValueAsync(note.Id, number.Id,
+                new SetNotePropertyValueRequest { NumberValue = 1, TextValue = "x" }));
+        // Non-finite number.
+        await Assert.ThrowsAsync<PropertyService.PropertyValidationException>(
+            () => h.Properties.SetValueAsync(note.Id, number.Id,
+                new SetNotePropertyValueRequest { NumberValue = double.NaN }));
+        // Empty text (must use DELETE).
+        var text = await h.Properties.CreateAsync("T", PropertyType.Text);
+        await Assert.ThrowsAsync<PropertyService.PropertyValidationException>(
+            () => h.Properties.SetValueAsync(note.Id, text.Id, new SetNotePropertyValueRequest { TextValue = "   " }));
+        // Option from another definition.
+        await Assert.ThrowsAsync<PropertyService.PropertyValidationException>(
+            () => h.Properties.SetValueAsync(note.Id, select.Id,
+                new SetNotePropertyValueRequest { OptionId = optOther!.Id }));
+
+        Assert.Equal(0, await h.Db.NotePropertyValues.CountAsync());
+    }
+
+    // T-13
+    [Fact]
+    public async Task Guards_Archived403_RecycleBin404_UnknownDefinition404()
+    {
+        using var h = new TestHost();
+        var def = await h.Properties.CreateAsync("N", PropertyType.Number);
+
+        // Archived note → NoteArchivedException (403).
+        var archived = await h.CreateNoteAsync();
+        await h.Notes.Archive(archived.Id);
+        await Assert.ThrowsAsync<PropertyService.NoteArchivedException>(
+            () => h.Properties.SetValueAsync(archived.Id, def.Id, new SetNotePropertyValueRequest { NumberValue = 1 }));
+
+        // Recycle-bin note → invisible → null (404).
+        var deleted = await h.CreateNoteAsync();
+        await h.Notes.Delete(deleted.Id);
+        Assert.Null(await h.Properties.SetValueAsync(deleted.Id, def.Id, new SetNotePropertyValueRequest { NumberValue = 1 }));
+
+        // Unknown definition on an active note → null (404).
+        var active = await h.CreateNoteAsync();
+        Assert.Null(await h.Properties.SetValueAsync(active.Id, Guid.NewGuid(), new SetNotePropertyValueRequest { NumberValue = 1 }));
+    }
+
+    // T-20
+    [Fact]
+    public async Task SoftDelete_HidesValuesFromFilters_RestoreBringsThemBack()
+    {
+        using var h = new TestHost();
+        var def = await h.Properties.CreateAsync("Done", PropertyType.Checkbox);
+        var note = await h.CreateNoteAsync();
+        await h.Properties.SetValueAsync(note.Id, def.Id, new SetNotePropertyValueRequest { BoolValue = true });
+
+        var filter = new List<PropertyFilter> { new(def.Id, PropertyFilterOp.Eq, "true") };
+
+        var before = await h.Notes.GetPaged(1, 50, null, "date", "desc", null, filter);
+        Assert.Contains(before.Items, n => n.Id == note.Id);
+
+        await h.Notes.Delete(note.Id);
+        var during = await h.Notes.GetPaged(1, 50, null, "date", "desc", null, filter);
+        Assert.DoesNotContain(during.Items, n => n.Id == note.Id);
+
+        await h.Notes.Restore(note.Id);
+        var after = await h.Notes.GetPaged(1, 50, null, "date", "desc", null, filter);
+        Assert.Contains(after.Items, n => n.Id == note.Id);
+    }
+
+    // T-13 (clear guards)
+    [Fact]
+    public async Task Clear_Archived403_RecycleBin404()
+    {
+        using var h = new TestHost();
+        var def = await h.Properties.CreateAsync("N", PropertyType.Number);
+
+        var archived = await h.CreateNoteAsync();
+        await h.Notes.Archive(archived.Id);
+        await Assert.ThrowsAsync<PropertyService.NoteArchivedException>(
+            () => h.Properties.ClearValueAsync(archived.Id, def.Id));
+
+        var deleted = await h.CreateNoteAsync();
+        await h.Notes.Delete(deleted.Id);
+        Assert.False(await h.Properties.ClearValueAsync(deleted.Id, def.Id));
+    }
+}

--- a/Vanadium.Note.REST.Tests/TestHost.cs
+++ b/Vanadium.Note.REST.Tests/TestHost.cs
@@ -23,6 +23,7 @@ public sealed class TestHost : IDisposable
     public NoteDbContext Db { get; }
     public NoteService Notes { get; }
     public LabelService Labels { get; }
+    public PropertyService Properties { get; }
     public AccountService Account { get; }
     public FileCleanupService FileCleanup { get; }
     public OrphanReferenceTracker OrphanTracker { get; }
@@ -57,6 +58,7 @@ public sealed class TestHost : IDisposable
         var share = new NoteShareService(Db, sanitizer, NullLogger<NoteShareService>.Instance);
         Notes = new NoteService(Db, sanitizer, lifecycle, share, NullLogger<NoteService>.Instance);
         Labels = new LabelService(Db, NullLogger<LabelService>.Instance);
+        Properties = new PropertyService(Db, NullLogger<PropertyService>.Instance);
         Account = new AccountService(Db, NullLogger<AccountService>.Instance);
     }
 

--- a/Vanadium.Note.REST/Controllers/NotesController.cs
+++ b/Vanadium.Note.REST/Controllers/NotesController.cs
@@ -21,6 +21,7 @@ public class NotesController(NoteService noteService, LabelService labelService,
         [FromQuery] string sortBy = "date",
         [FromQuery] string sortDir = "desc",
         [FromQuery] Guid[]? labelIds = null,
+        [FromQuery] string[]? pf = null,
         [FromQuery] bool includeLabels = false,
         CancellationToken ct = default)
     {
@@ -28,10 +29,19 @@ public class NotesController(NoteService noteService, LabelService labelService,
         pageSize = Math.Clamp(pageSize, 1, 200);
         if (labelIds is { Length: > 50 })
             return Problem(detail: "Too many label IDs (maximum 50).", statusCode: StatusCodes.Status400BadRequest);
-        var result = await noteService.GetPaged(page, pageSize, search, sortBy, sortDir, labelIds, ct);
-        if (includeLabels)
-            result.Labels = await labelService.GetAllLabelsAsync();
-        return Ok(result);
+        try
+        {
+            var propertyFilters = ParsePropertyFilters(pf);
+            var result = await noteService.GetPaged(page, pageSize, search, sortBy, sortDir, labelIds, propertyFilters, ct);
+            if (includeLabels)
+                result.Labels = await labelService.GetAllLabelsAsync();
+            return Ok(result);
+        }
+        catch (NoteService.PropertyQueryException ex)
+        {
+            logger.LogWarning("Rejected note list query — invalid property filter/sort: {Message}", ex.Message);
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
     }
 
     [HttpGet("mention-search")]
@@ -61,11 +71,55 @@ public class NotesController(NoteService noteService, LabelService labelService,
     [HttpGet("summaries")]
     public async Task<ActionResult<List<NoteSummary>>> GetSummaries(
         [FromQuery] Guid[]? labelIds = null,
+        [FromQuery] string[]? pf = null,
         CancellationToken ct = default)
     {
         if (labelIds is { Length: > 50 })
             return Problem(detail: "Too many label IDs (maximum 50).", statusCode: StatusCodes.Status400BadRequest);
-        return Ok(await noteService.GetAllSummaries(labelIds, ct));
+        try
+        {
+            var propertyFilters = ParsePropertyFilters(pf);
+            return Ok(await noteService.GetAllSummaries(labelIds, propertyFilters, ct));
+        }
+        catch (NoteService.PropertyQueryException ex)
+        {
+            logger.LogWarning("Rejected board summaries query — invalid property filter: {Message}", ex.Message);
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    /// <summary>Parses repeatable <c>pf={definitionId}:{op}[:{value}]</c> query entries (§6.3). The
+    /// value is split with a limit of 3 so a colon inside a Text value is preserved. Malformed
+    /// triplets / unknown operators throw <see cref="NoteService.PropertyQueryException"/> (→ 400);
+    /// definition/type/value validation happens in the service.</summary>
+    private static List<PropertyFilter>? ParsePropertyFilters(string[]? pf)
+    {
+        if (pf is null || pf.Length == 0) return null;
+        var filters = new List<PropertyFilter>(pf.Length);
+        foreach (var entry in pf)
+        {
+            var parts = entry.Split(':', 3);
+            if (parts.Length < 2)
+                throw new NoteService.PropertyQueryException($"Malformed property filter '{entry}'.");
+            if (!Guid.TryParse(parts[0], out var definitionId))
+                throw new NoteService.PropertyQueryException($"'{parts[0]}' is not a valid property definition id.");
+            var op = parts[1].ToLowerInvariant() switch
+            {
+                "eq" => PropertyFilterOp.Eq,
+                "ne" => PropertyFilterOp.Ne,
+                "lt" => PropertyFilterOp.Lt,
+                "lte" => PropertyFilterOp.Lte,
+                "gt" => PropertyFilterOp.Gt,
+                "gte" => PropertyFilterOp.Gte,
+                "empty" => PropertyFilterOp.Empty,
+                "notempty" => PropertyFilterOp.NotEmpty,
+                "anyof" => PropertyFilterOp.AnyOf,
+                _ => throw new NoteService.PropertyQueryException($"Unknown filter operator '{parts[1]}'.")
+            };
+            var value = parts.Length == 3 ? parts[2] : null;
+            filters.Add(new PropertyFilter(definitionId, op, value));
+        }
+        return filters;
     }
 
     [HttpGet("{id:guid}/children")]

--- a/Vanadium.Note.REST/Controllers/PropertiesController.cs
+++ b/Vanadium.Note.REST/Controllers/PropertiesController.cs
@@ -1,0 +1,156 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Vanadium.Note.REST.Models;
+using Vanadium.Note.REST.Services;
+
+namespace Vanadium.Note.REST.Controllers;
+
+/// <summary>
+/// Note Properties (issue #343): definition CRUD, option CRUD, and per-note value upsert/clear.
+/// Hosts both the definition/option routes and the note-value routes, mirroring how
+/// <see cref="LabelsController"/> hosts label CRUD plus note-label assignment.
+/// </summary>
+[Authorize]
+[ApiController]
+public class PropertiesController(PropertyService properties, ILogger<PropertiesController> logger) : ControllerBase
+{
+    // ── Definitions ──────────────────────────────────────────────────────────────
+
+    [HttpGet("api/properties")]
+    public async Task<ActionResult<IEnumerable<PropertyDefinitionDto>>> GetAll(
+        [FromQuery] bool includeUsage = false, CancellationToken ct = default) =>
+        Ok(await properties.GetAllAsync(includeUsage, ct));
+
+    [HttpPost("api/properties")]
+    public async Task<ActionResult<PropertyDefinitionDto>> Create(
+        [FromBody] CreatePropertyDefinitionRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var result = await properties.CreateAsync(req.Name, req.Type, ct);
+            return Created($"api/properties/{result.Id}", result);
+        }
+        catch (PropertyService.DuplicateNameException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+        catch (Exception ex) when (ex is PropertyService.CapExceededException or PropertyService.PropertyValidationException)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    [HttpPut("api/properties/{id:guid}")]
+    public async Task<ActionResult<PropertyDefinitionDto>> Update(
+        Guid id, [FromBody] UpdatePropertyDefinitionRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var result = await properties.UpdateAsync(id, req.Name, req.Type, req.SortOrder, ct);
+            if (result is null) return NotFound();
+            return Ok(result);
+        }
+        catch (Exception ex) when (ex is PropertyService.DuplicateNameException or PropertyService.TypeChangeBlockedException)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+        catch (PropertyService.PropertyValidationException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    [HttpDelete("api/properties/{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        if (!await properties.DeleteAsync(id, ct)) return NotFound();
+        return NoContent();
+    }
+
+    // ── Options ──────────────────────────────────────────────────────────────────
+
+    [HttpPost("api/properties/{id:guid}/options")]
+    public async Task<ActionResult<PropertyOptionDto>> AddOption(
+        Guid id, [FromBody] CreatePropertyOptionRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var result = await properties.AddOptionAsync(id, req.Name, ct);
+            if (result is null) return NotFound();
+            return Created($"api/properties/{id}/options/{result.Id}", result);
+        }
+        catch (PropertyService.DuplicateNameException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+        catch (Exception ex) when (ex is PropertyService.CapExceededException or PropertyService.PropertyValidationException)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    [HttpPut("api/properties/{id:guid}/options/{optionId:guid}")]
+    public async Task<ActionResult<PropertyOptionDto>> UpdateOption(
+        Guid id, Guid optionId, [FromBody] UpdatePropertyOptionRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var result = await properties.UpdateOptionAsync(id, optionId, req.Name, req.SortOrder, ct);
+            if (result is null) return NotFound();
+            return Ok(result);
+        }
+        catch (PropertyService.DuplicateNameException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+        catch (PropertyService.PropertyValidationException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    [HttpDelete("api/properties/{id:guid}/options/{optionId:guid}")]
+    public async Task<IActionResult> DeleteOption(Guid id, Guid optionId, CancellationToken ct)
+    {
+        if (!await properties.DeleteOptionAsync(id, optionId, ct)) return NotFound();
+        return NoContent();
+    }
+
+    // ── Note values ────────────────────────────────────────────────────────────────
+
+    [HttpPut("api/notes/{noteId:guid}/properties/{definitionId:guid}")]
+    public async Task<ActionResult<NotePropertyValueDto>> SetValue(
+        Guid noteId, Guid definitionId, [FromBody] SetNotePropertyValueRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var result = await properties.SetValueAsync(noteId, definitionId, req, ct);
+            if (result is null) return NotFound();
+            return Ok(result);
+        }
+        catch (PropertyService.NoteArchivedException)
+        {
+            logger.LogWarning("SetValue rejected — note {NoteId} is archived and read-only.", noteId);
+            return Problem(detail: "Note is archived and read-only.", statusCode: StatusCodes.Status403Forbidden);
+        }
+        catch (PropertyService.PropertyValidationException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    [HttpDelete("api/notes/{noteId:guid}/properties/{definitionId:guid}")]
+    public async Task<IActionResult> ClearValue(Guid noteId, Guid definitionId, CancellationToken ct)
+    {
+        try
+        {
+            if (!await properties.ClearValueAsync(noteId, definitionId, ct)) return NotFound();
+            return NoContent();
+        }
+        catch (PropertyService.NoteArchivedException)
+        {
+            logger.LogWarning("ClearValue rejected — note {NoteId} is archived and read-only.", noteId);
+            return Problem(detail: "Note is archived and read-only.", statusCode: StatusCodes.Status403Forbidden);
+        }
+    }
+}

--- a/Vanadium.Note.REST/Data/NoteDbContext.cs
+++ b/Vanadium.Note.REST/Data/NoteDbContext.cs
@@ -12,6 +12,10 @@ public class NoteDbContext(DbContextOptions<NoteDbContext> options) : DbContext(
     public DbSet<NoteLabel> NoteLabels => Set<NoteLabel>();
     public DbSet<UserSettings> UserSettings => Set<UserSettings>();
     public DbSet<ApiToken> ApiTokens => Set<ApiToken>();
+    public DbSet<PropertyDefinition> PropertyDefinitions => Set<PropertyDefinition>();
+    public DbSet<PropertyOption> PropertyOptions => Set<PropertyOption>();
+    public DbSet<NotePropertyValue> NotePropertyValues => Set<NotePropertyValue>();
+    public DbSet<NotePropertySelectedOption> NotePropertySelectedOptions => Set<NotePropertySelectedOption>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -94,5 +98,82 @@ public class NoteDbContext(DbContextOptions<NoteDbContext> options) : DbContext(
         modelBuilder.Entity<ApiToken>()
             .HasIndex(t => t.TokenHash)
             .IsUnique();
+
+        ConfigureProperties(modelBuilder);
+    }
+
+    /// <summary>Note Properties (issue #343): the EAV value store mirroring the NoteLabel pattern
+    /// (composite PKs, matching soft-delete query filters, DB cascades). See
+    /// docs/plannings/note-property/note-properties-feature.md §4.4–4.5.</summary>
+    private static void ConfigureProperties(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<NotePropertyValue>()
+            .HasKey(v => new { v.NoteId, v.DefinitionId });
+
+        modelBuilder.Entity<NotePropertyValue>()
+            .HasOne(v => v.Note)
+            .WithMany(n => n.PropertyValues)
+            .HasForeignKey(v => v.NoteId)
+            .OnDelete(DeleteBehavior.Cascade);          // note hard-delete wipes its values
+
+        modelBuilder.Entity<NotePropertyValue>()
+            .HasOne(v => v.Definition)
+            .WithMany()
+            .HasForeignKey(v => v.DefinitionId)
+            .OnDelete(DeleteBehavior.Cascade);          // definition delete wipes all values (FR-7)
+
+        // INV-P3 at the DB level: (DefinitionId, SelectedOptionId) must match an option
+        // of the same definition. Requires the alternate key below on PropertyOption.
+        modelBuilder.Entity<NotePropertyValue>()
+            .HasOne(v => v.SelectedOption)
+            .WithMany()
+            .HasForeignKey(v => new { v.DefinitionId, v.SelectedOptionId })
+            .HasPrincipalKey(o => new { o.DefinitionId, o.Id })
+            .OnDelete(DeleteBehavior.Cascade);          // option delete removes Select value rows (FR-8)
+
+        modelBuilder.Entity<NotePropertySelectedOption>()
+            .HasKey(s => new { s.NoteId, s.DefinitionId, s.OptionId });
+
+        modelBuilder.Entity<NotePropertySelectedOption>()
+            .HasOne(s => s.Value)
+            .WithMany(v => v.SelectedOptions)
+            .HasForeignKey(s => new { s.NoteId, s.DefinitionId })
+            .OnDelete(DeleteBehavior.Cascade);          // clearing a value clears its selections
+
+        modelBuilder.Entity<NotePropertySelectedOption>()
+            .HasOne(s => s.Option)
+            .WithMany()
+            .HasForeignKey(s => new { s.DefinitionId, s.OptionId })
+            .HasPrincipalKey(o => new { o.DefinitionId, o.Id })
+            .OnDelete(DeleteBehavior.Cascade);          // option delete removes selections (FR-8)
+
+        modelBuilder.Entity<PropertyOption>()
+            .HasOne(o => o.Definition)
+            .WithMany(d => d.Options)
+            .HasForeignKey(o => o.DefinitionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // INV-P4: mirror the NoteLabel soft-delete parity filters so default queries
+        // never see recycle-bin values. Definition-level scans must use IgnoreQueryFilters().
+        modelBuilder.Entity<NotePropertyValue>()
+            .HasQueryFilter(v => v.Note.DeletedAt == null);
+        modelBuilder.Entity<NotePropertySelectedOption>()
+            .HasQueryFilter(s => s.Value.Note.DeletedAt == null);
+
+        // One composite index per filter/sort shape: "for definition D, compare/order <typed column>".
+        modelBuilder.Entity<NotePropertyValue>()
+            .HasIndex(v => new { v.DefinitionId, v.NumberValue });
+        modelBuilder.Entity<NotePropertyValue>()
+            .HasIndex(v => new { v.DefinitionId, v.DateValue });
+        modelBuilder.Entity<NotePropertyValue>()
+            .HasIndex(v => new { v.DefinitionId, v.TextValue });
+        modelBuilder.Entity<NotePropertyValue>()
+            .HasIndex(v => new { v.DefinitionId, v.SelectedOptionId });
+        modelBuilder.Entity<NotePropertyValue>()
+            .HasIndex(v => new { v.DefinitionId, v.BoolValue });
+
+        // Option usage counts and option-delete fan-out.
+        modelBuilder.Entity<NotePropertySelectedOption>()
+            .HasIndex(s => s.OptionId);
     }
 }

--- a/Vanadium.Note.REST/Migrations/20260729083715_AddNoteProperties.Designer.cs
+++ b/Vanadium.Note.REST/Migrations/20260729083715_AddNoteProperties.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Vanadium.Note.REST.Data;
@@ -11,9 +12,11 @@ using Vanadium.Note.REST.Data;
 namespace Vanadium.Note.REST.Migrations
 {
     [DbContext(typeof(NoteDbContext))]
-    partial class NoteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729083715_AddNoteProperties")]
+    partial class AddNoteProperties
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Vanadium.Note.REST/Migrations/20260729083715_AddNoteProperties.cs
+++ b/Vanadium.Note.REST/Migrations/20260729083715_AddNoteProperties.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Vanadium.Note.REST.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNoteProperties : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PropertyDefinitions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PropertyDefinitions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PropertyOptions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PropertyOptions", x => x.Id);
+                    table.UniqueConstraint("AK_PropertyOptions_DefinitionId_Id", x => new { x.DefinitionId, x.Id });
+                    table.ForeignKey(
+                        name: "FK_PropertyOptions_PropertyDefinitions_DefinitionId",
+                        column: x => x.DefinitionId,
+                        principalTable: "PropertyDefinitions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NotePropertyValues",
+                columns: table => new
+                {
+                    NoteId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TextValue = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    NumberValue = table.Column<double>(type: "double precision", nullable: true),
+                    DateValue = table.Column<DateOnly>(type: "date", nullable: true),
+                    BoolValue = table.Column<bool>(type: "boolean", nullable: true),
+                    SelectedOptionId = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NotePropertyValues", x => new { x.NoteId, x.DefinitionId });
+                    table.ForeignKey(
+                        name: "FK_NotePropertyValues_Notes_NoteId",
+                        column: x => x.NoteId,
+                        principalTable: "Notes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_NotePropertyValues_PropertyDefinitions_DefinitionId",
+                        column: x => x.DefinitionId,
+                        principalTable: "PropertyDefinitions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_NotePropertyValues_PropertyOptions_DefinitionId_SelectedOpt~",
+                        columns: x => new { x.DefinitionId, x.SelectedOptionId },
+                        principalTable: "PropertyOptions",
+                        principalColumns: new[] { "DefinitionId", "Id" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NotePropertySelectedOptions",
+                columns: table => new
+                {
+                    NoteId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OptionId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NotePropertySelectedOptions", x => new { x.NoteId, x.DefinitionId, x.OptionId });
+                    table.ForeignKey(
+                        name: "FK_NotePropertySelectedOptions_NotePropertyValues_NoteId_Defin~",
+                        columns: x => new { x.NoteId, x.DefinitionId },
+                        principalTable: "NotePropertyValues",
+                        principalColumns: new[] { "NoteId", "DefinitionId" },
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_NotePropertySelectedOptions_PropertyOptions_DefinitionId_Op~",
+                        columns: x => new { x.DefinitionId, x.OptionId },
+                        principalTable: "PropertyOptions",
+                        principalColumns: new[] { "DefinitionId", "Id" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotePropertySelectedOptions_DefinitionId_OptionId",
+                table: "NotePropertySelectedOptions",
+                columns: new[] { "DefinitionId", "OptionId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotePropertySelectedOptions_OptionId",
+                table: "NotePropertySelectedOptions",
+                column: "OptionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotePropertyValues_DefinitionId_BoolValue",
+                table: "NotePropertyValues",
+                columns: new[] { "DefinitionId", "BoolValue" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotePropertyValues_DefinitionId_DateValue",
+                table: "NotePropertyValues",
+                columns: new[] { "DefinitionId", "DateValue" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotePropertyValues_DefinitionId_NumberValue",
+                table: "NotePropertyValues",
+                columns: new[] { "DefinitionId", "NumberValue" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotePropertyValues_DefinitionId_SelectedOptionId",
+                table: "NotePropertyValues",
+                columns: new[] { "DefinitionId", "SelectedOptionId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotePropertyValues_DefinitionId_TextValue",
+                table: "NotePropertyValues",
+                columns: new[] { "DefinitionId", "TextValue" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "NotePropertySelectedOptions");
+
+            migrationBuilder.DropTable(
+                name: "NotePropertyValues");
+
+            migrationBuilder.DropTable(
+                name: "PropertyOptions");
+
+            migrationBuilder.DropTable(
+                name: "PropertyDefinitions");
+        }
+    }
+}

--- a/Vanadium.Note.REST/Models/NoteItem.cs
+++ b/Vanadium.Note.REST/Models/NoteItem.cs
@@ -85,4 +85,13 @@ public class NoteItem
 
     [JsonIgnore]
     public ICollection<NoteLabel> NoteLabels { get; set; } = [];
+
+    /// <summary>Read-model projection of the note's non-empty property values, ordered by
+    /// definition SortOrder. Populated like <see cref="Labels"/>; never persisted directly.
+    /// Server-owned (INV-P5): ignored on the create/update write path.</summary>
+    [NotMapped]
+    public List<NotePropertyValueDto> Properties { get; set; } = [];
+
+    [JsonIgnore]
+    public ICollection<NotePropertyValue> PropertyValues { get; set; } = [];
 }

--- a/Vanadium.Note.REST/Models/NotePropertySelectedOption.cs
+++ b/Vanadium.Note.REST/Models/NotePropertySelectedOption.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace Vanadium.Note.REST.Models;
+
+/// <summary>One MultiSelect selection. PK (NoteId, DefinitionId, OptionId); the first two
+/// columns tie it back to its <see cref="NotePropertyValue"/> parent row.</summary>
+public class NotePropertySelectedOption
+{
+    public Guid NoteId { get; set; }
+    public Guid DefinitionId { get; set; }
+    public Guid OptionId { get; set; }
+
+    [JsonIgnore]
+    public NotePropertyValue Value { get; set; } = null!;
+    [JsonIgnore]
+    public PropertyOption Option { get; set; } = null!;
+}

--- a/Vanadium.Note.REST/Models/NotePropertyValue.cs
+++ b/Vanadium.Note.REST/Models/NotePropertyValue.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Vanadium.Note.REST.Models;
+
+/// <summary>One value of one property on one note. A missing row = empty value (INV-P1).
+/// Exactly the column matching the definition's type is non-null; for MultiSelect the value
+/// lives in <see cref="SelectedOptions"/> and all typed columns stay null.</summary>
+public class NotePropertyValue
+{
+    public Guid NoteId { get; set; }
+    public Guid DefinitionId { get; set; }
+
+    [JsonIgnore]
+    public NoteItem Note { get; set; } = null!;
+    [JsonIgnore]
+    public PropertyDefinition Definition { get; set; } = null!;
+
+    [MaxLength(500)]
+    public string? TextValue { get; set; }
+    public double? NumberValue { get; set; }
+    public DateOnly? DateValue { get; set; }
+    public bool? BoolValue { get; set; }
+    public Guid? SelectedOptionId { get; set; }
+
+    [JsonIgnore]
+    public PropertyOption? SelectedOption { get; set; }
+
+    public ICollection<NotePropertySelectedOption> SelectedOptions { get; set; } = [];
+}

--- a/Vanadium.Note.REST/Models/NotePropertyValueDto.cs
+++ b/Vanadium.Note.REST/Models/NotePropertyValueDto.cs
@@ -1,0 +1,16 @@
+namespace Vanadium.Note.REST.Models;
+
+/// <summary>Read model for one non-empty value; embedded in NoteItem.Properties and
+/// NoteSummary.Properties. Exactly the member(s) matching <see cref="Type"/> are set.</summary>
+public class NotePropertyValueDto
+{
+    public Guid DefinitionId { get; set; }
+    public string Name { get; set; } = string.Empty;   // denormalized for display
+    public PropertyType Type { get; set; }
+    public string? TextValue { get; set; }
+    public double? NumberValue { get; set; }
+    public DateOnly? DateValue { get; set; }
+    public bool? BoolValue { get; set; }
+    public Guid? OptionId { get; set; }
+    public List<Guid> OptionIds { get; set; } = [];
+}

--- a/Vanadium.Note.REST/Models/NoteSummary.cs
+++ b/Vanadium.Note.REST/Models/NoteSummary.cs
@@ -13,4 +13,8 @@ public class NoteSummary
     public bool IsArchived { get; set; }
 
     public List<LabelSummary> Labels { get; set; } = [];
+
+    /// <summary>Non-empty property values, ordered by definition SortOrder. Drives list chips
+    /// (v1 renders only the active sort property's value) and avoids N+1 value fetches.</summary>
+    public List<NotePropertyValueDto> Properties { get; set; } = [];
 }

--- a/Vanadium.Note.REST/Models/PropertyDefinition.cs
+++ b/Vanadium.Note.REST/Models/PropertyDefinition.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Vanadium.Note.REST.Models;
+
+/// <summary>A globally-defined property: a name, a type, a display order, and (for
+/// Select/MultiSelect) an ordered option list. Notes carry only values for these
+/// definitions, never their own definitions.</summary>
+public class PropertyDefinition
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    public PropertyType Type { get; set; }
+
+    /// <summary>Display order in the editor panel, filter menu, and /properties page.</summary>
+    public int SortOrder { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public ICollection<PropertyOption> Options { get; set; } = [];
+}

--- a/Vanadium.Note.REST/Models/PropertyDefinitionDto.cs
+++ b/Vanadium.Note.REST/Models/PropertyDefinitionDto.cs
@@ -1,0 +1,13 @@
+namespace Vanadium.Note.REST.Models;
+
+public class PropertyDefinitionDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public PropertyType Type { get; set; }
+    public int SortOrder { get; set; }
+    public List<PropertyOptionDto> Options { get; set; } = [];
+
+    /// <summary>Only populated when includeUsage=true. Counted with IgnoreQueryFilters().</summary>
+    public int? ValueCount { get; set; }
+}

--- a/Vanadium.Note.REST/Models/PropertyFilter.cs
+++ b/Vanadium.Note.REST/Models/PropertyFilter.cs
@@ -1,0 +1,22 @@
+namespace Vanadium.Note.REST.Models;
+
+/// <summary>Operators supported by the <c>pf</c> property-filter grammar (§6.3). Which ops are
+/// valid depends on the definition's <see cref="PropertyType"/>; the service rejects invalid
+/// combinations with a 400.</summary>
+public enum PropertyFilterOp
+{
+    Eq,
+    Ne,
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+    Empty,
+    NotEmpty,
+    AnyOf
+}
+
+/// <summary>One parsed <c>pf={definitionId}:{op}[:{value}]</c> entry. The controller parses the raw
+/// query strings into these; the service resolves definitions, validates op/type/value, and builds
+/// the EXISTS subqueries.</summary>
+public record PropertyFilter(Guid DefinitionId, PropertyFilterOp Op, string? RawValue);

--- a/Vanadium.Note.REST/Models/PropertyOption.cs
+++ b/Vanadium.Note.REST/Models/PropertyOption.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Vanadium.Note.REST.Models;
+
+/// <summary>One option of a Select/MultiSelect definition. The composite alternate
+/// key (DefinitionId, Id) is what lets value rows reference an option of the same
+/// definition at the DB level (INV-P3).</summary>
+public class PropertyOption
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid DefinitionId { get; set; }
+
+    [JsonIgnore]
+    public PropertyDefinition Definition { get; set; } = null!;
+
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Display order in pickers; also the sort key when sorting notes by a Select property.</summary>
+    public int SortOrder { get; set; }
+}

--- a/Vanadium.Note.REST/Models/PropertyOptionDto.cs
+++ b/Vanadium.Note.REST/Models/PropertyOptionDto.cs
@@ -1,0 +1,11 @@
+namespace Vanadium.Note.REST.Models;
+
+public class PropertyOptionDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+
+    /// <summary>Only populated when includeUsage=true. Counted with IgnoreQueryFilters().</summary>
+    public int? NoteCount { get; set; }
+}

--- a/Vanadium.Note.REST/Models/PropertyRequests.cs
+++ b/Vanadium.Note.REST/Models/PropertyRequests.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Vanadium.Note.REST.Models;
+
+public record CreatePropertyDefinitionRequest(
+    [Required][MaxLength(100)] string Name,
+    PropertyType Type);
+
+public record UpdatePropertyDefinitionRequest(
+    [Required][MaxLength(100)] string Name,
+    PropertyType Type,
+    int SortOrder);
+
+public record CreatePropertyOptionRequest([Required][MaxLength(100)] string Name);
+
+public record UpdatePropertyOptionRequest(
+    [Required][MaxLength(100)] string Name,
+    int SortOrder);
+
+/// <summary>Exactly the member(s) matching the definition's type must be set (§7.2).</summary>
+public class SetNotePropertyValueRequest
+{
+    [MaxLength(500)]
+    public string? TextValue { get; set; }      // Text
+    public double? NumberValue { get; set; }    // Number
+    public DateOnly? DateValue { get; set; }    // Date
+    public bool? BoolValue { get; set; }        // Checkbox
+    public Guid? OptionId { get; set; }         // Select
+    public List<Guid>? OptionIds { get; set; }  // MultiSelect
+}

--- a/Vanadium.Note.REST/Models/PropertyType.cs
+++ b/Vanadium.Note.REST/Models/PropertyType.cs
@@ -1,0 +1,13 @@
+namespace Vanadium.Note.REST.Models;
+
+/// <summary>The six v1 property value types. Numeric values are stable across the
+/// wire and DB, so new types must be appended (never re-numbered).</summary>
+public enum PropertyType
+{
+    Text = 0,
+    Number = 1,
+    Select = 2,
+    MultiSelect = 3,
+    Date = 4,
+    Checkbox = 5
+}

--- a/Vanadium.Note.REST/Program.cs
+++ b/Vanadium.Note.REST/Program.cs
@@ -169,6 +169,7 @@ builder.Services.AddScoped<NoteService>();
 builder.Services.AddScoped<NoteLifecycleService>();
 builder.Services.AddScoped<NoteShareService>();
 builder.Services.AddScoped<LabelService>();
+builder.Services.AddScoped<PropertyService>();
 builder.Services.AddScoped<SettingsService>();
 builder.Services.AddScoped<ApiTokenService>();
 builder.Services.AddScoped<FileCleanupService>();

--- a/Vanadium.Note.REST/Services/AccountService.cs
+++ b/Vanadium.Note.REST/Services/AccountService.cs
@@ -47,6 +47,10 @@ public class AccountService(NoteDbContext db, ILogger<AccountService> logger)
             var labelsRemoved = await db.Labels.ExecuteDeleteAsync(ct);
             var categoriesRemoved = await db.LabelCategories.ExecuteDeleteAsync(ct);
 
+            // Property definitions cascade their options; note-value rows and their
+            // selection rows were already removed by the Notes delete above (NoteId FK cascade).
+            var propertyDefinitionsRemoved = await db.PropertyDefinitions.ExecuteDeleteAsync(ct);
+
             var tokensRemoved = await db.ApiTokens.ExecuteDeleteAsync(ct);
 
             var settingsRemoved = await db.UserSettings.ExecuteDeleteAsync(ct);
@@ -55,9 +59,11 @@ public class AccountService(NoteDbContext db, ILogger<AccountService> logger)
 
             logger.LogInformation(
                 "Purged all data: {Notes} note(s), {Labels} label(s), " +
-                "{Categories} category(ies), {Tokens} token(s), {Settings} settings row(s). " +
+                "{Categories} category(ies), {PropertyDefinitions} property definition(s), " +
+                "{Tokens} token(s), {Settings} settings row(s). " +
                 "Orphaned files/images will be reclaimed by the periodic cleanup job.",
-                notesRemoved, labelsRemoved, categoriesRemoved, tokensRemoved, settingsRemoved);
+                notesRemoved, labelsRemoved, categoriesRemoved, propertyDefinitionsRemoved,
+                tokensRemoved, settingsRemoved);
         });
 
         return true;

--- a/Vanadium.Note.REST/Services/NoteService.cs
+++ b/Vanadium.Note.REST/Services/NoteService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.EntityFrameworkCore;
 using Vanadium.Note.REST.Data;
 using Vanadium.Note.REST.Models;
@@ -26,6 +27,7 @@ public class NoteService(
         string sortBy,
         string sortDir,
         Guid[]? labelIds,
+        IReadOnlyList<PropertyFilter>? propertyFilters = null,
         CancellationToken ct = default)
     {
         // When not searching, show active root notes only.
@@ -37,16 +39,25 @@ public class NoteService(
             ? allNotes.Where(n => n.ParentNoteId == null && n.ArchivedAt == null)
             : allNotes;
 
+        // Resolve + validate property filters and (non-search) property sort up front so a bad
+        // pf/sortBy fails fast with a 400 before any DB read (PropertyQueryException).
+        var resolvedFilters = await ResolveFiltersAsync(propertyFilters, ct);
+        var sortDefinition = rootOnly ? await ResolveSortDefinitionAsync(sortBy, ct) : null;
+
         // Lean query for COUNT — no joins to label/category tables
-        var countQuery = ApplyFilters(baseNotes, search, labelIds);
+        var countQuery = ApplyPropertyFilters(ApplyFilters(baseNotes, search, labelIds), resolvedFilters);
         var totalCount = await countQuery.CountAsync(ct);
 
         // Full query for data — projects to NoteSummary to avoid fetching large Content column
-        var baseDataQuery = ApplyFilters(baseNotes, search, labelIds);
+        var baseDataQuery = ApplyPropertyFilters(ApplyFilters(baseNotes, search, labelIds), resolvedFilters);
 
-        var orderedQuery = !string.IsNullOrWhiteSpace(search)
-            ? baseDataQuery.OrderByDescending(n => n.UpdatedAt)
-            : (sortBy.ToLowerInvariant(), sortDir.ToLowerInvariant()) switch
+        IQueryable<NoteItem> orderedQuery;
+        if (!string.IsNullOrWhiteSpace(search))
+            orderedQuery = baseDataQuery.OrderByDescending(n => n.UpdatedAt);
+        else if (sortDefinition is not null)
+            orderedQuery = ApplyPropertySort(baseDataQuery, sortDefinition, sortDir);
+        else
+            orderedQuery = (sortBy.ToLowerInvariant(), sortDir.ToLowerInvariant()) switch
             {
                 ("title", "asc")  => baseDataQuery.OrderBy(n => n.Title),
                 ("title", "desc") => baseDataQuery.OrderByDescending(n => n.Title),
@@ -70,6 +81,19 @@ public class NoteService(
                     Name = nl.Label.Name,
                     CategoryId = nl.Label.CategoryId,
                     CategoryName = nl.Label.Category == null ? null : nl.Label.Category.Name
+                }).ToList(),
+                Properties = n.PropertyValues.Select(v => new PropertyValueProjection
+                {
+                    DefinitionId = v.DefinitionId,
+                    Name = v.Definition.Name,
+                    Type = v.Definition.Type,
+                    SortOrder = v.Definition.SortOrder,
+                    TextValue = v.TextValue,
+                    NumberValue = v.NumberValue,
+                    DateValue = v.DateValue,
+                    BoolValue = v.BoolValue,
+                    OptionId = v.SelectedOptionId,
+                    OptionIds = v.SelectedOptions.Select(s => s.OptionId).ToList()
                 }).ToList()
             })
             .ToListAsync(ct);
@@ -104,7 +128,8 @@ public class NoteService(
                 ParentTitle = n.ParentNoteId.HasValue ? parentTitles.GetValueOrDefault(n.ParentNoteId.Value) : null,
                 ChildCount = childCounts.GetValueOrDefault(n.Id),
                 IsArchived = n.IsArchived,
-                Labels = OrderLabelsForDisplay(n.Labels).ToList()
+                Labels = OrderLabelsForDisplay(n.Labels).ToList(),
+                Properties = ToValueDtos(n.Properties)
             }).ToList(),
             TotalCount = totalCount,
             Page = page,
@@ -112,7 +137,10 @@ public class NoteService(
         };
     }
 
-    public async Task<List<NoteSummary>> GetAllSummaries(Guid[]? labelIds = null, CancellationToken ct = default)
+    public async Task<List<NoteSummary>> GetAllSummaries(
+        Guid[]? labelIds = null,
+        IReadOnlyList<PropertyFilter>? propertyFilters = null,
+        CancellationToken ct = default)
     {
         // The board never shows archived notes.
         var query = db.Notes.Where(n => n.ArchivedAt == null);
@@ -120,6 +148,10 @@ public class NoteService(
         // OR logic: notes that have ANY of the specified labels
         if (labelIds is { Length: > 0 })
             query = query.Where(n => n.NoteLabels.Any(nl => labelIds.Contains(nl.LabelId)));
+
+        // AND semantics across pf entries (documented asymmetry with labelIds' OR on this endpoint).
+        var resolvedFilters = await ResolveFiltersAsync(propertyFilters, ct);
+        query = ApplyPropertyFilters(query, resolvedFilters);
 
         var summaries = await query
             .OrderByDescending(n => n.UpdatedAt)
@@ -135,6 +167,19 @@ public class NoteService(
                     Name = nl.Label.Name,
                     CategoryId = nl.Label.CategoryId,
                     CategoryName = nl.Label.Category == null ? null : nl.Label.Category.Name
+                }).ToList(),
+                Properties = n.PropertyValues.Select(v => new PropertyValueProjection
+                {
+                    DefinitionId = v.DefinitionId,
+                    Name = v.Definition.Name,
+                    Type = v.Definition.Type,
+                    SortOrder = v.Definition.SortOrder,
+                    TextValue = v.TextValue,
+                    NumberValue = v.NumberValue,
+                    DateValue = v.DateValue,
+                    BoolValue = v.BoolValue,
+                    OptionId = v.SelectedOptionId,
+                    OptionIds = v.SelectedOptions.Select(s => s.OptionId).ToList()
                 }).ToList()
             })
             .ToListAsync(ct);
@@ -149,7 +194,8 @@ public class NoteService(
             UpdatedAt = n.UpdatedAt,
             ParentNoteId = n.ParentNoteId,
             ChildCount = childCounts.GetValueOrDefault(n.Id),
-            Labels = OrderLabelsForDisplay(n.Labels).ToList()
+            Labels = OrderLabelsForDisplay(n.Labels).ToList(),
+            Properties = ToValueDtos(n.Properties)
         }).ToList();
     }
 
@@ -194,11 +240,16 @@ public class NoteService(
             .Include(n => n.NoteLabels)
             .ThenInclude(nl => nl.Label)
             .ThenInclude(l => l.Category)
+            .Include(n => n.PropertyValues)
+            .ThenInclude(v => v.Definition)
+            .Include(n => n.PropertyValues)
+            .ThenInclude(v => v.SelectedOptions)
             .FirstOrDefaultAsync(n => n.Id == id, ct);
 
         if (note is null) return null;
 
         PopulateLabels(note);
+        PopulateProperties(note);
         note.ChildCount = await db.Notes.CountAsync(n => n.ParentNoteId == id, ct);
 
         if (note.ParentNoteId.HasValue)
@@ -658,4 +709,330 @@ public class NoteService(
             .OrderBy(l => l.CategoryId.HasValue ? 0 : 1)
             .ThenBy(l => l.CategoryName)
             .ThenBy(l => l.Name);
+
+    // ── Note Properties (issue #343) ─────────────────────────────────────────────
+
+    /// <summary>Thrown when a <c>pf</c> filter or a <c>sortBy=prop:</c> value is malformed, references
+    /// an unknown definition, or mismatches its type. Mapped to 400 by the controller.</summary>
+    public class PropertyQueryException(string message) : Exception(message);
+
+    /// <summary>In-memory shape projected out of EF so property DTOs can be ordered by definition
+    /// SortOrder without relying on ORDER BY translation inside a collection subquery.</summary>
+    private sealed class PropertyValueProjection
+    {
+        public Guid DefinitionId { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public PropertyType Type { get; init; }
+        public int SortOrder { get; init; }
+        public string? TextValue { get; init; }
+        public double? NumberValue { get; init; }
+        public DateOnly? DateValue { get; init; }
+        public bool? BoolValue { get; init; }
+        public Guid? OptionId { get; init; }
+        public List<Guid> OptionIds { get; init; } = [];
+    }
+
+    private static List<NotePropertyValueDto> ToValueDtos(IEnumerable<PropertyValueProjection> values) =>
+        values
+            .OrderBy(v => v.SortOrder)
+            .Select(v => new NotePropertyValueDto
+            {
+                DefinitionId = v.DefinitionId,
+                Name = v.Name,
+                Type = v.Type,
+                TextValue = v.TextValue,
+                NumberValue = v.NumberValue,
+                DateValue = v.DateValue,
+                BoolValue = v.BoolValue,
+                OptionId = v.OptionId,
+                OptionIds = v.OptionIds
+            })
+            .ToList();
+
+    private static void PopulateProperties(NoteItem note) =>
+        note.Properties = note.PropertyValues
+            .OrderBy(v => v.Definition.SortOrder)
+            .Select(v => new NotePropertyValueDto
+            {
+                DefinitionId = v.DefinitionId,
+                Name = v.Definition.Name,
+                Type = v.Definition.Type,
+                TextValue = v.TextValue,
+                NumberValue = v.NumberValue,
+                DateValue = v.DateValue,
+                BoolValue = v.BoolValue,
+                OptionId = v.SelectedOptionId,
+                OptionIds = v.SelectedOptions.Select(s => s.OptionId).ToList()
+            })
+            .ToList();
+
+    // ── Property filtering (§7.3) ────────────────────────────────────────────────
+
+    /// <summary>Resolved + validated filter carrying the parsed typed value(s).</summary>
+    private sealed class ResolvedFilter
+    {
+        public required PropertyDefinition Definition { get; init; }
+        public required PropertyFilterOp Op { get; init; }
+        public string? Text { get; init; }
+        public double Number { get; init; }
+        public DateOnly Date { get; init; }
+        public bool Bool { get; init; }
+        public Guid Option { get; init; }
+        public List<Guid> Options { get; init; } = [];
+    }
+
+    private async Task<List<ResolvedFilter>> ResolveFiltersAsync(
+        IReadOnlyList<PropertyFilter>? filters, CancellationToken ct)
+    {
+        if (filters is null || filters.Count == 0) return [];
+        if (filters.Count > 20)
+            throw new PropertyQueryException("Too many property filters (maximum 20).");
+
+        var ids = filters.Select(f => f.DefinitionId).Distinct().ToList();
+        var definitions = await db.PropertyDefinitions
+            .Include(d => d.Options)
+            .Where(d => ids.Contains(d.Id))
+            .ToDictionaryAsync(d => d.Id, ct);
+
+        var resolved = new List<ResolvedFilter>(filters.Count);
+        foreach (var f in filters)
+        {
+            if (!definitions.TryGetValue(f.DefinitionId, out var def))
+                throw new PropertyQueryException($"Unknown property definition '{f.DefinitionId}'.");
+            resolved.Add(ResolveFilter(def, f));
+        }
+        return resolved;
+    }
+
+    private static ResolvedFilter ResolveFilter(PropertyDefinition def, PropertyFilter f)
+    {
+        // empty / notempty are valid for every type except Checkbox (two-state by design).
+        if (f.Op is PropertyFilterOp.Empty or PropertyFilterOp.NotEmpty)
+        {
+            if (def.Type == PropertyType.Checkbox)
+                throw new PropertyQueryException("empty/notempty is not valid for a Checkbox property.");
+            return new ResolvedFilter { Definition = def, Op = f.Op };
+        }
+
+        string RawValue()
+        {
+            if (string.IsNullOrEmpty(f.RawValue))
+                throw new PropertyQueryException($"Operator '{f.Op}' requires a value.");
+            return f.RawValue;
+        }
+
+        List<Guid> ParseOptionList()
+        {
+            var ids = RawValue().Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var parsed = new List<Guid>(ids.Length);
+            foreach (var s in ids)
+            {
+                if (!Guid.TryParse(s, out var g))
+                    throw new PropertyQueryException($"'{s}' is not a valid option id.");
+                parsed.Add(g);
+            }
+            if (parsed.Count == 0)
+                throw new PropertyQueryException("anyof requires at least one option id.");
+            EnsureOptionsBelong(def, parsed);
+            return parsed;
+        }
+
+        Guid ParseOption()
+        {
+            if (!Guid.TryParse(RawValue(), out var g))
+                throw new PropertyQueryException($"'{f.RawValue}' is not a valid option id.");
+            EnsureOptionsBelong(def, [g]);
+            return g;
+        }
+
+        switch (def.Type)
+        {
+            case PropertyType.Text:
+                RequireOp(def, f.Op, PropertyFilterOp.Eq, PropertyFilterOp.Ne);
+                var text = RawValue();
+                if (text.Length > PropertyService.MaxTextValueLength)
+                    throw new PropertyQueryException($"Text filter value exceeds {PropertyService.MaxTextValueLength} characters.");
+                return new ResolvedFilter { Definition = def, Op = f.Op, Text = text };
+
+            case PropertyType.Number:
+                RequireOp(def, f.Op, PropertyFilterOp.Eq, PropertyFilterOp.Ne, PropertyFilterOp.Lt,
+                    PropertyFilterOp.Lte, PropertyFilterOp.Gt, PropertyFilterOp.Gte);
+                if (!double.TryParse(RawValue(), NumberStyles.Float, CultureInfo.InvariantCulture, out var num)
+                    || !double.IsFinite(num))
+                    throw new PropertyQueryException($"'{f.RawValue}' is not a valid number.");
+                return new ResolvedFilter { Definition = def, Op = f.Op, Number = num };
+
+            case PropertyType.Date:
+                RequireOp(def, f.Op, PropertyFilterOp.Eq, PropertyFilterOp.Ne, PropertyFilterOp.Lt,
+                    PropertyFilterOp.Lte, PropertyFilterOp.Gt, PropertyFilterOp.Gte);
+                if (!DateOnly.TryParseExact(RawValue(), "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                        DateTimeStyles.None, out var date))
+                    throw new PropertyQueryException($"'{f.RawValue}' is not a valid date (expected yyyy-MM-dd).");
+                return new ResolvedFilter { Definition = def, Op = f.Op, Date = date };
+
+            case PropertyType.Checkbox:
+                RequireOp(def, f.Op, PropertyFilterOp.Eq);
+                var raw = RawValue();
+                var b = raw switch
+                {
+                    "true" => true,
+                    "false" => false,
+                    _ => throw new PropertyQueryException("Checkbox filter value must be 'true' or 'false'.")
+                };
+                return new ResolvedFilter { Definition = def, Op = f.Op, Bool = b };
+
+            case PropertyType.Select:
+                if (f.Op == PropertyFilterOp.AnyOf)
+                    return new ResolvedFilter { Definition = def, Op = f.Op, Options = ParseOptionList() };
+                RequireOp(def, f.Op, PropertyFilterOp.Eq, PropertyFilterOp.Ne, PropertyFilterOp.AnyOf);
+                return new ResolvedFilter { Definition = def, Op = f.Op, Option = ParseOption() };
+
+            case PropertyType.MultiSelect:
+                if (f.Op == PropertyFilterOp.AnyOf)
+                    return new ResolvedFilter { Definition = def, Op = f.Op, Options = ParseOptionList() };
+                RequireOp(def, f.Op, PropertyFilterOp.Eq, PropertyFilterOp.AnyOf);
+                return new ResolvedFilter { Definition = def, Op = f.Op, Option = ParseOption() };
+
+            default:
+                throw new PropertyQueryException($"Unknown property type '{(int)def.Type}'.");
+        }
+    }
+
+    private static void RequireOp(PropertyDefinition def, PropertyFilterOp op, params PropertyFilterOp[] allowed)
+    {
+        if (!allowed.Contains(op))
+            throw new PropertyQueryException($"Operator '{op}' is not valid for a {def.Type} property.");
+    }
+
+    private static void EnsureOptionsBelong(PropertyDefinition def, IReadOnlyCollection<Guid> optionIds)
+    {
+        var valid = def.Options.Select(o => o.Id).ToHashSet();
+        if (!optionIds.All(valid.Contains))
+            throw new PropertyQueryException("One or more options do not belong to this property.");
+    }
+
+    private static IQueryable<NoteItem> ApplyPropertyFilters(
+        IQueryable<NoteItem> query, IReadOnlyList<ResolvedFilter> filters)
+    {
+        foreach (var f in filters)
+        {
+            var d = f.Definition.Id;
+            query = (f.Definition.Type, f.Op) switch
+            {
+                (_, PropertyFilterOp.Empty) =>
+                    query.Where(n => !n.PropertyValues.Any(v => v.DefinitionId == d)),
+                (_, PropertyFilterOp.NotEmpty) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d)),
+
+                (PropertyType.Text, PropertyFilterOp.Eq) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.TextValue == f.Text)),
+                (PropertyType.Text, PropertyFilterOp.Ne) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.TextValue != f.Text)),
+
+                (PropertyType.Number, PropertyFilterOp.Eq) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.NumberValue == f.Number)),
+                (PropertyType.Number, PropertyFilterOp.Ne) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.NumberValue != f.Number)),
+                (PropertyType.Number, PropertyFilterOp.Lt) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.NumberValue < f.Number)),
+                (PropertyType.Number, PropertyFilterOp.Lte) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.NumberValue <= f.Number)),
+                (PropertyType.Number, PropertyFilterOp.Gt) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.NumberValue > f.Number)),
+                (PropertyType.Number, PropertyFilterOp.Gte) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.NumberValue >= f.Number)),
+
+                (PropertyType.Date, PropertyFilterOp.Eq) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.DateValue == f.Date)),
+                (PropertyType.Date, PropertyFilterOp.Ne) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.DateValue != f.Date)),
+                (PropertyType.Date, PropertyFilterOp.Lt) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.DateValue < f.Date)),
+                (PropertyType.Date, PropertyFilterOp.Lte) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.DateValue <= f.Date)),
+                (PropertyType.Date, PropertyFilterOp.Gt) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.DateValue > f.Date)),
+                (PropertyType.Date, PropertyFilterOp.Gte) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.DateValue >= f.Date)),
+
+                // Checkbox eq:true → a true row exists; eq:false → no true row (missing = unchecked).
+                (PropertyType.Checkbox, PropertyFilterOp.Eq) when f.Bool =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.BoolValue == true)),
+                (PropertyType.Checkbox, PropertyFilterOp.Eq) =>
+                    query.Where(n => !n.PropertyValues.Any(v => v.DefinitionId == d && v.BoolValue == true)),
+
+                (PropertyType.Select, PropertyFilterOp.Eq) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.SelectedOptionId == f.Option)),
+                (PropertyType.Select, PropertyFilterOp.Ne) =>
+                    query.Where(n => n.PropertyValues.Any(v => v.DefinitionId == d && v.SelectedOptionId != f.Option)),
+                (PropertyType.Select, PropertyFilterOp.AnyOf) =>
+                    query.Where(n => n.PropertyValues.Any(v =>
+                        v.DefinitionId == d && v.SelectedOptionId != null && f.Options.Contains(v.SelectedOptionId.Value))),
+
+                (PropertyType.MultiSelect, PropertyFilterOp.Eq) =>
+                    query.Where(n => n.PropertyValues.Any(v =>
+                        v.DefinitionId == d && v.SelectedOptions.Any(s => s.OptionId == f.Option))),
+                (PropertyType.MultiSelect, PropertyFilterOp.AnyOf) =>
+                    query.Where(n => n.PropertyValues.Any(v =>
+                        v.DefinitionId == d && v.SelectedOptions.Any(s => f.Options.Contains(s.OptionId)))),
+
+                _ => throw new PropertyQueryException(
+                    $"Operator '{f.Op}' is not valid for a {f.Definition.Type} property.")
+            };
+        }
+        return query;
+    }
+
+    // ── Property sorting (§7.5) ──────────────────────────────────────────────────
+
+    private async Task<PropertyDefinition?> ResolveSortDefinitionAsync(string sortBy, CancellationToken ct)
+    {
+        const string prefix = "prop:";
+        if (string.IsNullOrEmpty(sortBy) || !sortBy.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var idText = sortBy[prefix.Length..];
+        if (!Guid.TryParse(idText, out var id))
+            throw new PropertyQueryException($"'{idText}' is not a valid property definition id.");
+
+        var def = await db.PropertyDefinitions.FirstOrDefaultAsync(d => d.Id == id, ct);
+        if (def is null)
+            throw new PropertyQueryException($"Unknown property definition '{id}'.");
+        if (def.Type == PropertyType.MultiSelect)
+            throw new PropertyQueryException("A MultiSelect property cannot be used for sorting.");
+        return def;
+    }
+
+    /// <summary>Orders notes by a property value with empties always last (independent of direction),
+    /// then by <c>UpdatedAt</c> desc as a stable tiebreak. A missing value row means empty (INV-P1),
+    /// so the presence key is simply "has a row for this definition".</summary>
+    private static IQueryable<NoteItem> ApplyPropertySort(
+        IQueryable<NoteItem> query, PropertyDefinition def, string sortDir)
+    {
+        var d = def.Id;
+        var asc = string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase);
+        var withPresence = query.OrderBy(n => n.PropertyValues.Any(v => v.DefinitionId == d) ? 0 : 1);
+
+        IOrderedQueryable<NoteItem> ordered = def.Type switch
+        {
+            PropertyType.Text => asc
+                ? withPresence.ThenBy(n => n.PropertyValues.Where(v => v.DefinitionId == d).Select(v => v.TextValue).FirstOrDefault())
+                : withPresence.ThenByDescending(n => n.PropertyValues.Where(v => v.DefinitionId == d).Select(v => v.TextValue).FirstOrDefault()),
+            PropertyType.Number => asc
+                ? withPresence.ThenBy(n => n.PropertyValues.Where(v => v.DefinitionId == d).Select(v => v.NumberValue).FirstOrDefault())
+                : withPresence.ThenByDescending(n => n.PropertyValues.Where(v => v.DefinitionId == d).Select(v => v.NumberValue).FirstOrDefault()),
+            PropertyType.Date => asc
+                ? withPresence.ThenBy(n => n.PropertyValues.Where(v => v.DefinitionId == d).Select(v => v.DateValue).FirstOrDefault())
+                : withPresence.ThenByDescending(n => n.PropertyValues.Where(v => v.DefinitionId == d).Select(v => v.DateValue).FirstOrDefault()),
+            PropertyType.Checkbox => asc
+                ? withPresence.ThenBy(n => n.PropertyValues.Where(v => v.DefinitionId == d).Select(v => v.BoolValue).FirstOrDefault())
+                : withPresence.ThenByDescending(n => n.PropertyValues.Where(v => v.DefinitionId == d).Select(v => v.BoolValue).FirstOrDefault()),
+            PropertyType.Select => asc
+                ? withPresence.ThenBy(n => n.PropertyValues.Where(v => v.DefinitionId == d).Select(v => (int?)v.SelectedOption!.SortOrder).FirstOrDefault())
+                : withPresence.ThenByDescending(n => n.PropertyValues.Where(v => v.DefinitionId == d).Select(v => (int?)v.SelectedOption!.SortOrder).FirstOrDefault()),
+            _ => withPresence
+        };
+
+        return ordered.ThenByDescending(n => n.UpdatedAt);
+    }
 }

--- a/Vanadium.Note.REST/Services/PropertyService.cs
+++ b/Vanadium.Note.REST/Services/PropertyService.cs
@@ -1,0 +1,470 @@
+using Microsoft.EntityFrameworkCore;
+using Vanadium.Note.REST.Data;
+using Vanadium.Note.REST.Models;
+
+namespace Vanadium.Note.REST.Services;
+
+/// <summary>
+/// Note Properties (issue #343): global property definitions + options + per-note typed values.
+/// Mirrors the <see cref="LabelService"/> precedent (case-insensitive uniqueness enforced in the
+/// service, archived-note 403, immediate saves that never touch <c>NoteItem.UpdatedAt</c>).
+/// Definition-level scans use <c>IgnoreQueryFilters()</c> so recycle-bin notes' values are counted
+/// and cleaned up (INV-P4). See docs/plannings/note-property/note-properties-feature.md.
+/// </summary>
+public class PropertyService(NoteDbContext db, ILogger<PropertyService> logger)
+{
+    public const int MaxDefinitions = 50;
+    public const int MaxOptionsPerDefinition = 100;
+    public const int MaxTextValueLength = 500;
+
+    // ── Exceptions (mapped to status codes by the controller) ────────────────────
+
+    /// <summary>Thrown when a value mutation targets an archived (read-only) note → 403.</summary>
+    public class NoteArchivedException() : InvalidOperationException("Note is archived and read-only.");
+
+    /// <summary>Case-insensitive duplicate definition/option name → 409.</summary>
+    public class DuplicateNameException(string message) : InvalidOperationException(message);
+
+    /// <summary>A cap (definition/option/text length) was exceeded → 400.</summary>
+    public class CapExceededException(string message) : InvalidOperationException(message);
+
+    /// <summary>Type change blocked because values exist (counted across all notes) → 409.</summary>
+    public class TypeChangeBlockedException(int valueCount)
+        : InvalidOperationException(
+            $"Cannot change the type of a property that has values on {valueCount} note(s). Clear the values first.")
+    {
+        public int ValueCount { get; } = valueCount;
+    }
+
+    /// <summary>Invalid value payload, unknown/foreign option, or an option op on a non-Select
+    /// definition → 400.</summary>
+    public class PropertyValidationException(string message) : InvalidOperationException(message);
+
+    // ── Definitions ──────────────────────────────────────────────────────────────
+
+    public async Task<List<PropertyDefinitionDto>> GetAllAsync(bool includeUsage, CancellationToken ct = default)
+    {
+        var defs = await db.PropertyDefinitions
+            .Include(d => d.Options)
+            .OrderBy(d => d.SortOrder)
+            .ThenBy(d => d.Name)
+            .ToListAsync(ct);
+
+        if (!includeUsage)
+            return defs.Select(d => ToDto(d)).ToList();
+
+        // Usage counts include recycle-bin AND archived notes (IgnoreQueryFilters): a count that
+        // omitted recycle-bin values would let the user "safely" delete something a restore misses.
+        var valueCounts = await db.NotePropertyValues.IgnoreQueryFilters()
+            .GroupBy(v => v.DefinitionId)
+            .Select(g => new { g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.Key, x => x.Count, ct);
+
+        var selectOptionCounts = await db.NotePropertyValues.IgnoreQueryFilters()
+            .Where(v => v.SelectedOptionId != null)
+            .GroupBy(v => v.SelectedOptionId!.Value)
+            .Select(g => new { g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.Key, x => x.Count, ct);
+
+        var multiOptionCounts = await db.NotePropertySelectedOptions.IgnoreQueryFilters()
+            .GroupBy(s => s.OptionId)
+            .Select(g => new { g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.Key, x => x.Count, ct);
+
+        return defs.Select(d => ToDto(
+            d,
+            valueCounts.GetValueOrDefault(d.Id),
+            optId => selectOptionCounts.GetValueOrDefault(optId) + multiOptionCounts.GetValueOrDefault(optId)))
+            .ToList();
+    }
+
+    public async Task<PropertyDefinitionDto> CreateAsync(string name, PropertyType type, CancellationToken ct = default)
+    {
+        if (!Enum.IsDefined(type))
+            throw new PropertyValidationException($"Unknown property type '{(int)type}'.");
+
+        name = name.Trim();
+        if (name.Length == 0)
+            throw new PropertyValidationException("Property name is required.");
+
+        var lowered = name.ToLower();
+        if (await db.PropertyDefinitions.AnyAsync(d => d.Name.ToLower() == lowered, ct))
+            throw new DuplicateNameException($"A property named '{name}' already exists.");
+
+        if (await db.PropertyDefinitions.CountAsync(ct) >= MaxDefinitions)
+            throw new CapExceededException($"Cannot create more than {MaxDefinitions} properties.");
+
+        var maxSort = await db.PropertyDefinitions.Select(d => (int?)d.SortOrder).MaxAsync(ct) ?? -1;
+        var def = new PropertyDefinition { Name = name, Type = type, SortOrder = maxSort + 1 };
+        db.PropertyDefinitions.Add(def);
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation("Property definition created: {DefinitionId} (type {Type})", def.Id, type);
+        return ToDto(def);
+    }
+
+    public async Task<PropertyDefinitionDto?> UpdateAsync(
+        Guid id, string name, PropertyType type, int sortOrder, CancellationToken ct = default)
+    {
+        if (!Enum.IsDefined(type))
+            throw new PropertyValidationException($"Unknown property type '{(int)type}'.");
+
+        var def = await db.PropertyDefinitions.Include(d => d.Options).FirstOrDefaultAsync(d => d.Id == id, ct);
+        if (def is null) return null;
+
+        name = name.Trim();
+        if (name.Length == 0)
+            throw new PropertyValidationException("Property name is required.");
+
+        if (!string.Equals(name, def.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            var lowered = name.ToLower();
+            if (await db.PropertyDefinitions.AnyAsync(d => d.Id != id && d.Name.ToLower() == lowered, ct))
+                throw new DuplicateNameException($"A property named '{name}' already exists.");
+        }
+
+        if (type != def.Type)
+        {
+            // INV-P4: include recycle-bin values so a type change can't leave a mistyped value
+            // hiding in the recycle bin to resurface (with the wrong column) on restore.
+            var valueCount = await db.NotePropertyValues.IgnoreQueryFilters()
+                .CountAsync(v => v.DefinitionId == id, ct);
+            if (valueCount > 0)
+                throw new TypeChangeBlockedException(valueCount);
+
+            // Moving away from a Select kind makes options meaningless — drop them.
+            if (def.Type is PropertyType.Select or PropertyType.MultiSelect
+                && type is not (PropertyType.Select or PropertyType.MultiSelect))
+                db.PropertyOptions.RemoveRange(def.Options);
+        }
+
+        def.Name = name;
+        def.Type = type;
+        def.SortOrder = sortOrder;
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation("Property definition updated: {DefinitionId}", id);
+        return ToDto(def);
+    }
+
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var def = await db.PropertyDefinitions.FirstOrDefaultAsync(d => d.Id == id, ct);
+        if (def is null) return false;
+        // DB cascade removes options → value rows → selection rows, INCLUDING soft-deleted and
+        // archived notes' rows (cascades run below EF's query filters — no IgnoreQueryFilters sweep).
+        db.PropertyDefinitions.Remove(def);
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation("Property definition deleted: {DefinitionId}", id);
+        return true;
+    }
+
+    // ── Options ──────────────────────────────────────────────────────────────────
+
+    public async Task<PropertyOptionDto?> AddOptionAsync(Guid definitionId, string name, CancellationToken ct = default)
+    {
+        var def = await db.PropertyDefinitions.Include(d => d.Options).FirstOrDefaultAsync(d => d.Id == definitionId, ct);
+        if (def is null) return null;
+
+        RequireSelectKind(def);
+
+        name = name.Trim();
+        if (name.Length == 0)
+            throw new PropertyValidationException("Option name is required.");
+
+        if (def.Options.Any(o => string.Equals(o.Name, name, StringComparison.OrdinalIgnoreCase)))
+            throw new DuplicateNameException($"An option named '{name}' already exists on this property.");
+
+        if (def.Options.Count >= MaxOptionsPerDefinition)
+            throw new CapExceededException($"Cannot create more than {MaxOptionsPerDefinition} options per property.");
+
+        var maxSort = def.Options.Count == 0 ? -1 : def.Options.Max(o => o.SortOrder);
+        var option = new PropertyOption { DefinitionId = definitionId, Name = name, SortOrder = maxSort + 1 };
+        db.PropertyOptions.Add(option);
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation("Property option created: {OptionId} on definition {DefinitionId}", option.Id, definitionId);
+        return ToDto(option);
+    }
+
+    public async Task<PropertyOptionDto?> UpdateOptionAsync(
+        Guid definitionId, Guid optionId, string name, int sortOrder, CancellationToken ct = default)
+    {
+        var option = await db.PropertyOptions
+            .FirstOrDefaultAsync(o => o.Id == optionId && o.DefinitionId == definitionId, ct);
+        if (option is null) return null;
+
+        name = name.Trim();
+        if (name.Length == 0)
+            throw new PropertyValidationException("Option name is required.");
+
+        var lowered = name.ToLower();
+        if (await db.PropertyOptions.AnyAsync(
+                o => o.DefinitionId == definitionId && o.Id != optionId && o.Name.ToLower() == lowered, ct))
+            throw new DuplicateNameException($"An option named '{name}' already exists on this property.");
+
+        option.Name = name;
+        option.SortOrder = sortOrder;
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation("Property option updated: {OptionId}", optionId);
+        return ToDto(option);
+    }
+
+    public async Task<bool> DeleteOptionAsync(Guid definitionId, Guid optionId, CancellationToken ct = default)
+    {
+        var option = await db.PropertyOptions
+            .Include(o => o.Definition)
+            .FirstOrDefaultAsync(o => o.Id == optionId && o.DefinitionId == definitionId, ct);
+        if (option is null) return false;
+
+        var isMultiSelect = option.Definition.Type == PropertyType.MultiSelect;
+        db.PropertyOptions.Remove(option);
+        // Cascades: Select value rows referencing it are deleted (composite FK); MultiSelect
+        // selection rows are deleted — across all notes incl. soft-deleted/archived.
+        await db.SaveChangesAsync(ct);
+
+        if (isMultiSelect)
+        {
+            // INV-P1 cleanup: MultiSelect value rows left with zero selections must go, and must
+            // include recycle-bin notes' rows, or a restored note resurrects a phantom "notempty".
+            await db.NotePropertyValues.IgnoreQueryFilters()
+                .Where(v => v.DefinitionId == definitionId && !v.SelectedOptions.Any())
+                .ExecuteDeleteAsync(ct);
+        }
+
+        logger.LogInformation("Property option deleted: {OptionId} on definition {DefinitionId}", optionId, definitionId);
+        return true;
+    }
+
+    // ── Note values ────────────────────────────────────────────────────────────────
+
+    /// <summary>Upsert one value. Returns null when the note (recycle-bin/unknown) or definition is
+    /// unknown → 404. Throws <see cref="NoteArchivedException"/> (403) or
+    /// <see cref="PropertyValidationException"/> (400). A checkbox-false / empty-multiselect payload
+    /// clears the value (INV-P1) and returns an empty DTO.</summary>
+    public async Task<NotePropertyValueDto?> SetValueAsync(
+        Guid noteId, Guid definitionId, SetNotePropertyValueRequest req, CancellationToken ct = default)
+    {
+        var note = await db.Notes
+            .Where(n => n.Id == noteId)
+            .Select(n => new { n.ArchivedAt })
+            .FirstOrDefaultAsync(ct);              // global filter → recycle-bin note invisible → 404
+        if (note is null) return null;
+        if (note.ArchivedAt is not null) throw new NoteArchivedException();
+
+        var def = await db.PropertyDefinitions.Include(d => d.Options).FirstOrDefaultAsync(d => d.Id == definitionId, ct);
+        if (def is null) return null;
+
+        var (clearRequested, text, optionIds) = ValidatePayload(def, req);
+
+        var row = await db.NotePropertyValues
+            .Include(v => v.SelectedOptions)
+            .FirstOrDefaultAsync(v => v.NoteId == noteId && v.DefinitionId == definitionId, ct);
+
+        if (clearRequested)
+        {
+            if (row is not null)
+            {
+                db.NotePropertyValues.Remove(row);
+                await db.SaveChangesAsync(ct);
+            }
+            logger.LogInformation("Property {DefinitionId} cleared on note {NoteId}", definitionId, noteId);
+            return EmptyValueDto(def);
+        }
+
+        if (row is null)
+        {
+            row = new NotePropertyValue { NoteId = noteId, DefinitionId = definitionId };
+            db.NotePropertyValues.Add(row);
+        }
+
+        // Null out ALL typed columns first, then set only the one for def.Type — heals any drift
+        // from a prior type and keeps INV-P1.
+        row.TextValue = null;
+        row.NumberValue = null;
+        row.DateValue = null;
+        row.BoolValue = null;
+        row.SelectedOptionId = null;
+
+        switch (def.Type)
+        {
+            case PropertyType.Text:
+                row.TextValue = text;
+                break;
+            case PropertyType.Number:
+                row.NumberValue = req.NumberValue;
+                break;
+            case PropertyType.Date:
+                row.DateValue = req.DateValue;
+                break;
+            case PropertyType.Checkbox:
+                row.BoolValue = true;                 // only true is ever stored (INV-P1)
+                break;
+            case PropertyType.Select:
+                row.SelectedOptionId = req.OptionId;
+                break;
+            case PropertyType.MultiSelect:
+                var target = optionIds.ToHashSet();
+                foreach (var s in row.SelectedOptions.Where(s => !target.Contains(s.OptionId)).ToList())
+                    db.NotePropertySelectedOptions.Remove(s);
+                var existing = row.SelectedOptions.Select(s => s.OptionId).ToHashSet();
+                foreach (var oid in optionIds.Where(oid => !existing.Contains(oid)))
+                    row.SelectedOptions.Add(new NotePropertySelectedOption
+                    {
+                        NoteId = noteId,
+                        DefinitionId = definitionId,
+                        OptionId = oid
+                    });
+                break;
+        }
+
+        await db.SaveChangesAsync(ct);             // NoteItem untouched — no UpdatedAt bump
+        logger.LogInformation("Property {DefinitionId} set on note {NoteId}", definitionId, noteId);
+        return BuildValueDto(def, row);
+    }
+
+    /// <summary>Clear one value (idempotent). Returns false when the note is unknown/recycle-bin
+    /// (→ 404); throws <see cref="NoteArchivedException"/> (403). Missing value row → true (204).</summary>
+    public async Task<bool> ClearValueAsync(Guid noteId, Guid definitionId, CancellationToken ct = default)
+    {
+        var note = await db.Notes
+            .Where(n => n.Id == noteId)
+            .Select(n => new { n.ArchivedAt })
+            .FirstOrDefaultAsync(ct);
+        if (note is null) return false;
+        if (note.ArchivedAt is not null) throw new NoteArchivedException();
+
+        var row = await db.NotePropertyValues
+            .FirstOrDefaultAsync(v => v.NoteId == noteId && v.DefinitionId == definitionId, ct);
+        if (row is not null)
+        {
+            db.NotePropertyValues.Remove(row);      // selections cascade
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("Property {DefinitionId} cleared on note {NoteId}", definitionId, noteId);
+        }
+        return true;
+    }
+
+    // ── Validation / mapping helpers ─────────────────────────────────────────────
+
+    private static void RequireSelectKind(PropertyDefinition def)
+    {
+        if (def.Type is not (PropertyType.Select or PropertyType.MultiSelect))
+            throw new PropertyValidationException("Options can only be managed on Select or MultiSelect properties.");
+    }
+
+    /// <summary>Enforces the "exactly the matching member is set" rule (§7.2) and per-type checks.
+    /// Returns whether the payload is a clear (checkbox-false / empty-multiselect), the trimmed text,
+    /// and the distinct option ids for MultiSelect.</summary>
+    private static (bool clear, string? text, List<Guid> optionIds) ValidatePayload(
+        PropertyDefinition def, SetNotePropertyValueRequest req)
+    {
+        var textSet = req.TextValue is not null;
+        var numberSet = req.NumberValue is not null;
+        var dateSet = req.DateValue is not null;
+        var boolSet = req.BoolValue is not null;
+        var optionSet = req.OptionId is not null;
+        var optionsSet = req.OptionIds is not null;
+
+        void RejectForeignMembers(bool allowed)
+        {
+            // Every member except the allowed one must be null.
+            var foreign =
+                (textSet && def.Type != PropertyType.Text) ||
+                (numberSet && def.Type != PropertyType.Number) ||
+                (dateSet && def.Type != PropertyType.Date) ||
+                (boolSet && def.Type != PropertyType.Checkbox) ||
+                (optionSet && def.Type != PropertyType.Select) ||
+                (optionsSet && def.Type != PropertyType.MultiSelect);
+            if (foreign || !allowed)
+                throw new PropertyValidationException($"Only the {def.Type} value member may be set.");
+        }
+
+        switch (def.Type)
+        {
+            case PropertyType.Text:
+                RejectForeignMembers(textSet);
+                var text = req.TextValue!.Trim();
+                if (text.Length == 0)
+                    throw new PropertyValidationException("Text value is empty; use DELETE to clear the value.");
+                if (text.Length > MaxTextValueLength)
+                    throw new PropertyValidationException($"Text value exceeds {MaxTextValueLength} characters.");
+                return (false, text, []);
+
+            case PropertyType.Number:
+                RejectForeignMembers(numberSet);
+                if (!double.IsFinite(req.NumberValue!.Value))
+                    throw new PropertyValidationException("Number value must be finite.");
+                return (false, null, []);
+
+            case PropertyType.Date:
+                RejectForeignMembers(dateSet);
+                return (false, null, []);
+
+            case PropertyType.Checkbox:
+                RejectForeignMembers(boolSet);
+                return (req.BoolValue == false, null, []);   // false normalizes to a clear (INV-P1)
+
+            case PropertyType.Select:
+                RejectForeignMembers(optionSet);
+                if (!def.Options.Any(o => o.Id == req.OptionId!.Value))
+                    throw new PropertyValidationException("Option does not belong to this property.");
+                return (false, null, []);
+
+            case PropertyType.MultiSelect:
+                RejectForeignMembers(optionsSet);
+                var distinct = req.OptionIds!.Distinct().ToList();
+                if (distinct.Count == 0)
+                    return (true, null, []);                 // empty list normalizes to a clear (INV-P1)
+                if (distinct.Count != req.OptionIds!.Count)
+                    throw new PropertyValidationException("Duplicate options are not allowed.");
+                var valid = def.Options.Select(o => o.Id).ToHashSet();
+                if (!distinct.All(valid.Contains))
+                    throw new PropertyValidationException("One or more options do not belong to this property.");
+                return (false, null, distinct);
+
+            default:
+                throw new PropertyValidationException($"Unknown property type '{(int)def.Type}'.");
+        }
+    }
+
+    private static PropertyDefinitionDto ToDto(
+        PropertyDefinition d, int? valueCount = null, Func<Guid, int>? optionNoteCount = null) => new()
+        {
+            Id = d.Id,
+            Name = d.Name,
+            Type = d.Type,
+            SortOrder = d.SortOrder,
+            ValueCount = valueCount,
+            Options = d.Options
+                .OrderBy(o => o.SortOrder)
+                .ThenBy(o => o.Name)
+                .Select(o => ToDto(o, optionNoteCount?.Invoke(o.Id)))
+                .ToList()
+        };
+
+    private static PropertyOptionDto ToDto(PropertyOption o, int? noteCount = null) => new()
+    {
+        Id = o.Id,
+        Name = o.Name,
+        SortOrder = o.SortOrder,
+        NoteCount = noteCount
+    };
+
+    private static NotePropertyValueDto BuildValueDto(PropertyDefinition def, NotePropertyValue row) => new()
+    {
+        DefinitionId = def.Id,
+        Name = def.Name,
+        Type = def.Type,
+        TextValue = row.TextValue,
+        NumberValue = row.NumberValue,
+        DateValue = row.DateValue,
+        BoolValue = row.BoolValue,
+        OptionId = row.SelectedOptionId,
+        OptionIds = row.SelectedOptions.Select(s => s.OptionId).ToList()
+    };
+
+    private static NotePropertyValueDto EmptyValueDto(PropertyDefinition def) => new()
+    {
+        DefinitionId = def.Id,
+        Name = def.Name,
+        Type = def.Type
+    };
+}

--- a/Vanadium.Note.Web.Tests/Components/NotePropertyPanelSmokeTests.cs
+++ b/Vanadium.Note.Web.Tests/Components/NotePropertyPanelSmokeTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MudBlazor;
+using MudBlazor.Services;
+using Vanadium.Note.Web.Components;
+using Vanadium.Note.Web.Models;
+using Vanadium.Note.Web.Services;
+using Xunit;
+
+namespace Vanadium.Note.Web.Tests.Components;
+
+/// <summary>
+/// Regression guard for the "Add property does nothing" report on PR #372 (issue #343): the panel's
+/// "Add property" control must render and stay enabled even when no property definitions exist yet —
+/// previously the menu was disabled when the definition list was empty, so the button was a silent
+/// dead end. Renders the real component with MudBlazor services and a stubbed empty definitions
+/// response.
+/// </summary>
+public sealed class NotePropertyPanelSmokeTests : TestContext
+{
+    [Fact]
+    public void AddProperty_Renders_AndIsNotDisabled_WithNoDefinitions()
+    {
+        Services.AddMudServices();
+        Services.AddLogging();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var http = new HttpClient(new EmptyDefinitionsHandler()) { BaseAddress = new Uri("http://localhost/") };
+        Services.AddScoped(_ => new PropertyService(http, NullLogger<PropertyService>.Instance));
+
+        // MudMenu renders a MudPopover, which requires a MudPopoverProvider in the same render tree.
+        var noteId = Guid.NewGuid();
+        var cut = Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<NotePropertyPanel>(1);
+            builder.AddComponentParameter(2, nameof(NotePropertyPanel.NoteId), noteId);
+            builder.AddComponentParameter(3, nameof(NotePropertyPanel.Values), new List<NotePropertyValue>());
+            builder.AddComponentParameter(4, nameof(NotePropertyPanel.ReadOnly), false);
+            builder.CloseComponent();
+        });
+
+        // The activator button is present …
+        var addButton = cut.FindAll("button").FirstOrDefault(b => b.TextContent.Contains("Add property"));
+        Assert.NotNull(addButton);
+        // … and NOT disabled (the regression: it was disabled whenever no definitions existed).
+        Assert.False(addButton!.HasAttribute("disabled"));
+    }
+
+    private sealed class EmptyDefinitionsHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+            });
+    }
+}

--- a/Vanadium.Note.Web.Tests/Models/PropertyFilterTests.cs
+++ b/Vanadium.Note.Web.Tests/Models/PropertyFilterTests.cs
@@ -1,0 +1,69 @@
+using Vanadium.Note.Web.Models;
+using Xunit;
+
+namespace Vanadium.Note.Web.Tests.Models;
+
+/// <summary>
+/// Guards the client-side <c>pf</c> wire form (issue #343): <see cref="PropertyFilter.ToQueryValue"/>
+/// and <see cref="PropertyFilter.Parse"/> must round-trip, including values that contain the ':' /
+/// ',' separators (which must be percent-encoded so the server's split stays unambiguous).
+/// </summary>
+public sealed class PropertyFilterTests
+{
+    [Fact]
+    public void ValueOp_RoundTrips()
+    {
+        var id = Guid.NewGuid();
+        var filter = new PropertyFilter { DefinitionId = id, Op = PropertyFilterOp.Eq, Value = "hello" };
+
+        var parsed = PropertyFilter.Parse(filter.ToQueryValue());
+
+        Assert.NotNull(parsed);
+        Assert.Equal(id, parsed!.DefinitionId);
+        Assert.Equal(PropertyFilterOp.Eq, parsed.Op);
+        Assert.Equal("hello", parsed.Value);
+    }
+
+    [Fact]
+    public void ValueWithSeparators_IsEncoded_AndRoundTrips()
+    {
+        var id = Guid.NewGuid();
+        var filter = new PropertyFilter { DefinitionId = id, Op = PropertyFilterOp.Eq, Value = "a:b,c" };
+
+        var wire = filter.ToQueryValue();
+        // The raw separators must not leak into the wire form's value segment.
+        Assert.DoesNotContain("a:b", wire);
+        Assert.DoesNotContain("b,c", wire);
+
+        var parsed = PropertyFilter.Parse(wire);
+        Assert.Equal("a:b,c", parsed!.Value);
+    }
+
+    [Fact]
+    public void EmptyOp_HasNoValueSegment()
+    {
+        var id = Guid.NewGuid();
+        var filter = new PropertyFilter { DefinitionId = id, Op = PropertyFilterOp.NotEmpty };
+
+        var wire = filter.ToQueryValue();
+        Assert.Equal($"{id}:notempty", wire);
+
+        var parsed = PropertyFilter.Parse(wire);
+        Assert.Equal(PropertyFilterOp.NotEmpty, parsed!.Op);
+        Assert.Null(parsed.Value);
+    }
+
+    [Theory]
+    [InlineData("not-a-guid:eq:x")]
+    [InlineData("onlyonepart")]
+    public void Parse_Malformed_ReturnsNull(string raw) => Assert.Null(PropertyFilter.Parse(raw));
+
+    [Fact]
+    public void IsEmpty_TracksClearedValues()
+    {
+        Assert.True(new NotePropertyValue { Type = PropertyType.Text }.IsEmpty);
+        Assert.True(new NotePropertyValue { Type = PropertyType.Checkbox, BoolValue = false }.IsEmpty);
+        Assert.False(new NotePropertyValue { Type = PropertyType.Number, NumberValue = 0 }.IsEmpty);
+        Assert.False(new NotePropertyValue { Type = PropertyType.Checkbox, BoolValue = true }.IsEmpty);
+    }
+}

--- a/Vanadium.Note.Web.Tests/Services/PropertyServiceClientTests.cs
+++ b/Vanadium.Note.Web.Tests/Services/PropertyServiceClientTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Vanadium.Note.Web.Models;
+using Vanadium.Note.Web.Services;
+using Xunit;
+
+namespace Vanadium.Note.Web.Tests.Services;
+
+/// <summary>
+/// Smoke coverage for the property-aware note list client (issue #343): property filters and the
+/// property sort must be serialized into the request URL, and the definitions cache must be
+/// invalidated after a mutation so a stale definition list never lingers.
+/// </summary>
+public sealed class PropertyServiceClientTests
+{
+    [Fact]
+    public async Task GetAllAsync_SerializesPropertyFilters_AndPropertySort()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"items\":[],\"totalCount\":0,\"page\":1,\"pageSize\":30}");
+        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var service = new NoteService(client, NullLogger<NoteService>.Instance);
+
+        var defId = Guid.NewGuid();
+        await service.GetAllAsync(
+            sortBy: $"prop:{defId}",
+            propertyFilters: [new PropertyFilter { DefinitionId = defId, Op = PropertyFilterOp.Gte, Value = "5" }]);
+
+        Assert.NotNull(handler.RequestUri);
+        Assert.Contains($"sortBy=prop:{defId}", handler.RequestUri!);
+        Assert.Contains($"pf={defId}:gte:5", handler.RequestUri!);
+    }
+
+    [Fact]
+    public async Task CreateDefinition_InvalidatesCache()
+    {
+        // First GET populates the cache; the create response then invalidates it, so the next GET
+        // must hit the network again (two GETs total across the sequence).
+        var handler = new SequenceHandler();
+        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var service = new PropertyService(client, NullLogger<PropertyService>.Instance);
+
+        await service.GetDefinitionsAsync();                 // GET #1 (network)
+        await service.GetDefinitionsAsync();                 // served from cache (no network)
+        Assert.Equal(1, handler.GetCount);
+
+        await service.CreateDefinitionAsync(new CreatePropertyDefinitionRequest("P", PropertyType.Text));
+        await service.GetDefinitionsAsync();                 // GET #2 (cache invalidated)
+        Assert.Equal(2, handler.GetCount);
+    }
+
+    private sealed class CapturingHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        public string? RequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUri = Uri.UnescapeDataString(request.RequestUri!.ToString());
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class SequenceHandler : HttpMessageHandler
+    {
+        public int GetCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Get)
+                GetCount++;
+            var body = request.Method == HttpMethod.Get
+                ? "[]"
+                : "{\"id\":\"" + Guid.NewGuid() + "\",\"name\":\"P\",\"type\":0,\"sortOrder\":0,\"options\":[]}";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/Vanadium.Note.Web/Components/NotePropertyPanel.razor
+++ b/Vanadium.Note.Web/Components/NotePropertyPanel.razor
@@ -30,7 +30,11 @@
             @foreach (var row in _rows)
             {
                 <div class="property-row">
-                    <span class="property-row-name">@row.Definition.Name</span>
+                    <span class="property-row-name">
+                        <MudIcon Icon="@TypeIcon(row.Definition.Type)" Size="Size.Small"
+                                 Class="property-type-icon" Title="@row.Definition.Type.ToString()" />
+                        @row.Definition.Name
+                    </span>
                     <div class="property-row-value">
                         <PropertyValueEditor Definition="row.Definition"
                                              Value="row.Value"
@@ -54,7 +58,7 @@
                          Variant="Variant.Text" Size="Size.Small" Dense="true" Class="property-add-menu">
                     @foreach (var def in addable)
                     {
-                        <MudMenuItem OnClick="@(() => AddRow(def))">@def.Name</MudMenuItem>
+                        <MudMenuItem Icon="@TypeIcon(def.Type)" OnClick="@(() => AddRow(def))">@def.Name</MudMenuItem>
                     }
                     @if (addable.Count == 0)
                     {
@@ -205,4 +209,6 @@
     private void ToggleCollapsed() => _collapsed = !_collapsed;
 
     private void GoToProperties() => Nav.NavigateTo("/properties");
+
+    private static string TypeIcon(PropertyType type) => PropertyTypeIcons.For(type);
 }

--- a/Vanadium.Note.Web/Components/NotePropertyPanel.razor
+++ b/Vanadium.Note.Web/Components/NotePropertyPanel.razor
@@ -4,6 +4,7 @@
    note save. Pure Blazor + MudBlazor; no tiptapInterop contact (§7.8). *@
 @using Vanadium.Note.Web.Models
 @inject PropertyService PropertyService
+@inject NavigationManager Nav
 @inject ISnackbar Snackbar
 @inject ILogger<NotePropertyPanel> Logger
 
@@ -49,18 +50,22 @@
             @if (!ReadOnly)
             {
                 var addable = AddableDefinitions.ToList();
-                <MudMenu Dense="true" Disabled="addable.Count == 0" Class="property-add-menu">
-                    <ActivatorContent>
-                        <MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Text">
-                            Add property
-                        </MudButton>
-                    </ActivatorContent>
-                    <ChildContent>
-                        @foreach (var def in addable)
-                        {
-                            <MudMenuItem OnClick="() => AddRow(def)">@def.Name</MudMenuItem>
-                        }
-                    </ChildContent>
+                <MudMenu Label="Add property" StartIcon="@Icons.Material.Filled.Add"
+                         Variant="Variant.Text" Size="Size.Small" Dense="true" Class="property-add-menu">
+                    @foreach (var def in addable)
+                    {
+                        <MudMenuItem OnClick="@(() => AddRow(def))">@def.Name</MudMenuItem>
+                    }
+                    @if (addable.Count == 0)
+                    {
+                        <MudMenuItem Disabled="true">
+                            @(_definitions.Count == 0 ? "No properties defined yet" : "All properties added")
+                        </MudMenuItem>
+                    }
+                    <MudDivider />
+                    <MudMenuItem Icon="@Icons.Material.Filled.Settings" OnClick="GoToProperties">
+                        Manage properties…
+                    </MudMenuItem>
                 </MudMenu>
             }
         </div>
@@ -198,4 +203,6 @@
     }
 
     private void ToggleCollapsed() => _collapsed = !_collapsed;
+
+    private void GoToProperties() => Nav.NavigateTo("/properties");
 }

--- a/Vanadium.Note.Web/Components/NotePropertyPanel.razor
+++ b/Vanadium.Note.Web/Components/NotePropertyPanel.razor
@@ -1,0 +1,201 @@
+@* Editor property panel between the title and the Tiptap body (issue #343, §9.2). Shows non-empty
+   values only; "Add property" reveals empty definitions. Each value change saves immediately via the
+   dedicated value endpoints — it never rides the note content auto-save, and never posts through
+   note save. Pure Blazor + MudBlazor; no tiptapInterop contact (§7.8). *@
+@using Vanadium.Note.Web.Models
+@inject PropertyService PropertyService
+@inject ISnackbar Snackbar
+@inject ILogger<NotePropertyPanel> Logger
+
+<div class="property-panel">
+    <div class="property-panel-header" @onclick="ToggleCollapsed">
+        <MudIcon Icon="@(_collapsed ? Icons.Material.Filled.ChevronRight : Icons.Material.Filled.ExpandMore)"
+                 Size="Size.Small" />
+        <span class="property-panel-title">Properties@(_rows.Count > 0 ? $" ({_rows.Count})" : "")</span>
+        @if (_saving)
+        {
+            <span class="property-panel-saving">Saving…</span>
+        }
+    </div>
+
+    @if (!_collapsed)
+    {
+        <div class="property-panel-body">
+            @if (_rows.Count == 0 && ReadOnly)
+            {
+                <div class="property-panel-empty">No properties set.</div>
+            }
+
+            @foreach (var row in _rows)
+            {
+                <div class="property-row">
+                    <span class="property-row-name">@row.Definition.Name</span>
+                    <div class="property-row-value">
+                        <PropertyValueEditor Definition="row.Definition"
+                                             Value="row.Value"
+                                             ReadOnly="ReadOnly"
+                                             OnCommit="req => CommitAsync(row, req)" />
+                    </div>
+                    @if (!ReadOnly)
+                    {
+                        <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small"
+                                       Class="property-row-remove"
+                                       aria-label="@($"Clear {row.Definition.Name}")"
+                                       OnClick="() => ClearAsync(row)" />
+                    }
+                </div>
+            }
+
+            @if (!ReadOnly)
+            {
+                var addable = AddableDefinitions.ToList();
+                <MudMenu Dense="true" Disabled="addable.Count == 0" Class="property-add-menu">
+                    <ActivatorContent>
+                        <MudButton StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Variant="Variant.Text">
+                            Add property
+                        </MudButton>
+                    </ActivatorContent>
+                    <ChildContent>
+                        @foreach (var def in addable)
+                        {
+                            <MudMenuItem OnClick="() => AddRow(def)">@def.Name</MudMenuItem>
+                        }
+                    </ChildContent>
+                </MudMenu>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public Guid NoteId { get; set; }
+
+    /// <summary>The note's non-empty values at load time (from GET /api/notes/{id}).</summary>
+    [Parameter] public List<NotePropertyValue> Values { get; set; } = [];
+
+    [Parameter] public bool ReadOnly { get; set; }
+
+    /// <summary>Raised when a value write returns 403 — the note was archived elsewhere, so the
+    /// editor should flip to read-only (same UX rule as the archive feature, E1).</summary>
+    [Parameter] public EventCallback OnArchivedElsewhere { get; set; }
+
+    private readonly List<PanelRow> _rows = [];
+    private List<PropertyDefinition> _definitions = [];
+    private bool _collapsed;
+    private bool _saving;
+    private Guid _loadedNoteId;
+
+    private sealed class PanelRow
+    {
+        public required PropertyDefinition Definition { get; init; }
+        public NotePropertyValue? Value { get; set; }
+    }
+
+    private IEnumerable<PropertyDefinition> AddableDefinitions =>
+        _definitions
+            .Where(d => _rows.All(r => r.Definition.Id != d.Id))
+            .OrderBy(d => d.SortOrder)
+            .ThenBy(d => d.Name);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Rebuild only when the note actually changes (the component is reused across navigations).
+        if (_loadedNoteId == NoteId && _definitions.Count > 0) return;
+        _loadedNoteId = NoteId;
+
+        var defsResult = await PropertyService.GetDefinitionsAsync();
+        _definitions = defsResult.IsSuccess ? defsResult.Value! : [];
+        RebuildRows();
+    }
+
+    private void RebuildRows()
+    {
+        _rows.Clear();
+        foreach (var value in Values.OrderBy(v => DefinitionSort(v.DefinitionId)))
+        {
+            var def = _definitions.FirstOrDefault(d => d.Id == value.DefinitionId);
+            if (def is not null)
+                _rows.Add(new PanelRow { Definition = def, Value = value });
+        }
+    }
+
+    private int DefinitionSort(Guid definitionId) =>
+        _definitions.FirstOrDefault(d => d.Id == definitionId)?.SortOrder ?? int.MaxValue;
+
+    private void AddRow(PropertyDefinition def)
+    {
+        if (_rows.Any(r => r.Definition.Id == def.Id)) return;
+        _rows.Add(new PanelRow { Definition = def, Value = null });
+    }
+
+    private async Task CommitAsync(PanelRow row, SetNotePropertyValueRequest req)
+    {
+        _saving = true;
+        try
+        {
+            var result = await PropertyService.SetValueAsync(NoteId, row.Definition.Id, req);
+            if (result.IsForbidden)
+            {
+                Snackbar.Add("This note is archived and read-only.", Severity.Warning);
+                await OnArchivedElsewhere.InvokeAsync();
+                return;
+            }
+            if (result.IsNotFound)
+            {
+                Snackbar.Add("This property or note no longer exists.", Severity.Warning);
+                PropertyService.InvalidateCache();
+                _rows.Remove(row);
+                return;
+            }
+            if (!result.IsSuccess)
+            {
+                Snackbar.Add(result.Error ?? "Failed to save property value.", Severity.Error);
+                return;
+            }
+
+            // Empty response (checkbox false / cleared) drops the row from the panel.
+            if (result.Value!.IsEmpty)
+                _rows.Remove(row);
+            else
+                row.Value = result.Value;
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task ClearAsync(PanelRow row)
+    {
+        // A row that was just added but never committed has no server value — drop it locally.
+        if (row.Value is null)
+        {
+            _rows.Remove(row);
+            return;
+        }
+
+        _saving = true;
+        try
+        {
+            var result = await PropertyService.ClearValueAsync(NoteId, row.Definition.Id);
+            if (result.IsForbidden)
+            {
+                Snackbar.Add("This note is archived and read-only.", Severity.Warning);
+                await OnArchivedElsewhere.InvokeAsync();
+                return;
+            }
+            if (!result.IsSuccess && !result.IsNotFound)
+            {
+                Snackbar.Add(result.Error ?? "Failed to clear property value.", Severity.Error);
+                return;
+            }
+            _rows.Remove(row);
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private void ToggleCollapsed() => _collapsed = !_collapsed;
+}

--- a/Vanadium.Note.Web/Components/NotePropertyPanel.razor.css
+++ b/Vanadium.Note.Web/Components/NotePropertyPanel.razor.css
@@ -44,10 +44,19 @@
 }
 
 .property-row-name {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
     min-width: 120px;
-    max-width: 160px;
+    max-width: 180px;
     font-size: 0.85rem;
     color: var(--mud-palette-text-secondary, #666);
+    flex-shrink: 0;
+}
+
+.property-type-icon {
+    font-size: 1rem;
+    opacity: 0.7;
     flex-shrink: 0;
 }
 

--- a/Vanadium.Note.Web/Components/NotePropertyPanel.razor.css
+++ b/Vanadium.Note.Web/Components/NotePropertyPanel.razor.css
@@ -1,0 +1,57 @@
+.property-panel {
+    margin: 0.25rem 0 0.75rem;
+    border-top: 1px solid var(--mud-palette-lines-default, rgba(0,0,0,0.12));
+    border-bottom: 1px solid var(--mud-palette-lines-default, rgba(0,0,0,0.12));
+    padding: 0.25rem 0;
+}
+
+.property-panel-header {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    cursor: pointer;
+    padding: 0.25rem 0.25rem;
+    user-select: none;
+}
+
+.property-panel-title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--mud-palette-text-secondary, #666);
+}
+
+.property-panel-saving {
+    font-size: 0.75rem;
+    color: var(--mud-palette-text-secondary, #999);
+    margin-left: auto;
+}
+
+.property-panel-body {
+    padding: 0.25rem 0.25rem 0.5rem;
+}
+
+.property-panel-empty {
+    font-size: 0.85rem;
+    color: var(--mud-palette-text-secondary, #999);
+    padding: 0.25rem 0;
+}
+
+.property-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.15rem 0;
+}
+
+.property-row-name {
+    min-width: 120px;
+    max-width: 160px;
+    font-size: 0.85rem;
+    color: var(--mud-palette-text-secondary, #666);
+    flex-shrink: 0;
+}
+
+.property-row-value {
+    flex-grow: 1;
+    min-width: 0;
+}

--- a/Vanadium.Note.Web/Components/PropertyFilterBar.razor
+++ b/Vanadium.Note.Web/Components/PropertyFilterBar.razor
@@ -1,0 +1,233 @@
+@* Property filter bar for Home and Board (issue #343, §9.4). Renders the active property filters as
+   removable chips and an inline "Add filter" builder (definition → operator → value). Filters are
+   owned by the parent (kept in memory, like the existing search/label filter state) and applied on
+   change via OnChanged. *@
+@using Vanadium.Note.Web.Models
+@inject PropertyService PropertyService
+
+@if (_definitions.Count > 0)
+{
+    <div class="property-filter-bar">
+        <span class="property-filter-label">Properties:</span>
+
+        @foreach (var filter in Filters)
+        {
+            <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Filled"
+                     OnClose="() => RemoveFilter(filter)">
+                @DescribeFilter(filter)
+            </MudChip>
+        }
+
+        @if (_adding)
+        {
+            <div class="property-filter-builder">
+                <MudSelect T="Guid" Value="_addDefinitionId" ValueChanged="OnDefinitionChosen" Dense="true"
+                           Margin="Margin.Dense" Placeholder="Property" Style="min-width: 130px;">
+                    @foreach (var def in _definitions)
+                    {
+                        <MudSelectItem T="Guid" Value="@def.Id">@def.Name</MudSelectItem>
+                    }
+                </MudSelect>
+
+                @if (_addDefinition is not null)
+                {
+                    <MudSelect T="PropertyFilterOp" @bind-Value="_addOp" Dense="true" Margin="Margin.Dense"
+                               Style="min-width: 110px;">
+                        @foreach (var op in OperatorsFor(_addDefinition.Type))
+                        {
+                            <MudSelectItem T="PropertyFilterOp" Value="@op">@OpLabel(op)</MudSelectItem>
+                        }
+                    </MudSelect>
+
+                    @if (NeedsValue(_addOp))
+                    {
+                        @switch (_addDefinition.Type)
+                        {
+                            case PropertyType.Text:
+                                <MudTextField T="string" @bind-Value="_addText" Margin="Margin.Dense"
+                                              Placeholder="Value" Style="min-width: 120px;" />
+                                break;
+                            case PropertyType.Number:
+                                <MudNumericField T="double?" @bind-Value="_addNumber" Margin="Margin.Dense"
+                                                 Placeholder="Value" Style="min-width: 100px;" />
+                                break;
+                            case PropertyType.Date:
+                                <MudDatePicker Date="_addDate" DateChanged="d => _addDate = d" Margin="Margin.Dense"
+                                               DateFormat="yyyy-MM-dd" Placeholder="Date" Style="min-width: 140px;" />
+                                break;
+                            case PropertyType.Checkbox:
+                                <MudSelect T="bool" @bind-Value="_addBool" Dense="true" Margin="Margin.Dense"
+                                           Style="min-width: 110px;">
+                                    <MudSelectItem T="bool" Value="true">checked</MudSelectItem>
+                                    <MudSelectItem T="bool" Value="false">unchecked (or not set)</MudSelectItem>
+                                </MudSelect>
+                                break;
+                            case PropertyType.Select:
+                            case PropertyType.MultiSelect:
+                                <MudSelect T="Guid" SelectedValues="_addOptions"
+                                           SelectedValuesChanged="v => _addOptions = v.ToHashSet()"
+                                           MultiSelection="true" Dense="true" Margin="Margin.Dense"
+                                           Placeholder="Options" Style="min-width: 150px;">
+                                    @foreach (var opt in _addDefinition.Options.OrderBy(o => o.SortOrder))
+                                    {
+                                        <MudSelectItem T="Guid" Value="@opt.Id">@opt.Name</MudSelectItem>
+                                    }
+                                </MudSelect>
+                                break;
+                        }
+                    }
+
+                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                               OnClick="AddFilter">Add</MudButton>
+                }
+
+                <MudButton Size="Size.Small" OnClick="CancelAdd">Cancel</MudButton>
+            </div>
+        }
+        else
+        {
+            <MudButton Size="Size.Small" StartIcon="@Icons.Material.Filled.FilterAlt" Variant="Variant.Text"
+                       OnClick="StartAdd">Add filter</MudButton>
+            @if (Filters.Count > 0)
+            {
+                <MudButton Size="Size.Small" OnClick="ClearAll">Clear</MudButton>
+            }
+        }
+    </div>
+}
+
+@code {
+    [Parameter, EditorRequired] public List<PropertyFilter> Filters { get; set; } = [];
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private List<PropertyDefinition> _definitions = [];
+    private bool _adding;
+    private Guid _addDefinitionId;
+    private PropertyDefinition? _addDefinition;
+    private PropertyFilterOp _addOp = PropertyFilterOp.Eq;
+    private string? _addText;
+    private double? _addNumber;
+    private DateTime? _addDate;
+    private bool _addBool = true;
+    private IReadOnlyCollection<Guid> _addOptions = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        var result = await PropertyService.GetDefinitionsAsync();
+        _definitions = result.IsSuccess
+            ? result.Value!.OrderBy(d => d.SortOrder).ThenBy(d => d.Name).ToList()
+            : [];
+    }
+
+    private void StartAdd()
+    {
+        _adding = true;
+        _addDefinitionId = _definitions.FirstOrDefault()?.Id ?? Guid.Empty;
+        OnDefinitionChosen(_addDefinitionId);
+    }
+
+    private void OnDefinitionChosen(Guid id)
+    {
+        _addDefinitionId = id;
+        _addDefinition = _definitions.FirstOrDefault(d => d.Id == id);
+        _addOp = OperatorsFor(_addDefinition?.Type ?? PropertyType.Text).First();
+        _addText = null;
+        _addNumber = null;
+        _addDate = null;
+        _addBool = true;
+        _addOptions = [];
+    }
+
+    private void CancelAdd()
+    {
+        _adding = false;
+        _addDefinition = null;
+    }
+
+    private async Task AddFilter()
+    {
+        if (_addDefinition is null) return;
+        var value = BuildValue();
+        if (NeedsValue(_addOp) && value is null) return;   // incomplete builder — ignore
+
+        Filters.Add(new PropertyFilter { DefinitionId = _addDefinition.Id, Op = _addOp, Value = value });
+        _adding = false;
+        _addDefinition = null;
+        await OnChanged.InvokeAsync();
+    }
+
+    private async Task RemoveFilter(PropertyFilter filter)
+    {
+        Filters.Remove(filter);
+        await OnChanged.InvokeAsync();
+    }
+
+    private async Task ClearAll()
+    {
+        Filters.Clear();
+        await OnChanged.InvokeAsync();
+    }
+
+    private string? BuildValue()
+    {
+        if (!NeedsValue(_addOp)) return null;
+        return _addDefinition!.Type switch
+        {
+            PropertyType.Text => string.IsNullOrWhiteSpace(_addText) ? null : _addText.Trim(),
+            PropertyType.Number => _addNumber?.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            PropertyType.Date => _addDate?.ToString("yyyy-MM-dd"),
+            PropertyType.Checkbox => _addBool ? "true" : "false",
+            PropertyType.Select or PropertyType.MultiSelect =>
+                _addOptions.Count == 0 ? null : string.Join(",", _addOptions),
+            _ => null
+        };
+    }
+
+    private static bool NeedsValue(PropertyFilterOp op) =>
+        op is not (PropertyFilterOp.Empty or PropertyFilterOp.NotEmpty);
+
+    private static IReadOnlyList<PropertyFilterOp> OperatorsFor(PropertyType type) => type switch
+    {
+        PropertyType.Text => [PropertyFilterOp.Eq, PropertyFilterOp.Ne, PropertyFilterOp.Empty, PropertyFilterOp.NotEmpty],
+        PropertyType.Number or PropertyType.Date =>
+            [PropertyFilterOp.Eq, PropertyFilterOp.Ne, PropertyFilterOp.Lt, PropertyFilterOp.Lte,
+             PropertyFilterOp.Gt, PropertyFilterOp.Gte, PropertyFilterOp.Empty, PropertyFilterOp.NotEmpty],
+        PropertyType.Checkbox => [PropertyFilterOp.Eq],
+        PropertyType.Select => [PropertyFilterOp.AnyOf, PropertyFilterOp.Eq, PropertyFilterOp.Empty, PropertyFilterOp.NotEmpty],
+        PropertyType.MultiSelect => [PropertyFilterOp.AnyOf, PropertyFilterOp.Eq, PropertyFilterOp.Empty, PropertyFilterOp.NotEmpty],
+        _ => [PropertyFilterOp.Eq]
+    };
+
+    private static string OpLabel(PropertyFilterOp op) => op switch
+    {
+        PropertyFilterOp.Eq => "is",
+        PropertyFilterOp.Ne => "is not",
+        PropertyFilterOp.Lt => "<",
+        PropertyFilterOp.Lte => "≤",
+        PropertyFilterOp.Gt => ">",
+        PropertyFilterOp.Gte => "≥",
+        PropertyFilterOp.Empty => "is empty",
+        PropertyFilterOp.NotEmpty => "is not empty",
+        PropertyFilterOp.AnyOf => "any of",
+        _ => op.ToString()
+    };
+
+    private string DescribeFilter(PropertyFilter filter)
+    {
+        var def = _definitions.FirstOrDefault(d => d.Id == filter.DefinitionId);
+        var name = def?.Name ?? "property";
+        if (!NeedsValue(filter.Op))
+            return $"{name} {OpLabel(filter.Op)}";
+
+        var value = filter.Value ?? "";
+        if (def is not null && def.Type is PropertyType.Select or PropertyType.MultiSelect)
+        {
+            var names = value.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(idText => Guid.TryParse(idText, out var g)
+                    ? def.Options.FirstOrDefault(o => o.Id == g)?.Name ?? idText
+                    : idText);
+            value = string.Join(", ", names);
+        }
+        return $"{name} {OpLabel(filter.Op)} {value}";
+    }
+}

--- a/Vanadium.Note.Web/Components/PropertyFilterBar.razor.css
+++ b/Vanadium.Note.Web/Components/PropertyFilterBar.razor.css
@@ -1,0 +1,22 @@
+.property-filter-bar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.property-filter-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--mud-palette-text-secondary, #666);
+}
+
+.property-filter-builder {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--mud-palette-lines-default, rgba(0,0,0,0.12));
+    border-radius: 6px;
+}

--- a/Vanadium.Note.Web/Components/PropertyOptionsDialog.razor
+++ b/Vanadium.Note.Web/Components/PropertyOptionsDialog.razor
@@ -1,0 +1,139 @@
+@* Option management for a Select/MultiSelect definition (issue #343, §9.5): add / rename / reorder /
+   delete options. Delete confirms with the usage count (incl. archived + recycle-bin notes). *@
+@using Vanadium.Note.Web.Models
+@inject PropertyService PropertyService
+@inject ConfirmService Confirm
+@inject ISnackbar Snackbar
+
+<MudDialog>
+    <DialogContent>
+        @if (_options.Count == 0)
+        {
+            <MudText Typo="Typo.body2" Class="mud-text-secondary mb-2">No options yet.</MudText>
+        }
+        @foreach (var opt in _options)
+        {
+            <div class="d-flex align-center gap-2 mb-2">
+                <MudTextField T="string" Value="@opt.Name" ValueChanged="v => RenameAsync(opt, v)"
+                              Immediate="false" Margin="Margin.Dense" Class="flex-grow-1" />
+                <MudIconButton Icon="@Icons.Material.Filled.ArrowUpward" Size="Size.Small"
+                               Disabled="_options.IndexOf(opt) == 0" OnClick="() => MoveAsync(opt, -1)" />
+                <MudIconButton Icon="@Icons.Material.Filled.ArrowDownward" Size="Size.Small"
+                               Disabled="_options.IndexOf(opt) == _options.Count - 1" OnClick="() => MoveAsync(opt, 1)" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                               OnClick="() => DeleteAsync(opt)" />
+            </div>
+        }
+
+        <div class="d-flex align-center gap-2 mt-3">
+            <MudTextField T="string" @bind-Value="_newOption" Label="New option" MaxLength="100"
+                          Immediate="true" Margin="Margin.Dense" Class="flex-grow-1"
+                          OnKeyDown="OnNewKeyDown" />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="AddAsync"
+                       Disabled="string.IsNullOrWhiteSpace(_newOption)">Add</MudButton>
+        </div>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close">Done</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter, EditorRequired] public PropertyDefinition Definition { get; set; } = null!;
+
+    private List<PropertyOption> _options = [];
+    private string _newOption = string.Empty;
+    private bool _changed;
+
+    protected override void OnInitialized() => ReloadFromDefinition();
+
+    private void ReloadFromDefinition() =>
+        _options = Definition.Options.OrderBy(o => o.SortOrder).ThenBy(o => o.Name).ToList();
+
+    private async Task AddAsync()
+    {
+        var name = _newOption.Trim();
+        if (name.Length == 0) return;
+        var result = await PropertyService.AddOptionAsync(Definition.Id, new CreatePropertyOptionRequest(name));
+        if (result.IsSuccess)
+        {
+            Definition.Options.Add(result.Value!);
+            _newOption = string.Empty;
+            _changed = true;
+            ReloadFromDefinition();
+        }
+        else
+        {
+            Snackbar.Add(result.Error ?? "Failed to add option.", Severity.Error);
+        }
+    }
+
+    private Task OnNewKeyDown(KeyboardEventArgs e) =>
+        e.Key == "Enter" ? AddAsync() : Task.CompletedTask;
+
+    private async Task RenameAsync(PropertyOption opt, string newName)
+    {
+        newName = newName?.Trim() ?? string.Empty;
+        if (newName.Length == 0 || newName == opt.Name) return;
+        var result = await PropertyService.UpdateOptionAsync(
+            Definition.Id, opt.Id, new UpdatePropertyOptionRequest(newName, opt.SortOrder));
+        if (result.IsSuccess)
+        {
+            opt.Name = newName;
+            _changed = true;
+        }
+        else
+        {
+            Snackbar.Add(result.Error ?? "Failed to rename option.", Severity.Error);
+            ReloadFromDefinition();   // revert the text field to the stored name
+        }
+    }
+
+    private async Task MoveAsync(PropertyOption opt, int delta)
+    {
+        var index = _options.IndexOf(opt);
+        var target = index + delta;
+        if (target < 0 || target >= _options.Count) return;
+        var other = _options[target];
+
+        // Swap sort orders on the server, then locally.
+        var a = await PropertyService.UpdateOptionAsync(
+            Definition.Id, opt.Id, new UpdatePropertyOptionRequest(opt.Name, other.SortOrder));
+        var b = await PropertyService.UpdateOptionAsync(
+            Definition.Id, other.Id, new UpdatePropertyOptionRequest(other.Name, opt.SortOrder));
+        if (a.IsSuccess && b.IsSuccess)
+        {
+            (opt.SortOrder, other.SortOrder) = (other.SortOrder, opt.SortOrder);
+            _changed = true;
+            ReloadFromDefinition();
+        }
+        else
+        {
+            Snackbar.Add("Failed to reorder options.", Severity.Error);
+        }
+    }
+
+    private async Task DeleteAsync(PropertyOption opt)
+    {
+        var confirmed = await Confirm.ConfirmAsync(
+            "Delete option",
+            $"Delete '{opt.Name}'? It will be removed from every note that uses it, including archived and recycle-bin notes.",
+            "Delete");
+        if (!confirmed) return;
+
+        var result = await PropertyService.DeleteOptionAsync(Definition.Id, opt.Id);
+        if (result.IsSuccess)
+        {
+            Definition.Options.RemoveAll(o => o.Id == opt.Id);
+            _changed = true;
+            ReloadFromDefinition();
+        }
+        else
+        {
+            Snackbar.Add(result.Error ?? "Failed to delete option.", Severity.Error);
+        }
+    }
+
+    private void Close() => MudDialog.Close(DialogResult.Ok(_changed));
+}

--- a/Vanadium.Note.Web/Components/PropertyTypeIcons.cs
+++ b/Vanadium.Note.Web/Components/PropertyTypeIcons.cs
@@ -1,0 +1,20 @@
+using MudBlazor;
+using Vanadium.Note.Web.Models;
+
+namespace Vanadium.Note.Web.Components;
+
+/// <summary>Maps a <see cref="PropertyType"/> to a distinct MudBlazor Material icon so property
+/// pickers, panels, and the management page can show at a glance what type a property is (issue #343).</summary>
+public static class PropertyTypeIcons
+{
+    public static string For(PropertyType type) => type switch
+    {
+        PropertyType.Text => Icons.Material.Filled.Notes,
+        PropertyType.Number => Icons.Material.Filled.Tag,
+        PropertyType.Select => Icons.Material.Filled.RadioButtonChecked,
+        PropertyType.MultiSelect => Icons.Material.Filled.Checklist,
+        PropertyType.Date => Icons.Material.Filled.CalendarToday,
+        PropertyType.Checkbox => Icons.Material.Filled.CheckBox,
+        _ => Icons.Material.Filled.Label
+    };
+}

--- a/Vanadium.Note.Web/Components/PropertyValueEditor.razor
+++ b/Vanadium.Note.Web/Components/PropertyValueEditor.razor
@@ -1,0 +1,154 @@
+@* One property value control, switched on the definition type (issue #343, §9.2). Purely
+   presentational: it seeds its controls from Value and raises OnCommit with a request the parent
+   (NotePropertyPanel) persists. No HTTP here. *@
+@using Vanadium.Note.Web.Models
+
+@switch (Definition.Type)
+{
+    case PropertyType.Text:
+        <MudTextField T="string" @bind-Value="_text" Disabled="ReadOnly" Immediate="false"
+                      Placeholder="Empty" Variant="Variant.Text" Margin="Margin.Dense"
+                      OnBlur="CommitText" OnKeyDown="OnTextKeyDown" Class="property-value-control" />
+        break;
+
+    case PropertyType.Number:
+        <MudNumericField T="double?" @bind-Value="_number" Disabled="ReadOnly" Immediate="false"
+                         Placeholder="Empty" Variant="Variant.Text" Margin="Margin.Dense"
+                         OnBlur="CommitNumber" Class="property-value-control" />
+        break;
+
+    case PropertyType.Date:
+        <MudDatePicker Date="_date" DateChanged="OnDateChanged" Disabled="ReadOnly"
+                       DateFormat="yyyy-MM-dd" Placeholder="Empty" Variant="Variant.Text"
+                       Margin="Margin.Dense" Class="property-value-control" />
+        break;
+
+    case PropertyType.Checkbox:
+        <MudCheckBox T="bool" Value="_bool" ValueChanged="OnBoolChanged" Disabled="ReadOnly"
+                     Dense="true" Color="Color.Primary" />
+        break;
+
+    case PropertyType.Select:
+        <MudSelect T="Guid?" Value="_option" ValueChanged="OnOptionChanged" Disabled="ReadOnly"
+                   Clearable="true" Dense="true" Variant="Variant.Text" Margin="Margin.Dense"
+                   Placeholder="Empty" Class="property-value-control">
+            @foreach (var opt in OrderedOptions)
+            {
+                <MudSelectItem T="Guid?" Value="@opt.Id">@opt.Name</MudSelectItem>
+            }
+        </MudSelect>
+        break;
+
+    case PropertyType.MultiSelect:
+        <MudSelect T="Guid" SelectedValues="_options" SelectedValuesChanged="OnOptionsChanged"
+                   MultiSelection="true" Disabled="ReadOnly" Dense="true" Variant="Variant.Text"
+                   Margin="Margin.Dense" Placeholder="Empty" Class="property-value-control"
+                   MultiSelectionTextFunc="@(_ => MultiSelectionText())">
+            @foreach (var opt in OrderedOptions)
+            {
+                <MudSelectItem T="Guid" Value="@opt.Id">@opt.Name</MudSelectItem>
+            }
+        </MudSelect>
+        break;
+}
+
+@code {
+    [Parameter, EditorRequired] public PropertyDefinition Definition { get; set; } = null!;
+    [Parameter] public NotePropertyValue? Value { get; set; }
+    [Parameter] public bool ReadOnly { get; set; }
+
+    /// <summary>Raised when the control commits a change; the parent persists it.</summary>
+    [Parameter] public EventCallback<SetNotePropertyValueRequest> OnCommit { get; set; }
+
+    private string? _text;
+    private double? _number;
+    private DateTime? _date;
+    private bool _bool;
+    private Guid? _option;
+    private IReadOnlyCollection<Guid> _options = [];
+
+    private IEnumerable<PropertyOption> OrderedOptions =>
+        Definition.Options.OrderBy(o => o.SortOrder).ThenBy(o => o.Name);
+
+    protected override void OnParametersSet()
+    {
+        _text = Value?.TextValue;
+        _number = Value?.NumberValue;
+        _date = Value?.DateValue?.ToDateTime(TimeOnly.MinValue);
+        _bool = Value?.BoolValue ?? false;
+        _option = Value?.OptionId;
+        _options = Value?.OptionIds is { } ids ? ids.ToHashSet() : [];
+    }
+
+    private async Task CommitText()
+    {
+        var trimmed = _text?.Trim();
+        // An empty text box means "clear"; the parent maps that to a DELETE.
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            if (Value?.TextValue is not null)
+                await OnCommit.InvokeAsync(new SetNotePropertyValueRequest());
+            return;
+        }
+        if (trimmed == Value?.TextValue) return;
+        await OnCommit.InvokeAsync(new SetNotePropertyValueRequest { TextValue = trimmed });
+    }
+
+    private Task OnTextKeyDown(KeyboardEventArgs e) =>
+        e.Key == "Enter" ? CommitText() : Task.CompletedTask;
+
+    private async Task CommitNumber()
+    {
+        if (_number is null)
+        {
+            if (Value?.NumberValue is not null)
+                await OnCommit.InvokeAsync(new SetNotePropertyValueRequest());
+            return;
+        }
+        if (_number == Value?.NumberValue) return;
+        await OnCommit.InvokeAsync(new SetNotePropertyValueRequest { NumberValue = _number });
+    }
+
+    private async Task OnDateChanged(DateTime? date)
+    {
+        _date = date;
+        if (date is null)
+        {
+            await OnCommit.InvokeAsync(new SetNotePropertyValueRequest());
+            return;
+        }
+        await OnCommit.InvokeAsync(new SetNotePropertyValueRequest
+        {
+            DateValue = DateOnly.FromDateTime(date.Value)
+        });
+    }
+
+    private async Task OnBoolChanged(bool value)
+    {
+        _bool = value;
+        // false normalizes to a clear on the server (INV-P1); we still send it via the value endpoint.
+        await OnCommit.InvokeAsync(new SetNotePropertyValueRequest { BoolValue = value });
+    }
+
+    private async Task OnOptionChanged(Guid? option)
+    {
+        _option = option;
+        await OnCommit.InvokeAsync(option is null
+            ? new SetNotePropertyValueRequest()
+            : new SetNotePropertyValueRequest { OptionId = option });
+    }
+
+    private async Task OnOptionsChanged(IReadOnlyCollection<Guid> options)
+    {
+        _options = options.ToHashSet();
+        await OnCommit.InvokeAsync(new SetNotePropertyValueRequest { OptionIds = _options.ToList() });
+    }
+
+    private string MultiSelectionText()
+    {
+        var names = _options
+            .Select(id => Definition.Options.FirstOrDefault(o => o.Id == id)?.Name)
+            .Where(n => n is not null);
+        return string.Join(", ", names);
+    }
+}

--- a/Vanadium.Note.Web/Layout/NavMenu.razor
+++ b/Vanadium.Note.Web/Layout/NavMenu.razor
@@ -28,6 +28,11 @@
                 </NavLink>
             </div>
             <div class="nav-item px-3">
+                <NavLink class="nav-link" href="properties">
+                    <span class="bi bi-sliders-nav-menu" aria-hidden="true"></span> Properties
+                </NavLink>
+            </div>
+            <div class="nav-item px-3">
                 <NavLink class="nav-link" href="archive">
                     <span class="bi bi-archive-nav-menu" aria-hidden="true"></span> Archive
                 </NavLink>

--- a/Vanadium.Note.Web/Layout/NavMenu.razor.css
+++ b/Vanadium.Note.Web/Layout/NavMenu.razor.css
@@ -36,6 +36,10 @@
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-archive' viewBox='0 0 16 16'%3E%3Cpath d='M0 2a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1v7.5a2.5 2.5 0 0 1-2.5 2.5h-9A2.5 2.5 0 0 1 1 12.5V5a1 1 0 0 1-1-1zm2 3v7.5A1.5 1.5 0 0 0 3.5 14h9a1.5 1.5 0 0 0 1.5-1.5V5zm13-3H1v2h14zM5 7.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5'/%3E%3C/svg%3E");
 }
 
+.bi-sliders-nav-menu {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-sliders' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M11.5 2a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3M9.05 3a2.5 2.5 0 0 1 4.9 0H16v1h-2.05a2.5 2.5 0 0 1-4.9 0H0V3zM4.5 7a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3M2.05 8a2.5 2.5 0 0 1 4.9 0H16v1H6.95a2.5 2.5 0 0 1-4.9 0H0V8zm9.45 4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3m-2.45 1a2.5 2.5 0 0 1 4.9 0H16v1h-2.05a2.5 2.5 0 0 1-4.9 0H0v-1z'/%3E%3C/svg%3E");
+}
+
 .bi-recycle-bin-nav-menu {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-recycle bin' viewBox='0 0 16 16'%3E%3Cpath d='M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z'/%3E%3Cpath d='M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z'/%3E%3C/svg%3E");
 }

--- a/Vanadium.Note.Web/Models/NoteItem.cs
+++ b/Vanadium.Note.Web/Models/NoteItem.cs
@@ -24,4 +24,8 @@ public class NoteItem
     public string? ParentTitle { get; set; }
     public int ChildCount { get; set; }
     public List<Label> Labels { get; set; } = [];
+
+    /// <summary>Non-empty property values (issue #343). Server-owned — read-only here; edited via
+    /// the dedicated property value endpoints, never posted back through note save.</summary>
+    public List<NotePropertyValue> Properties { get; set; } = [];
 }

--- a/Vanadium.Note.Web/Models/NotePropertyValue.cs
+++ b/Vanadium.Note.Web/Models/NotePropertyValue.cs
@@ -1,0 +1,20 @@
+namespace Vanadium.Note.Web.Models;
+
+/// <summary>Mirror of the REST <c>NotePropertyValueDto</c>: one non-empty property value on a note.</summary>
+public class NotePropertyValue
+{
+    public Guid DefinitionId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public PropertyType Type { get; set; }
+    public string? TextValue { get; set; }
+    public double? NumberValue { get; set; }
+    public DateOnly? DateValue { get; set; }
+    public bool? BoolValue { get; set; }
+    public Guid? OptionId { get; set; }
+    public List<Guid> OptionIds { get; set; } = [];
+
+    /// <summary>True when no member carries a value — the write-response shape after a clear.</summary>
+    public bool IsEmpty =>
+        TextValue is null && NumberValue is null && DateValue is null &&
+        (BoolValue is null or false) && OptionId is null && OptionIds.Count == 0;
+}

--- a/Vanadium.Note.Web/Models/NoteSummary.cs
+++ b/Vanadium.Note.Web/Models/NoteSummary.cs
@@ -13,4 +13,7 @@ public class NoteSummary
     public bool IsArchived { get; set; }
 
     public List<Label> Labels { get; set; } = [];
+
+    /// <summary>Non-empty property values, ordered by definition sort order (issue #343).</summary>
+    public List<NotePropertyValue> Properties { get; set; } = [];
 }

--- a/Vanadium.Note.Web/Models/PropertyDefinition.cs
+++ b/Vanadium.Note.Web/Models/PropertyDefinition.cs
@@ -1,0 +1,14 @@
+namespace Vanadium.Note.Web.Models;
+
+/// <summary>Mirror of the REST <c>PropertyDefinitionDto</c>.</summary>
+public class PropertyDefinition
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public PropertyType Type { get; set; }
+    public int SortOrder { get; set; }
+    public List<PropertyOption> Options { get; set; } = [];
+
+    /// <summary>Only populated when the list was fetched with includeUsage=true.</summary>
+    public int? ValueCount { get; set; }
+}

--- a/Vanadium.Note.Web/Models/PropertyFilter.cs
+++ b/Vanadium.Note.Web/Models/PropertyFilter.cs
@@ -1,0 +1,70 @@
+namespace Vanadium.Note.Web.Models;
+
+public enum PropertyFilterOp
+{
+    Eq,
+    Ne,
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+    Empty,
+    NotEmpty,
+    AnyOf
+}
+
+/// <summary>Client-side representation of one <c>pf</c> filter. Serializes to and parses from the
+/// <c>{definitionId}:{op}[:{value}]</c> wire form used by the note list / board queries (§6.3).</summary>
+public class PropertyFilter
+{
+    public Guid DefinitionId { get; set; }
+    public PropertyFilterOp Op { get; set; }
+    public string? Value { get; set; }
+
+    /// <summary>The wire form: <c>{definitionId}:{op}[:{value}]</c> (value URL-encoded).</summary>
+    public string ToQueryValue()
+    {
+        var op = OpToken(Op);
+        return Op is PropertyFilterOp.Empty or PropertyFilterOp.NotEmpty || string.IsNullOrEmpty(Value)
+            ? $"{DefinitionId}:{op}"
+            : $"{DefinitionId}:{op}:{Uri.EscapeDataString(Value)}";
+    }
+
+    public static PropertyFilter? Parse(string raw)
+    {
+        var parts = raw.Split(':', 3);
+        if (parts.Length < 2 || !Guid.TryParse(parts[0], out var id)) return null;
+        var op = ParseOp(parts[1]);
+        if (op is null) return null;
+        var value = parts.Length == 3 ? Uri.UnescapeDataString(parts[2]) : null;
+        return new PropertyFilter { DefinitionId = id, Op = op.Value, Value = value };
+    }
+
+    public static string OpToken(PropertyFilterOp op) => op switch
+    {
+        PropertyFilterOp.Eq => "eq",
+        PropertyFilterOp.Ne => "ne",
+        PropertyFilterOp.Lt => "lt",
+        PropertyFilterOp.Lte => "lte",
+        PropertyFilterOp.Gt => "gt",
+        PropertyFilterOp.Gte => "gte",
+        PropertyFilterOp.Empty => "empty",
+        PropertyFilterOp.NotEmpty => "notempty",
+        PropertyFilterOp.AnyOf => "anyof",
+        _ => "eq"
+    };
+
+    private static PropertyFilterOp? ParseOp(string token) => token.ToLowerInvariant() switch
+    {
+        "eq" => PropertyFilterOp.Eq,
+        "ne" => PropertyFilterOp.Ne,
+        "lt" => PropertyFilterOp.Lt,
+        "lte" => PropertyFilterOp.Lte,
+        "gt" => PropertyFilterOp.Gt,
+        "gte" => PropertyFilterOp.Gte,
+        "empty" => PropertyFilterOp.Empty,
+        "notempty" => PropertyFilterOp.NotEmpty,
+        "anyof" => PropertyFilterOp.AnyOf,
+        _ => null
+    };
+}

--- a/Vanadium.Note.Web/Models/PropertyOption.cs
+++ b/Vanadium.Note.Web/Models/PropertyOption.cs
@@ -1,0 +1,12 @@
+namespace Vanadium.Note.Web.Models;
+
+/// <summary>Mirror of the REST <c>PropertyOptionDto</c>.</summary>
+public class PropertyOption
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+
+    /// <summary>Only populated when the list was fetched with includeUsage=true.</summary>
+    public int? NoteCount { get; set; }
+}

--- a/Vanadium.Note.Web/Models/PropertyRequests.cs
+++ b/Vanadium.Note.Web/Models/PropertyRequests.cs
@@ -1,0 +1,20 @@
+namespace Vanadium.Note.Web.Models;
+
+public record CreatePropertyDefinitionRequest(string Name, PropertyType Type);
+
+public record UpdatePropertyDefinitionRequest(string Name, PropertyType Type, int SortOrder);
+
+public record CreatePropertyOptionRequest(string Name);
+
+public record UpdatePropertyOptionRequest(string Name, int SortOrder);
+
+/// <summary>Exactly the member matching the definition's type is set; the rest stay null.</summary>
+public class SetNotePropertyValueRequest
+{
+    public string? TextValue { get; set; }
+    public double? NumberValue { get; set; }
+    public DateOnly? DateValue { get; set; }
+    public bool? BoolValue { get; set; }
+    public Guid? OptionId { get; set; }
+    public List<Guid>? OptionIds { get; set; }
+}

--- a/Vanadium.Note.Web/Models/PropertyType.cs
+++ b/Vanadium.Note.Web/Models/PropertyType.cs
@@ -1,0 +1,12 @@
+namespace Vanadium.Note.Web.Models;
+
+/// <summary>Mirror of the REST <c>PropertyType</c> enum (issue #343). Numeric values must match.</summary>
+public enum PropertyType
+{
+    Text = 0,
+    Number = 1,
+    Select = 2,
+    MultiSelect = 3,
+    Date = 4,
+    Checkbox = 5
+}

--- a/Vanadium.Note.Web/Pages/Board.razor
+++ b/Vanadium.Note.Web/Pages/Board.razor
@@ -1,5 +1,6 @@
 @page "/board"
 @attribute [Authorize]
+@using Vanadium.Note.Web.Components
 @inject NoteService NoteService
 @inject LabelService LabelService
 @inject NavigationManager Nav
@@ -30,6 +31,7 @@
                 }
             }
         </div>
+        <PropertyFilterBar Filters="propertyFilters" OnChanged="OnPropertyFiltersChanged" />
     </div>
 
     @if (isLoading && !notes.Any())
@@ -278,6 +280,7 @@
 
     private IReadOnlyList<NoteSummary> notes = [];
     private List<LabelCategory> categories = [];
+    private readonly List<PropertyFilter> propertyFilters = [];
     private Guid? selectedCategoryId;
     private bool isLoading = false;
     // Label ids whose column has been expanded past CardsPerColumnLimit.
@@ -319,6 +322,8 @@
         isLoading = false;
     }
 
+    private async Task OnPropertyFiltersChanged() => await LoadNotesForCurrentCategory();
+
     private async Task LoadNotesForCurrentCategory()
     {
         // A fresh load collapses every column back to the cap.
@@ -334,7 +339,8 @@
         // Load every non-archived note (no label filter) so notes that carry none of this
         // category's labels are available client-side for the "No label" virtual column (#272).
         // Server-side label filtering would drop them entirely, making them invisible on the board.
-        var notesResult = await NoteService.GetAllSummariesAsync();
+        var notesResult = await NoteService.GetAllSummariesAsync(
+            propertyFilters: propertyFilters.Count > 0 ? propertyFilters : null);
         if (!notesResult.IsSuccess)
             Snackbar.Add(notesResult.Error ?? "Failed to load notes.", Severity.Error);
         notes = notesResult.Value ?? [];

--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -1,6 +1,8 @@
 @page "/"
 @attribute [Authorize]
+@using Vanadium.Note.Web.Components
 @inject NoteService NoteService
+@inject PropertyService PropertyService
 @inject SettingsService SettingsService
 @inject NavigationManager Nav
 @inject ConfirmService Confirm
@@ -125,6 +127,33 @@
         </div>
     }
 
+    @if (propertyDefinitions.Count > 0)
+    {
+        <div class="property-controls-bar">
+            <PropertyFilterBar Filters="propertyFilters" OnChanged="OnPropertyFiltersChanged" />
+            @if (SortableProperties.Any())
+            {
+                <MudMenu Dense="true" Class="property-sort-menu">
+                    <ActivatorContent>
+                        <MudButton Size="Size.Small" Variant="Variant.Text"
+                                   StartIcon="@Icons.Material.Filled.Sort"
+                                   EndIcon="@(sortPropertyId is not null ? (sortAscending ? Icons.Material.Filled.ArrowUpward : Icons.Material.Filled.ArrowDownward) : null)">
+                            @(sortPropertyId is { } sid
+                                ? $"Sort: {propertyDefinitions.FirstOrDefault(d => d.Id == sid)?.Name}"
+                                : "Sort by property")
+                        </MudButton>
+                    </ActivatorContent>
+                    <ChildContent>
+                        @foreach (var def in SortableProperties)
+                        {
+                            <MudMenuItem OnClick="() => SortByProperty(def.Id)">@def.Name</MudMenuItem>
+                        }
+                    </ChildContent>
+                </MudMenu>
+            }
+        </div>
+    }
+
     @if (isLoading && !notes.Any())
     {
         <p class="empty-message">Loading...</p>
@@ -220,6 +249,14 @@
                                     Archive
                                 </button>
                             }
+                            @{
+                                var sortChip = SortPropertyChip(note);
+                            }
+                            @if (!string.IsNullOrEmpty(sortChip))
+                            {
+                                var sortDef = propertyDefinitions.FirstOrDefault(d => d.Id == sortPropertyId);
+                                <span class="property-sort-chip" title="@sortDef?.Name">@sortDef?.Name: @sortChip</span>
+                            }
                         </div>
                         @if (note.Labels?.Any() == true)
                         {
@@ -261,6 +298,9 @@
 @code {
     private List<NoteSummary> notes = [];
     private List<Label> allLabels = [];
+    private List<PropertyDefinition> propertyDefinitions = [];
+    private readonly List<PropertyFilter> propertyFilters = [];
+    private Guid? sortPropertyId;
     private HashSet<Guid> selectedIds = [];
     private HashSet<Guid> activeFilters = [];
     private HashSet<Guid> expandedNoteIds = [];
@@ -296,15 +336,71 @@
 
     private string SortIcon(SortColumn col)
     {
-        if (currentSort != col) return "⇅";
+        if (sortPropertyId is not null || currentSort != col) return "⇅";
         return sortAscending ? "↑" : "↓";
     }
 
     protected override async Task OnInitializedAsync()
     {
         await ApplyUserSettings();
+        var defs = await PropertyService.GetDefinitionsAsync();
+        if (defs.IsSuccess)
+            propertyDefinitions = defs.Value!.OrderBy(d => d.SortOrder).ThenBy(d => d.Name).ToList();
         await LoadNotes(includeLabels: true);
         StartBackgroundRefresh();
+    }
+
+    // Sortable property types (MultiSelect is not sortable, matching the server).
+    private IEnumerable<PropertyDefinition> SortableProperties =>
+        propertyDefinitions.Where(d => d.Type != PropertyType.MultiSelect);
+
+    private string CurrentSortBy() =>
+        sortPropertyId is { } id ? $"prop:{id}" : (currentSort == SortColumn.Title ? "title" : "date");
+
+    private async Task OnPropertyFiltersChanged()
+    {
+        currentPage = 1;
+        selectedIds.Clear();
+        await LoadNotes();
+    }
+
+    // When a property sort is active, the row shows that property's value as a trailing chip
+    // (data already present in NoteSummary.Properties — no extra fetch).
+    private string? SortPropertyChip(NoteSummary note)
+    {
+        if (sortPropertyId is not { } id) return null;
+        var value = note.Properties.FirstOrDefault(p => p.DefinitionId == id);
+        if (value is null) return null;
+        var def = propertyDefinitions.FirstOrDefault(d => d.Id == id);
+        return FormatValue(def, value);
+    }
+
+    private static string FormatValue(PropertyDefinition? def, NotePropertyValue value) => value.Type switch
+    {
+        PropertyType.Text => value.TextValue ?? "",
+        PropertyType.Number => value.NumberValue?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "",
+        PropertyType.Date => value.DateValue?.ToString("yyyy-MM-dd") ?? "",
+        PropertyType.Checkbox => value.BoolValue == true ? "✓" : "",
+        PropertyType.Select => def?.Options.FirstOrDefault(o => o.Id == value.OptionId)?.Name ?? "",
+        PropertyType.MultiSelect => string.Join(", ",
+            value.OptionIds.Select(oid => def?.Options.FirstOrDefault(o => o.Id == oid)?.Name).Where(n => n is not null)),
+        _ => ""
+    };
+
+    private async Task SortByProperty(Guid definitionId)
+    {
+        if (sortPropertyId == definitionId)
+        {
+            sortAscending = !sortAscending;
+        }
+        else
+        {
+            sortPropertyId = definitionId;
+            sortAscending = true;
+        }
+        currentPage = 1;
+        selectedIds.Clear();
+        await LoadNotes();
     }
 
     // Seed the sort column/direction and page size from the user's saved settings so the
@@ -352,10 +448,11 @@
                     currentPage,
                     pageSize,
                     string.IsNullOrWhiteSpace(_searchText) ? null : _searchText,
-                    currentSort == SortColumn.Title ? "title" : "date",
+                    CurrentSortBy(),
                     sortAscending ? "asc" : "desc",
                     activeFilters.Count > 0 ? activeFilters : null,
                     includeLabels: includeLabels,
+                    propertyFilters: propertyFilters.Count > 0 ? propertyFilters : null,
                     cancellationToken: token);
 
                 if (!result.IsSuccess)
@@ -460,10 +557,11 @@
             currentPage,
             pageSize,
             string.IsNullOrWhiteSpace(_searchText) ? null : _searchText,
-            currentSort == SortColumn.Title ? "title" : "date",
+            CurrentSortBy(),
             sortAscending ? "asc" : "desc",
             activeFilters.Count > 0 ? activeFilters : null,
             includeLabels: false,
+            propertyFilters: propertyFilters.Count > 0 ? propertyFilters : null,
             cancellationToken: CancellationToken.None);
 
         if (isLoading || !result.IsSuccess || result.Value is null)
@@ -545,13 +643,14 @@
 
     private async Task SetSort(SortColumn col)
     {
-        if (currentSort == col)
+        if (sortPropertyId is null && currentSort == col)
             sortAscending = !sortAscending;
         else
         {
             currentSort = col;
             sortAscending = true;
         }
+        sortPropertyId = null;   // a column-header sort clears any active property sort
         currentPage = 1;
         selectedIds.Clear();
         await LoadNotes();

--- a/Vanadium.Note.Web/Pages/Home.razor
+++ b/Vanadium.Note.Web/Pages/Home.razor
@@ -133,22 +133,12 @@
             <PropertyFilterBar Filters="propertyFilters" OnChanged="OnPropertyFiltersChanged" />
             @if (SortableProperties.Any())
             {
-                <MudMenu Dense="true" Class="property-sort-menu">
-                    <ActivatorContent>
-                        <MudButton Size="Size.Small" Variant="Variant.Text"
-                                   StartIcon="@Icons.Material.Filled.Sort"
-                                   EndIcon="@(sortPropertyId is not null ? (sortAscending ? Icons.Material.Filled.ArrowUpward : Icons.Material.Filled.ArrowDownward) : null)">
-                            @(sortPropertyId is { } sid
-                                ? $"Sort: {propertyDefinitions.FirstOrDefault(d => d.Id == sid)?.Name}"
-                                : "Sort by property")
-                        </MudButton>
-                    </ActivatorContent>
-                    <ChildContent>
-                        @foreach (var def in SortableProperties)
-                        {
-                            <MudMenuItem OnClick="() => SortByProperty(def.Id)">@def.Name</MudMenuItem>
-                        }
-                    </ChildContent>
+                <MudMenu Label="@SortMenuLabel()" StartIcon="@Icons.Material.Filled.Sort"
+                         Variant="Variant.Text" Size="Size.Small" Dense="true" Class="property-sort-menu">
+                    @foreach (var def in SortableProperties)
+                    {
+                        <MudMenuItem OnClick="@(() => SortByProperty(def.Id))">@def.Name</MudMenuItem>
+                    }
                 </MudMenu>
             }
         </div>
@@ -348,6 +338,13 @@
             propertyDefinitions = defs.Value!.OrderBy(d => d.SortOrder).ThenBy(d => d.Name).ToList();
         await LoadNotes(includeLabels: true);
         StartBackgroundRefresh();
+    }
+
+    private string SortMenuLabel()
+    {
+        if (sortPropertyId is not { } id) return "Sort by property";
+        var name = propertyDefinitions.FirstOrDefault(d => d.Id == id)?.Name ?? "property";
+        return $"Sort: {name} {(sortAscending ? "↑" : "↓")}";
     }
 
     // Sortable property types (MultiSelect is not sortable, matching the server).

--- a/Vanadium.Note.Web/Pages/Home.razor.css
+++ b/Vanadium.Note.Web/Pages/Home.razor.css
@@ -518,3 +518,27 @@ a.note-title-text:hover {
         display: none;
     }
 }
+
+/* Property filter/sort controls (issue #343) */
+.property-controls-bar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin: 0.4rem 0 0.6rem;
+}
+
+.property-sort-chip {
+    display: inline-block;
+    margin-left: 0.5rem;
+    padding: 0.05rem 0.4rem;
+    font-size: 0.72rem;
+    border-radius: 10px;
+    background: var(--mud-palette-primary, #594ae2);
+    color: #fff;
+    white-space: nowrap;
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+}

--- a/Vanadium.Note.Web/Pages/NoteEditor.razor
+++ b/Vanadium.Note.Web/Pages/NoteEditor.razor
@@ -130,6 +130,14 @@
         </Footer>
     </LabelPicker>
 
+    @if (Id is not null)
+    {
+        <NotePropertyPanel NoteId="Id.Value"
+                           Values="noteProperties"
+                           ReadOnly="IsArchived"
+                           OnArchivedElsewhere="OnPropertyArchivedElsewhere" />
+    }
+
     @if (showLabelManager)
     {
         <div class="label-manager">
@@ -265,6 +273,15 @@
     private bool isNew => Id is null;
     private DateTime? archivedAt;
     private bool IsArchived => archivedAt is not null;
+
+    /// <summary>A property value write returned 403 — the note was archived in another session.
+    /// Flip the whole editor to read-only, mirroring the archive feature's E1/E5 handling.</summary>
+    private void OnPropertyArchivedElsewhere()
+    {
+        archivedAt = DateTime.UtcNow;
+        StateHasChanged();
+    }
+
     private Guid? parentNoteId;
     private string? parentTitle;
     private int childCount;
@@ -330,6 +347,9 @@
     private bool _backlinksLoading = false;
     private bool _backlinksFailed = false;
 
+    // Property state (issue #343): the note's non-empty values at load; the panel manages edits.
+    private List<NotePropertyValue> noteProperties = [];
+
     // Label state
     private List<Label> noteLabels = [];
     private List<Label> availableLabels = [];
@@ -377,6 +397,7 @@
         parentTitle = null;
         childCount = 0;
         noteLabels = [];
+        noteProperties = [];
         backlinks = [];
         _backlinksFailed = false;
         _hasConflict = false;
@@ -397,6 +418,7 @@
                 content = result.Value!.Content;
                 archivedAt = result.Value!.ArchivedAt;
                 noteLabels = result.Value!.Labels ?? [];
+                noteProperties = result.Value!.Properties ?? [];
                 parentNoteId = result.Value!.ParentNoteId;
                 parentTitle = result.Value!.ParentTitle;
                 childCount = result.Value!.ChildCount;

--- a/Vanadium.Note.Web/Pages/Properties.razor
+++ b/Vanadium.Note.Web/Pages/Properties.razor
@@ -66,7 +66,12 @@
                                    OnClick="() => MoveAsync(context, 1)" />
                 </MudTd>
                 <MudTd DataLabel="Name">@context.Name</MudTd>
-                <MudTd DataLabel="Type">@context.Type.ToString()</MudTd>
+                <MudTd DataLabel="Type">
+                    <span class="d-inline-flex align-center gap-1">
+                        <MudIcon Icon="@PropertyTypeIcons.For(context.Type)" Size="Size.Small" />
+                        @context.Type.ToString()
+                    </span>
+                </MudTd>
                 <MudTd DataLabel="Used on">@(context.ValueCount ?? 0) note(s)</MudTd>
                 <MudTd DataLabel="Options">
                     @if (context.Type is PropertyType.Select or PropertyType.MultiSelect)

--- a/Vanadium.Note.Web/Pages/Properties.razor
+++ b/Vanadium.Note.Web/Pages/Properties.razor
@@ -54,7 +54,7 @@
                 <MudTh>Type</MudTh>
                 <MudTh>Used on</MudTh>
                 <MudTh>Options</MudTh>
-                <MudTh Style="width: 220px;">Actions</MudTh>
+                <MudTh Style="width: 140px; white-space: nowrap;">Actions</MudTh>
             </HeaderContent>
             <RowTemplate>
                 <MudTd DataLabel="Order">
@@ -78,13 +78,22 @@
                         <span class="mud-text-secondary">—</span>
                     }
                 </MudTd>
-                <MudTd DataLabel="Actions">
-                    <MudButton Size="Size.Small" OnClick="() => EditAsync(context)">Edit</MudButton>
+                <MudTd DataLabel="Actions" Style="white-space: nowrap;">
+                    <MudTooltip Text="Edit">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                       OnClick="() => EditAsync(context)" />
+                    </MudTooltip>
                     @if (context.Type is PropertyType.Select or PropertyType.MultiSelect)
                     {
-                        <MudButton Size="Size.Small" OnClick="() => ManageOptionsAsync(context)">Options…</MudButton>
+                        <MudTooltip Text="Manage options">
+                            <MudIconButton Icon="@Icons.Material.Filled.Tune" Size="Size.Small"
+                                           OnClick="() => ManageOptionsAsync(context)" />
+                        </MudTooltip>
                     }
-                    <MudButton Size="Size.Small" Color="Color.Error" OnClick="() => DeleteAsync(context)">Delete</MudButton>
+                    <MudTooltip Text="Delete">
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                                       OnClick="() => DeleteAsync(context)" />
+                    </MudTooltip>
                 </MudTd>
             </RowTemplate>
         </MudTable>

--- a/Vanadium.Note.Web/Pages/Properties.razor
+++ b/Vanadium.Note.Web/Pages/Properties.razor
@@ -1,0 +1,185 @@
+@page "/properties"
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+@using Vanadium.Note.Web.Components
+@using Vanadium.Note.Web.Models
+@inject PropertyService PropertyService
+@inject IDialogService DialogService
+@inject ConfirmService Confirm
+@inject ISnackbar Snackbar
+
+<PageTitle>Properties</PageTitle>
+
+<div class="properties-page pa-4">
+    <div class="d-flex align-center justify-space-between mb-4">
+        <MudText Typo="Typo.h5">Properties</MudText>
+    </div>
+
+    <MudPaper Class="pa-4 mb-4" Elevation="1">
+        <MudText Typo="Typo.subtitle1" Class="mb-2">New property</MudText>
+        <div class="d-flex align-center gap-2 flex-wrap">
+            <MudTextField T="string" @bind-Value="_newName" Label="Name" MaxLength="100"
+                          Immediate="true" Margin="Margin.Dense" Style="min-width: 220px;" />
+            <MudSelect T="PropertyType" @bind-Value="_newType" Label="Type" Dense="true" Margin="Margin.Dense"
+                       Style="min-width: 160px;">
+                @foreach (var type in Enum.GetValues<PropertyType>())
+                {
+                    <MudSelectItem T="PropertyType" Value="@type">@type.ToString()</MudSelectItem>
+                }
+            </MudSelect>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="CreateAsync"
+                       Disabled="_creating || string.IsNullOrWhiteSpace(_newName)"
+                       StartIcon="@Icons.Material.Filled.Add">Create</MudButton>
+        </div>
+    </MudPaper>
+
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="my-4" />
+    }
+    else if (_definitions.Count == 0)
+    {
+        <MudPaper Class="pa-6 text-center" Elevation="0">
+            <MudText Typo="Typo.body1" Class="mud-text-secondary">
+                No properties yet. Create one to attach structured data — like a due date or a priority — to your notes.
+            </MudText>
+        </MudPaper>
+    }
+    else
+    {
+        <MudTable Items="_definitions" Dense="true" Hover="true" Elevation="1">
+            <HeaderContent>
+                <MudTh Style="width: 90px;">Order</MudTh>
+                <MudTh>Name</MudTh>
+                <MudTh>Type</MudTh>
+                <MudTh>Used on</MudTh>
+                <MudTh>Options</MudTh>
+                <MudTh Style="width: 220px;">Actions</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Order">
+                    <MudIconButton Icon="@Icons.Material.Filled.ArrowUpward" Size="Size.Small"
+                                   Disabled="_definitions.IndexOf(context) == 0"
+                                   OnClick="() => MoveAsync(context, -1)" />
+                    <MudIconButton Icon="@Icons.Material.Filled.ArrowDownward" Size="Size.Small"
+                                   Disabled="_definitions.IndexOf(context) == _definitions.Count - 1"
+                                   OnClick="() => MoveAsync(context, 1)" />
+                </MudTd>
+                <MudTd DataLabel="Name">@context.Name</MudTd>
+                <MudTd DataLabel="Type">@context.Type.ToString()</MudTd>
+                <MudTd DataLabel="Used on">@(context.ValueCount ?? 0) note(s)</MudTd>
+                <MudTd DataLabel="Options">
+                    @if (context.Type is PropertyType.Select or PropertyType.MultiSelect)
+                    {
+                        @context.Options.Count
+                    }
+                    else
+                    {
+                        <span class="mud-text-secondary">—</span>
+                    }
+                </MudTd>
+                <MudTd DataLabel="Actions">
+                    <MudButton Size="Size.Small" OnClick="() => EditAsync(context)">Edit</MudButton>
+                    @if (context.Type is PropertyType.Select or PropertyType.MultiSelect)
+                    {
+                        <MudButton Size="Size.Small" OnClick="() => ManageOptionsAsync(context)">Options…</MudButton>
+                    }
+                    <MudButton Size="Size.Small" Color="Color.Error" OnClick="() => DeleteAsync(context)">Delete</MudButton>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+</div>
+
+@code {
+    private List<PropertyDefinition> _definitions = [];
+    private bool _loading = true;
+    private bool _creating;
+    private string _newName = string.Empty;
+    private PropertyType _newType = PropertyType.Text;
+
+    protected override async Task OnInitializedAsync() => await ReloadAsync();
+
+    private async Task ReloadAsync()
+    {
+        _loading = true;
+        PropertyService.InvalidateCache();
+        var result = await PropertyService.GetDefinitionsAsync(includeUsage: true);
+        _definitions = result.IsSuccess
+            ? result.Value!.OrderBy(d => d.SortOrder).ThenBy(d => d.Name).ToList()
+            : [];
+        if (!result.IsSuccess)
+            Snackbar.Add(result.Error ?? "Failed to load properties.", Severity.Error);
+        _loading = false;
+    }
+
+    private async Task CreateAsync()
+    {
+        var name = _newName.Trim();
+        if (name.Length == 0) return;
+        _creating = true;
+        var result = await PropertyService.CreateDefinitionAsync(new CreatePropertyDefinitionRequest(name, _newType));
+        _creating = false;
+        if (result.IsSuccess)
+        {
+            _newName = string.Empty;
+            _newType = PropertyType.Text;
+            await ReloadAsync();
+        }
+        else
+        {
+            Snackbar.Add(result.Error ?? "Failed to create the property.", Severity.Error);
+        }
+    }
+
+    private async Task EditAsync(PropertyDefinition def)
+    {
+        var parameters = new DialogParameters<PropertyEditDialog> { { x => x.Definition, def } };
+        var dialog = await DialogService.ShowAsync<PropertyEditDialog>($"Edit '{def.Name}'", parameters);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+            await ReloadAsync();
+    }
+
+    private async Task ManageOptionsAsync(PropertyDefinition def)
+    {
+        var parameters = new DialogParameters<PropertyOptionsDialog> { { x => x.Definition, def } };
+        var dialog = await DialogService.ShowAsync<PropertyOptionsDialog>($"Options — {def.Name}", parameters);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled && result.Data is true)
+            await ReloadAsync();
+    }
+
+    private async Task DeleteAsync(PropertyDefinition def)
+    {
+        var count = def.ValueCount ?? 0;
+        var confirmed = await Confirm.ConfirmAsync(
+            "Delete property",
+            $"This will remove '{def.Name}' and its values from {count} note(s), including archived and recycle-bin notes. This cannot be undone.",
+            "Delete");
+        if (!confirmed) return;
+
+        var result = await PropertyService.DeleteDefinitionAsync(def.Id);
+        if (result.IsSuccess)
+            await ReloadAsync();
+        else
+            Snackbar.Add(result.Error ?? "Failed to delete the property.", Severity.Error);
+    }
+
+    private async Task MoveAsync(PropertyDefinition def, int delta)
+    {
+        var index = _definitions.IndexOf(def);
+        var target = index + delta;
+        if (target < 0 || target >= _definitions.Count) return;
+        var other = _definitions[target];
+
+        var a = await PropertyService.UpdateDefinitionAsync(
+            def.Id, new UpdatePropertyDefinitionRequest(def.Name, def.Type, other.SortOrder));
+        var b = await PropertyService.UpdateDefinitionAsync(
+            other.Id, new UpdatePropertyDefinitionRequest(other.Name, other.Type, def.SortOrder));
+        if (a.IsSuccess && b.IsSuccess)
+            await ReloadAsync();
+        else
+            Snackbar.Add("Failed to reorder properties.", Severity.Error);
+    }
+}

--- a/Vanadium.Note.Web/Pages/PropertyEditDialog.razor
+++ b/Vanadium.Note.Web/Pages/PropertyEditDialog.razor
@@ -1,0 +1,67 @@
+@* Rename / change-type dialog for a property definition (issue #343, §9.5). Surfaces the server's
+   409 (duplicate name / "in use on N notes — clear values first") inline. *@
+@using Vanadium.Note.Web.Models
+@inject PropertyService PropertyService
+
+<MudDialog>
+    <DialogContent>
+        <MudTextField T="string" @bind-Value="_name" Label="Name" MaxLength="100" Immediate="true"
+                      Class="mb-3" />
+        <MudSelect T="PropertyType" @bind-Value="_type" Label="Type" Dense="true">
+            @foreach (var type in Enum.GetValues<PropertyType>())
+            {
+                <MudSelectItem T="PropertyType" Value="@type">@type.ToString()</MudSelectItem>
+            }
+        </MudSelect>
+        @if (_type != Definition.Type)
+        {
+            <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+                Changing the type is only allowed while the property has no values on any note.
+            </MudAlert>
+        }
+        @if (_error is not null)
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Class="mt-3">@_error</MudAlert>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Save" Disabled="_saving">Save</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter, EditorRequired] public PropertyDefinition Definition { get; set; } = null!;
+
+    private string _name = string.Empty;
+    private PropertyType _type;
+    private string? _error;
+    private bool _saving;
+
+    protected override void OnInitialized()
+    {
+        _name = Definition.Name;
+        _type = Definition.Type;
+    }
+
+    private async Task Save()
+    {
+        _error = null;
+        if (string.IsNullOrWhiteSpace(_name))
+        {
+            _error = "Name is required.";
+            return;
+        }
+        _saving = true;
+        var result = await PropertyService.UpdateDefinitionAsync(
+            Definition.Id, new UpdatePropertyDefinitionRequest(_name.Trim(), _type, Definition.SortOrder));
+        _saving = false;
+        if (result.IsSuccess)
+            MudDialog.Close(DialogResult.Ok(true));
+        else
+            _error = result.Error ?? "Failed to save the property.";
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/Vanadium.Note.Web/Program.cs
+++ b/Vanadium.Note.Web/Program.cs
@@ -40,6 +40,7 @@ namespace Vanadium.Note.Web
 
             builder.Services.AddScoped<NoteService>();
             builder.Services.AddScoped<LabelService>();
+            builder.Services.AddScoped<PropertyService>();
             builder.Services.AddScoped<SettingsService>();
             builder.Services.AddScoped<ApiTokenService>();
             builder.Services.AddScoped<ThemeService>();

--- a/Vanadium.Note.Web/Services/NoteService.cs
+++ b/Vanadium.Note.Web/Services/NoteService.cs
@@ -15,6 +15,7 @@ public class NoteService(HttpClient http, ILogger<NoteService> logger)
         string sortDir = "desc",
         IEnumerable<Guid>? labelIds = null,
         bool includeLabels = false,
+        IEnumerable<PropertyFilter>? propertyFilters = null,
         CancellationToken cancellationToken = default)
     {
         try
@@ -25,6 +26,11 @@ public class NoteService(HttpClient http, ILogger<NoteService> logger)
             if (labelIds is not null)
                 foreach (var id in labelIds)
                     sb.Append($"&labelIds={id}");
+            if (propertyFilters is not null)
+                foreach (var pf in propertyFilters)
+                    // ToQueryValue already URL-encodes the value portion; the ':' separators stay
+                    // literal, and the whole param is decoded once by the server's model binding.
+                    sb.Append($"&pf={pf.ToQueryValue()}");
             if (includeLabels)
                 sb.Append("&includeLabels=true");
 
@@ -45,17 +51,19 @@ public class NoteService(HttpClient http, ILogger<NoteService> logger)
     }
 
     public async Task<ServiceResult<IReadOnlyList<NoteSummary>>> GetAllSummariesAsync(
-        IEnumerable<Guid>? labelIds = null)
+        IEnumerable<Guid>? labelIds = null,
+        IEnumerable<PropertyFilter>? propertyFilters = null)
     {
         try
         {
-            var url = "api/notes/summaries";
+            var query = new List<string>();
             if (labelIds is not null)
-            {
-                var ids = labelIds.ToList();
-                if (ids.Count > 0)
-                    url += "?" + string.Join("&", ids.Select(id => $"labelIds={id}"));
-            }
+                query.AddRange(labelIds.Select(id => $"labelIds={id}"));
+            if (propertyFilters is not null)
+                query.AddRange(propertyFilters.Select(pf => $"pf={pf.ToQueryValue()}"));
+            var url = "api/notes/summaries";
+            if (query.Count > 0)
+                url += "?" + string.Join("&", query);
             var result = await http.GetFromJsonAsync<IReadOnlyList<NoteSummary>>(url);
             return result is not null
                 ? ServiceResult<IReadOnlyList<NoteSummary>>.Ok(result)

--- a/Vanadium.Note.Web/Services/PropertyService.cs
+++ b/Vanadium.Note.Web/Services/PropertyService.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Vanadium.Note.Web.Models;
+
+namespace Vanadium.Note.Web.Services;
+
+/// <summary>
+/// HTTP client for Note Properties (issue #343). Definitions are cached per circuit (the panel,
+/// filter bar, and sort menu all read from the cache) and the cache is invalidated after any
+/// definition/option mutation.
+/// </summary>
+public class PropertyService(HttpClient http, ILogger<PropertyService> logger)
+{
+    private List<PropertyDefinition>? _cache;
+
+    /// <summary>Cached definitions (without usage counts). Fetched once per circuit; call
+    /// <see cref="InvalidateCache"/> after a mutation to force a refresh.</summary>
+    public async Task<ServiceResult<List<PropertyDefinition>>> GetDefinitionsAsync(bool includeUsage = false)
+    {
+        if (!includeUsage && _cache is not null)
+            return ServiceResult<List<PropertyDefinition>>.Ok(_cache);
+
+        try
+        {
+            var url = includeUsage ? "api/properties?includeUsage=true" : "api/properties";
+            var result = await http.GetFromJsonAsync<List<PropertyDefinition>>(url);
+            if (result is null)
+                return ServiceResult<List<PropertyDefinition>>.Fail("Failed to load properties.");
+            if (!includeUsage)
+                _cache = result;
+            return ServiceResult<List<PropertyDefinition>>.Ok(result);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to load property definitions.");
+            return ServiceResult<List<PropertyDefinition>>.Fail("Failed to load properties.");
+        }
+    }
+
+    public void InvalidateCache() => _cache = null;
+
+    public async Task<ServiceResult<PropertyDefinition>> CreateDefinitionAsync(CreatePropertyDefinitionRequest req)
+    {
+        var result = await PostForAsync<PropertyDefinition>("api/properties", req, "create property");
+        if (result.IsSuccess) InvalidateCache();
+        return result;
+    }
+
+    public async Task<ServiceResult<PropertyDefinition>> UpdateDefinitionAsync(Guid id, UpdatePropertyDefinitionRequest req)
+    {
+        var result = await PutForAsync<PropertyDefinition>($"api/properties/{id}", req, "update property");
+        if (result.IsSuccess) InvalidateCache();
+        return result;
+    }
+
+    public async Task<ServiceResult<bool>> DeleteDefinitionAsync(Guid id)
+    {
+        var result = await DeleteForAsync($"api/properties/{id}", "delete property");
+        if (result.IsSuccess) InvalidateCache();
+        return result;
+    }
+
+    public async Task<ServiceResult<PropertyOption>> AddOptionAsync(Guid definitionId, CreatePropertyOptionRequest req)
+    {
+        var result = await PostForAsync<PropertyOption>($"api/properties/{definitionId}/options", req, "add option");
+        if (result.IsSuccess) InvalidateCache();
+        return result;
+    }
+
+    public async Task<ServiceResult<PropertyOption>> UpdateOptionAsync(Guid definitionId, Guid optionId, UpdatePropertyOptionRequest req)
+    {
+        var result = await PutForAsync<PropertyOption>($"api/properties/{definitionId}/options/{optionId}", req, "update option");
+        if (result.IsSuccess) InvalidateCache();
+        return result;
+    }
+
+    public async Task<ServiceResult<bool>> DeleteOptionAsync(Guid definitionId, Guid optionId)
+    {
+        var result = await DeleteForAsync($"api/properties/{definitionId}/options/{optionId}", "delete option");
+        if (result.IsSuccess) InvalidateCache();
+        return result;
+    }
+
+    public async Task<ServiceResult<NotePropertyValue>> SetValueAsync(Guid noteId, Guid definitionId, SetNotePropertyValueRequest req)
+    {
+        try
+        {
+            var response = await http.PutAsJsonAsync($"api/notes/{noteId}/properties/{definitionId}", req);
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+                return ServiceResult<NotePropertyValue>.Forbidden();
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return ServiceResult<NotePropertyValue>.NotFound("Note or property no longer exists.");
+            if (!response.IsSuccessStatusCode)
+                return ServiceResult<NotePropertyValue>.Fail(await ReadErrorAsync(response));
+            var value = await response.Content.ReadFromJsonAsync<NotePropertyValue>();
+            return value is not null
+                ? ServiceResult<NotePropertyValue>.Ok(value)
+                : ServiceResult<NotePropertyValue>.Fail("Failed to save property value.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to set property {DefinitionId} on note {NoteId}.", definitionId, noteId);
+            return ServiceResult<NotePropertyValue>.Fail("Failed to save property value.");
+        }
+    }
+
+    public async Task<ServiceResult<bool>> ClearValueAsync(Guid noteId, Guid definitionId)
+    {
+        try
+        {
+            var response = await http.DeleteAsync($"api/notes/{noteId}/properties/{definitionId}");
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+                return ServiceResult<bool>.Forbidden();
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return ServiceResult<bool>.NotFound("Note or property no longer exists.");
+            return response.IsSuccessStatusCode
+                ? ServiceResult<bool>.Ok(true)
+                : ServiceResult<bool>.Fail("Failed to clear property value.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to clear property {DefinitionId} on note {NoteId}.", definitionId, noteId);
+            return ServiceResult<bool>.Fail("Failed to clear property value.");
+        }
+    }
+
+    // ── Shared request helpers ───────────────────────────────────────────────────
+
+    private async Task<ServiceResult<T>> PostForAsync<T>(string url, object body, string action)
+    {
+        try
+        {
+            var response = await http.PostAsJsonAsync(url, body);
+            return await ReadResultAsync<T>(response, action);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to {Action}.", action);
+            return ServiceResult<T>.Fail("An error occurred.");
+        }
+    }
+
+    private async Task<ServiceResult<T>> PutForAsync<T>(string url, object body, string action)
+    {
+        try
+        {
+            var response = await http.PutAsJsonAsync(url, body);
+            return await ReadResultAsync<T>(response, action);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to {Action}.", action);
+            return ServiceResult<T>.Fail("An error occurred.");
+        }
+    }
+
+    private async Task<ServiceResult<bool>> DeleteForAsync(string url, string action)
+    {
+        try
+        {
+            var response = await http.DeleteAsync(url);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return ServiceResult<bool>.NotFound("Not found.");
+            return response.IsSuccessStatusCode
+                ? ServiceResult<bool>.Ok(true)
+                : ServiceResult<bool>.Fail(await ReadErrorAsync(response));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to {Action}.", action);
+            return ServiceResult<bool>.Fail("An error occurred.");
+        }
+    }
+
+    private async Task<ServiceResult<T>> ReadResultAsync<T>(HttpResponseMessage response, string action)
+    {
+        if (response.StatusCode == HttpStatusCode.Conflict)
+            return ServiceResult<T>.Fail(await ReadErrorAsync(response));
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return ServiceResult<T>.NotFound("Not found.");
+        if (!response.IsSuccessStatusCode)
+            return ServiceResult<T>.Fail(await ReadErrorAsync(response));
+        var value = await response.Content.ReadFromJsonAsync<T>();
+        return value is not null
+            ? ServiceResult<T>.Ok(value)
+            : ServiceResult<T>.Fail($"Failed to {action}.");
+    }
+
+    private static async Task<string> ReadErrorAsync(HttpResponseMessage response)
+    {
+        try
+        {
+            var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+            if (json.TryGetProperty("detail", out var detail) && detail.ValueKind == JsonValueKind.String)
+                return detail.GetString() ?? "An error occurred.";
+        }
+        catch { }
+        return "An error occurred.";
+    }
+}

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -141,13 +141,20 @@ Route prefix `/api/notes`. **Auth: Bearer (JWT or PAT)** for every endpoint.
 ### GET `/api/notes`
 
 - **Query:** `page` (default 1, min 1), `pageSize` (default 30, clamped 1–200),
-  `search` (≤200 chars), `sortBy` (default `date`), `sortDir` (default `desc`),
-  `labelIds` (Guid[], max 50), `includeLabels` (bool, default false).
+  `search` (≤200 chars), `sortBy` (default `date`; also `title` or `prop:{definitionId}`),
+  `sortDir` (default `desc`), `labelIds` (Guid[], max 50), `pf` (repeatable property filter,
+  max 20 — see [Property filter grammar](#property-filter-grammar-pf)), `includeLabels` (bool, default false).
 - **Response `200`:** `PagedResult<NoteSummary>` — `{ items: NoteSummary[], totalCount, page, pageSize, labels? }`.
   `labels` is populated only when `includeLabels=true`. Search results include archived notes
   (`NoteSummary.isArchived = true`); the non-search list excludes them.
-- **Status codes:** `200` · `400` more than 50 label IDs.
-- **`NoteSummary`:** `{ id, title, updatedAt, parentNoteId?, parentTitle?, childCount, isArchived, labels: LabelSummary[] }`.
+- **Sorting by a property** (`sortBy=prop:{definitionId}`) applies only to the non-search branch;
+  notes with an empty value always sort **after** notes with a value regardless of `sortDir`, with
+  `updatedAt` desc as tiebreak. `MultiSelect` and unknown definitions → `400`. Ignored during search.
+- **`pf` filters** apply in both the search and non-search branches, AND across entries, and combine
+  with `search`/`labelIds`.
+- **Status codes:** `200` · `400` more than 50 label IDs, malformed `pf`, or invalid `sortBy=prop:`.
+- **`NoteSummary`:** `{ id, title, updatedAt, parentNoteId?, parentTitle?, childCount, isArchived, labels: LabelSummary[], properties: NotePropertyValueDto[] }`.
+  `properties` holds the note's non-empty property values, ordered by definition sort order.
 
 ### GET `/api/notes/mention-search`
 
@@ -161,9 +168,10 @@ Route prefix `/api/notes`. **Auth: Bearer (JWT or PAT)** for every endpoint.
 
 ### GET `/api/notes/summaries`
 
-- **Query:** `labelIds` (Guid[], max 50).
+- **Query:** `labelIds` (Guid[], max 50, OR semantics), `pf` (repeatable property filter, max 20,
+  AND semantics — see [Property filter grammar](#property-filter-grammar-pf)).
 - **Response `200`:** `NoteSummary[]`. Excludes archived notes.
-- **Status codes:** `200` · `400` more than 50 label IDs.
+- **Status codes:** `200` · `400` more than 50 label IDs or malformed `pf`.
 
 ### GET `/api/notes/{id:guid}/children`
 
@@ -305,6 +313,107 @@ others in the same category).
 ### DELETE `/api/notes/{noteId:guid}/labels/{labelId:guid}`
 
 - **Status codes:** `204` · `404` note not found or label not assigned · `403` note is archived and read-only.
+
+---
+
+## Note properties — `PropertiesController`
+
+Notion-style typed metadata (issue #343). Property **definitions** are global (name + type + option
+list for Select kinds); notes carry only **values**. Six value types: `Text` (0), `Number` (1),
+`Select` (2), `MultiSelect` (3), `Date` (4), `Checkbox` (5). Values are **server-owned** — never read
+from the `POST/PUT /api/notes` payload; the value endpoints below are the only mutation path, and they
+do **not** bump `NoteItem.updatedAt`. All routes require Bearer auth.
+
+Caps (all `400` on the server, mirrored client-side): max **50** definitions, **100** options per
+definition, **500** chars for a `Text` value, **20** `pf` filters per request.
+
+| Method | Route | Notes |
+|---|---|---|
+| GET | `/api/properties?includeUsage=` | All definitions with options, ordered by sort order. `includeUsage=true` adds `valueCount` per definition and `noteCount` per option (counted across all notes incl. recycle-bin/archived). |
+| POST | `/api/properties` | Create a definition. |
+| PUT | `/api/properties/{id:guid}` | Update name / sort order / type. |
+| DELETE | `/api/properties/{id:guid}` | Delete a definition (cascades options + all value/selection rows). |
+| POST | `/api/properties/{id:guid}/options` | Add an option (Select/MultiSelect only). |
+| PUT | `/api/properties/{id:guid}/options/{optionId:guid}` | Rename / reorder an option. |
+| DELETE | `/api/properties/{id:guid}/options/{optionId:guid}` | Delete an option (cascades values/selections). |
+| PUT | `/api/notes/{noteId:guid}/properties/{definitionId:guid}` | Upsert one value. |
+| DELETE | `/api/notes/{noteId:guid}/properties/{definitionId:guid}` | Clear one value (idempotent). |
+
+### POST `/api/properties`
+
+- **Request body:** `CreatePropertyDefinitionRequest` — `{ "name": string (required, ≤100), "type": PropertyType }`.
+- **Response `201`:** `PropertyDefinitionDto`.
+- **Status codes:** `201` · `409` duplicate name (case-insensitive) · `400` over 50 definitions or invalid type.
+
+### PUT `/api/properties/{id:guid}`
+
+- **Request body:** `UpdatePropertyDefinitionRequest` — `{ "name": string (required, ≤100), "type": PropertyType, "sortOrder": int }`.
+- A **type change** is allowed only while the definition has **zero** values across all notes
+  (incl. recycle-bin/archived); otherwise `409` with the value count. Changing away from a Select kind
+  (with zero values) deletes its options.
+- **Status codes:** `200` · `404` not found · `409` duplicate name or type change with existing values · `400` invalid type/name.
+
+### DELETE `/api/properties/{id:guid}`
+
+- **Status codes:** `204` · `404` not found.
+
+### POST `/api/properties/{id:guid}/options`
+
+- **Request body:** `CreatePropertyOptionRequest` — `{ "name": string (required, ≤100) }`.
+- **Response `201`:** `PropertyOptionDto`.
+- **Status codes:** `201` · `404` definition not found · `409` duplicate option name · `400` non-Select definition or over 100 options.
+
+### PUT `/api/properties/{id:guid}/options/{optionId:guid}`
+
+- **Request body:** `UpdatePropertyOptionRequest` — `{ "name": string (required, ≤100), "sortOrder": int }`.
+- **Status codes:** `200` · `404` not found · `409` duplicate option name · `400` invalid name.
+
+### DELETE `/api/properties/{id:guid}/options/{optionId:guid}`
+
+- **Status codes:** `204` · `404` not found.
+
+### PUT `/api/notes/{noteId:guid}/properties/{definitionId:guid}`
+
+Upserts one value. Exactly the member matching the definition's type must be set; all others null.
+
+- **Request body:** `SetNotePropertyValueRequest` — `{ "textValue"?, "numberValue"?, "dateValue"? (yyyy-MM-dd), "boolValue"?, "optionId"? (Guid), "optionIds"? (Guid[]) }`.
+- **Normalization:** `boolValue=false` and an empty `optionIds` clear the value (a value row exists iff
+  the value is non-empty). A `Checkbox` row only ever stores `true`.
+- **Response `200`:** `NotePropertyValueDto` (empty members when the write cleared the value).
+- **Status codes:** `200` · `403` note is archived and read-only · `404` note (recycle-bin/unknown) or definition unknown · `400` type mismatch, empty text, non-finite number, or foreign option.
+
+### DELETE `/api/notes/{noteId:guid}/properties/{definitionId:guid}`
+
+- **Status codes:** `204` (idempotent — missing value row still `204`) · `403` note is archived · `404` note unknown/recycle-bin.
+
+### Property filter grammar (`pf`)
+
+Repeatable `GET /api/notes` / `GET /api/notes/summaries` query parameter, AND across entries, max 20:
+
+```
+pf={definitionId}:{op}[:{value}]
+```
+
+`value` is URL-encoded and omitted for `empty`/`notempty`; for `anyof` it is a comma-separated list of
+option GUIDs. Operators per type:
+
+| Type | Operators | Value | Notes |
+|---|---|---|---|
+| `Text` | `eq`, `ne`, `empty`, `notempty` | literal (≤500) | Exact, case-sensitive. `ne` matches only notes whose value exists and differs. |
+| `Number` | `eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `empty`, `notempty` | invariant double | Two range entries express *between*. |
+| `Date` | `eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `empty`, `notempty` | `yyyy-MM-dd` | |
+| `Checkbox` | `eq` | `true`/`false` | `eq:false` matches unchecked **and** never-set notes. `empty`/`notempty` → `400`. |
+| `Select` | `eq`, `ne`, `anyof`, `empty`, `notempty` | option GUID(s) | Options must belong to the definition. |
+| `MultiSelect` | `eq`, `anyof`, `empty`, `notempty` | option GUID(s) | `eq` = option is selected; `anyof` = any listed option selected. |
+
+Malformed triplets, unknown ops, op/type mismatches, unparsable values, unknown definitions, or foreign
+options → `400`.
+
+### DTO shapes
+
+- **`PropertyDefinitionDto`:** `{ id, name, type: PropertyType, sortOrder, options: PropertyOptionDto[], valueCount? }`.
+- **`PropertyOptionDto`:** `{ id, name, sortOrder, noteCount? }`.
+- **`NotePropertyValueDto`:** `{ definitionId, name, type: PropertyType, textValue?, numberValue?, dateValue?, boolValue?, optionId?, optionIds: Guid[] }`.
 
 ---
 


### PR DESCRIPTION
Closes #343

Notion 스타일의 타입 있는 노트 메타데이터(**Note Properties**)를 도입한다. 전역 정의 + 노트별 값(EAV 저장 모델), 필터/정렬, 에디터 프로퍼티 패널, `/properties` 관리 페이지를 포함한다. 상세 설계는 `docs/plannings/note-property/note-properties-feature.md`.

## 백엔드
- **스키마(§4)**: `PropertyDefinition`/`PropertyOption`/`NotePropertyValue`/`NotePropertySelectedOption` (EAV, JSONB 아님). 복합 PK/FK, 대체키 `PropertyOption(DefinitionId,Id)`로 INV-P3 DB 보장, INV-P4 소프트삭제 쿼리 필터(`NoteLabel` 미러), 필터/정렬용 복합 인덱스. `AddNoteProperties` 마이그레이션.
- **정의/옵션 API(§6.1)**: `PropertyService` + `PropertiesController` — CRUD, 사용량 카운트, 이름 대소문자 무시 유일(409), 캡 초과(400), 값 있는 정의의 타입 변경 차단(409, `IgnoreQueryFilters()`로 휴지통 값까지 카운트).
- **값 API(§7.2)**: `PUT/DELETE /api/notes/{noteId}/properties/{definitionId}` 업서트/클리어 + 서버측 타입 검증. 아카이브 403 / 휴지통·미존재 404 / 타입 불일치 400. INV-P1 정규화(Checkbox false·MultiSelect 빈 선택 → 행 삭제). 값은 서버 소유(INV-P5), `UpdatedAt` bump 없음.
- **필터/정렬(§6.3/§7.3/§7.5)**: `pf` 반복 파라미터(AND, 최대 20)를 `GetPaged`(검색·비검색 브랜치)·`GetAllSummaries`에 적용, `sortBy=prop:{id}`(비검색 브랜치, 빈 값 항상 뒤, MultiSelect 400). 잘못된 `pf`/`sortBy` → 400.
- **투영/계정 초기화**: `Get`/`GetPaged`/`GetAllSummaries`에 `Properties` 투영, `AccountService.PurgeAllDataAsync`에 정의 삭제 추가.

## 프론트엔드
- Web DTO 미러 + `PropertyService` 클라이언트(정의 캐시, 뮤테이션 시 무효화).
- `NotePropertyPanel`(제목-본문 사이, 비어있지 않은 값만, 즉시 저장, 403 시 읽기전용 전환) + `PropertyValueEditor`(타입별 MudBlazor 컨트롤). **Tiptap/JS interop 미접촉(§7.8)**.
- `/properties` 관리 페이지 + `PropertyEditDialog` + `PropertyOptionsDialog` + NavMenu 항목.
- `PropertyFilterBar`(Home/Board) + Home 프로퍼티 정렬 메뉴 + 정렬 프로퍼티 행 칩.

## 완료 조건 검증
- 6종 타입 생성/업서트/투영, INV-P1 정규화, `pf` 연산자 의미, 정렬(빈 값 뒤·타이브레이크), 아카이브 403/휴지통 404/무손실 복원, 타입 변경 409(휴지통 값 포함), 정의/옵션 삭제 cascade, 중복 409·캡 400, 계정 초기화 후 4개 테이블 비움 — **`Vanadium.Note.REST.Tests` T-1~T-21(신규 32개)로 검증**. 값 경로는 값 자체를 info 로그에 남기지 않음(ID·카운트만).
- `docs/api-specification.md` 동일 변경에서 갱신. `AddNoteProperties` 마이그레이션 추가(모델 스냅샷 반영, 개발 DB 적용은 미실행 — SQLite `EnsureCreated`로 모델 검증).
- `dotnet build Vanadium.slnx` 클린(경고 0), `dotnet test Vanadium.slnx` 그린(REST 275, Web 20 통과 / E2E 3 스킵).

## 범위 밖 준수
새 최상위 의존성/`Vanadium.Note.Shared` 없음, 비인덱스 `ILIKE` 없음, 신규 테이블 `UserId` 없음, 기존 마이그레이션 미수정, Tiptap/JS 미변경.

## 수동 확인 필요
- PostgreSQL 전용: `pf` + 트라이그램 검색 조합(검색 브랜치, SQLite `ILike` 미지원으로 단위 스코프 외), 인덱스 사용(`EXPLAIN`), 복합 FK cascade.
- UI 전반(T-22): 패널 컨트롤/읽기전용, 필터바, 정렬 칩, `/properties` 플로우 — 두 앱 실행 후 스모크.
- 개발 DB에 `dotnet ef database update` 적용.
